### PR TITLE
Add JSON string support to StaticJsonProvider and fix instance sharing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+[0.14.0] - 2025-09-17
+
+### Added
+- StaticJsonProvider now supports JSON strings directly via `Rule.From.StaticJson(jsonString)`.
+
+### Changed
+- StaticJsonProvider instances are no longer shared between rules (null-key pattern) to prevent configuration data leakage between different rules.
+
 ## [0.13.0] - 2025-09-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Manual overrides & keyed registrations: see [ADVANCED.md](docs/ADVANCED.md).
 
 | Provider          | Package   | Change Signal        | Notes                             |
 | ----------------- | --------- | -------------------- | --------------------------------- |
-| Static            | Core      | ❌                    | Seed defaults, compose values     |
+| Static            | Core      | ❌                    | JSON strings or factories         |
 | File (JSON)       | Core      | ✅ FS watcher         | Deterministic layering            |
 | Environment       | Core      | ❌                    | Prefix filter; `__` / `:` nesting |
 | HTTP Polling      | Extension | ✅ Interval polling   | Payload diffing (streaming hash)  |
@@ -224,7 +224,7 @@ Each example is a standalone runnable project under `src/Examples/`:
 | [HttpPollingExample](src/Examples/HttpPollingExample) | Remote HTTP polling configuration pattern |
 | [MicrosoftAdapterExample](src/Examples/MicrosoftAdapterExample) | Integrating existing `IConfigurationSource` assets |
 | [ServiceLifetimes](src/Examples/ServiceLifetimes) | DI lifetime & keyed registration control |
-| [StaticProviderExample](src/Examples/StaticProviderExample) | Static seeding + dependent recompute |
+| [StaticProviderExample](src/Examples/StaticProviderExample) | Static seeding with JSON strings and factory functions |
 | [DIExample](src/Examples/DIExample) | Comprehensive DI patterns & overrides |
 | [SimplifiedCoreExample](src/Examples/SimplifiedCoreExample) | Pure core (no DI) with `ConfigManager` |
 | [BindingExample](src/Examples/BindingExample) | Interface binding without DI |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -2,7 +2,7 @@
 
 ## Built-in Providers
 
-* **Static Provider** – in-memory seeding & dependent composition
+* **Static Provider** – in-memory seeding with JSON strings or factory functions
 * **File Provider** – JSON files with filesystem watching
 * **Environment Provider** – environment variables with prefix filtering
 
@@ -17,11 +17,52 @@
 
 | Provider          | Package   | Change Signal          | Notes                           |
 | ----------------- | --------- | ---------------------- | ------------------------------- |
-| Static            | Core      | ❌                      | Snapshot only                   |
+| Static            | Core      | ❌                      | JSON strings or factories       |
 | File (JSON)       | Core      | ✅ Debounced FS watcher | Good base layer                 |
 | Environment       | Core      | ❌ Snapshot only        | Prefix filter                   |
 | HTTP Polling      | Extension | ✅ Payload diff         | Optional headers, interval      |
 | Microsoft Adapter | Extension | Depends                | Wrap any `IConfigurationSource` |
+
+---
+
+## Static Provider Details
+
+The Static Provider offers two approaches for in-memory configuration:
+
+### JSON String Support
+Perfect for testing, defaults, and simple configuration overrides:
+
+```csharp
+Rule.From.StaticJson("""
+{
+    "ApiUrl": "https://api.example.com",
+    "Timeout": 30,
+    "Features": {
+        "EnableNewUI": true,
+        "DebugMode": false
+    }
+}
+""").For<AppConfig>()
+```
+
+### Factory Functions
+Dynamic configuration generation using dependency injection:
+
+```csharp
+Rule.From.Static<DbConfig>(configManager => {
+    var baseConfig = configManager.Get<BaseConfig>();
+    return new DbConfig {
+        ConnectionString = $"Server={baseConfig.DbServer};Database=MyApp",
+        Timeout = baseConfig.IsProduction ? 60 : 30
+    };
+}).For<DbConfig>()
+```
+
+**Key Features:**
+- No instance sharing - each rule gets isolated provider
+- Strongly typed configuration objects
+- Excellent for layered configuration (base + overrides)
+- Zero I/O overhead
 
 ---
 

--- a/src/Cocoar.Configuration/ProviderRegistry.cs
+++ b/src/Cocoar.Configuration/ProviderRegistry.cs
@@ -36,19 +36,32 @@ internal sealed class ProviderRegistry
 
     public sealed class ProviderHandle : IDisposable
     {
-        private readonly ProviderRegistry _owner;
-        private readonly (Type type, string key) _id;
+        private readonly ProviderRegistry? _owner;
+        private readonly (Type type, string key)? _id;
         private Entry? _entry;
+        private readonly bool _isReusable;
 
         private ProviderHandle(ProviderRegistry owner, (Type type, string key) id, Entry entry)
         {
             _owner = owner;
             _id = id;
             _entry = entry;
+            _isReusable = true;
+        }
+        
+        private ProviderHandle(Entry entry)
+        {
+            _owner = null;
+            _id = null;
+            _entry = entry;
+            _isReusable = false;
         }
 
         internal static ProviderHandle Create(ProviderRegistry owner, (Type type, string key) id, Entry entry)
             => new ProviderHandle(owner, id, entry);
+            
+        internal static ProviderHandle CreateNonReusable(ProviderRegistry owner, Entry entry)
+            => new ProviderHandle(entry);
 
         public ConfigurationProvider Provider
             => _entry?.Provider ?? throw new ObjectDisposedException(nameof(ProviderHandle));
@@ -57,13 +70,44 @@ internal sealed class ProviderRegistry
         {
             var e = Interlocked.Exchange(ref _entry, null);
             if (e is null) return;
-            _owner.Release(_id, e);
+            
+            if (_isReusable && _owner is not null && _id.HasValue)
+            {
+                _owner.Release(_id.Value, e);
+            }
+            else
+            {
+                // Non-reusable provider - dispose directly
+                if (e.Provider is IDisposable disp)
+                {
+                    try { disp.Dispose(); } catch { /* ignore */ }
+                }
+            }
         }
     }
 
     public ProviderHandle Acquire(Type providerType, IProviderConfiguration options)
     {
         var key = options.GenerateProviderKey();
+        
+        // If key is null, create a new provider instance without registering (never reuse)
+        if (key is null)
+        {
+            var provider = CreateProvider(providerType, options);
+            if (_diagnosticsEnabled)
+                _logger.LogDebug("ProviderRegistry: created non-reusable {Provider} (null key)", providerType.Name);
+            
+            var nonReusableEntry = new Entry
+            {
+                Provider = provider,
+                RefCount = 1 // Start with ref count 1, will be decremented when disposed
+            };
+            
+            // Create a special handle that doesn't interact with the registry
+            return ProviderHandle.CreateNonReusable(this, nonReusableEntry);
+        }
+        
+        // Standard reusable provider logic
         var id = (providerType, key);
         var entry = _entries.GetOrAdd(id, _ =>
         {

--- a/src/Cocoar.Configuration/Providers/Abstractions/IProviderConfiguration.cs
+++ b/src/Cocoar.Configuration/Providers/Abstractions/IProviderConfiguration.cs
@@ -4,7 +4,13 @@ namespace Cocoar.Configuration.Providers.Abstractions;
 
 public interface IProviderConfiguration
 {
-    string GenerateProviderKey()
+    /// <summary>
+    /// Generates a provider key for instance sharing. 
+    /// Return null to indicate this provider should never be reused/shared.
+    /// Return the same key to share provider instances with the same key.
+    /// </summary>
+    /// <returns>A unique key for sharing, or null to prevent sharing.</returns>
+    string? GenerateProviderKey()
     {
         var options = new JsonSerializerOptions
         {

--- a/src/Cocoar.Configuration/Providers/StaticJsonProvider/README.md
+++ b/src/Cocoar.Configuration/Providers/StaticJsonProvider/README.md
@@ -1,18 +1,67 @@
 # StaticJsonProvider
 
-Seed a configuration type with a value produced by a factory.
+Seed a configuration type with static values from JSON data or factory functions.
 
-- Instance options: `StaticJsonProviderOptions(Func<ConfigManager, object> Factory)`
-- Query options: `StaticJsonProviderQueryOptions(wrapperPath?)`
-- Changes: none (static); the factory is evaluated during recompute.
+## Features
 
-Fluent usage:
+- **JSON String Support**: Directly provide JSON strings for configuration
+- **Factory Functions**: Generate configurations dynamically using `ConfigManager` dependencies
+- **No Instance Sharing**: Each rule gets its own isolated provider instance
+- **Change Signal**: None (static data)
+
+## API Options
+
+- **Instance options**: `StaticJsonProviderOptions(JsonElement)` or factory-based
+- **Query options**: `StaticJsonProviderQueryOptions(wrapperPath?)`
+
+## Usage Examples
+
+### JSON String (New!)
 
 ```csharp
-services.AddCocoarConfiguration(
-    Rules.FromStatic(_ => new MySettings { Url = "/api/config" })
-         .ForType<MySettings>()
-         .Required()
-         .Build()
+// Direct JSON string
+var rule = Rule.From.StaticJson("""
+{
+    "DatabaseUrl": "Server=localhost;Database=MyApp",
+    "Timeout": 30,
+    "EnableRetries": true
+}
+""").For<DatabaseSettings>();
+
+services.AddCocoarConfiguration([rule]);
+```
+
+### Factory Function
+
+```csharp
+// Dynamic factory-based configuration
+var rule = Rule.From.Static<MySettings>(_ => new MySettings { 
+    Url = "/api/config",
+    GeneratedAt = DateTime.UtcNow
+}).For<MySettings>();
+
+services.AddCocoarConfiguration([rule]);
+```
+
+### Static Method API
+
+```csharp
+// Using static methods directly
+var jsonRule = StaticJsonProvider.CreateRule<DatabaseSettings>("""
+{
+    "DatabaseUrl": "Server=prod;Database=MyApp",
+    "Timeout": 45
+}
+""");
+
+var factoryRule = StaticJsonProvider.CreateRule<MySettings>(
+    _ => new MySettings { Environment = "Production" }
 );
 ```
+
+## Key Benefits
+
+- **Simple Testing**: Easy to provide test configurations via JSON strings
+- **Configuration Overrides**: Layer static values over file/environment config
+- **Dependency Composition**: Use factory functions to build config from other resolved configs
+- **Type Safety**: Strongly typed configuration objects with compile-time checking

--- a/src/Cocoar.Configuration/Providers/StaticJsonProvider/RulesExtensions.cs
+++ b/src/Cocoar.Configuration/Providers/StaticJsonProvider/RulesExtensions.cs
@@ -1,10 +1,18 @@
 using Cocoar.Configuration.Fluent;
+using System.Text.Json;
 
 namespace Cocoar.Configuration.Providers.StaticJsonProvider;
 
 public static class RulesExtensions
 {
-    // Static provider convenience: seed a type with a factory
+    /// <summary>
+    /// Creates a static configuration rule using a factory function to generate instances.
+    /// The instances are serialized to JSON internally.
+    /// </summary>
+    /// <typeparam name="T">The type of object created by the factory.</typeparam>
+    /// <param name="dsl">The rule DSL.</param>
+    /// <param name="factory">Factory function that creates instances based on ConfigManager.</param>
+    /// <returns>A provider rule builder for further configuration.</returns>
     public static ProviderRuleBuilder<
         StaticJsonProvider,
         StaticJsonProviderOptions,
@@ -12,7 +20,30 @@ public static class RulesExtensions
     > Static<T>(this Rule.Dsl dsl, Func<ConfigManager, T> factory)
     {
         return new(
-            cm => new StaticJsonProviderOptions(System.Text.Json.JsonSerializer.SerializeToElement(factory(cm)!)),
+            cm => new StaticJsonProviderOptions(JsonSerializer.SerializeToElement(factory(cm)!)),
+            _ => new StaticJsonProviderQueryOptions()
+        );
+    }
+
+    /// <summary>
+    /// Creates a static configuration rule from a JSON string.
+    /// </summary>
+    /// <param name="dsl">The rule DSL.</param>
+    /// <param name="jsonString">The JSON string containing configuration data.</param>
+    /// <returns>A provider rule builder for further configuration.</returns>
+    /// <exception cref="JsonException">Thrown when the JSON string is invalid.</exception>
+    public static ProviderRuleBuilder<
+        StaticJsonProvider,
+        StaticJsonProviderOptions,
+        StaticJsonProviderQueryOptions
+    > StaticJson(this Rule.Dsl dsl, string jsonString)
+    {
+        // Parse and clone the JsonElement to avoid lifetime issues  
+        using var document = JsonDocument.Parse(jsonString);
+        var jsonElement = document.RootElement.Clone();
+        
+        return new(
+            _ => new StaticJsonProviderOptions(jsonElement),
             _ => new StaticJsonProviderQueryOptions()
         );
     }

--- a/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticJsonProvider.cs
+++ b/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticJsonProvider.cs
@@ -4,9 +4,25 @@ using Cocoar.Configuration.Providers.Abstractions;
 
 namespace Cocoar.Configuration.Providers.StaticJsonProvider;
 
+/// <summary>
+/// A configuration provider that serves static configuration data.
+/// 
+/// Despite its name, this provider supports two primary use cases:
+/// 1. Serving pre-created JSON elements (true static JSON)
+/// 2. Serving instances created by factory functions (serialized to JSON internally)
+/// 
+/// This provider does not support dynamic updates - it returns the same configuration
+/// data throughout the application's lifetime.
+/// </summary>
 public sealed class StaticJsonProvider(StaticJsonProviderOptions options)
     : ConfigurationProvider<StaticJsonProviderOptions, StaticJsonProviderQueryOptions>(options)
 {
+    /// <summary>
+    /// Fetches the static configuration data.
+    /// </summary>
+    /// <param name="query">Query options (not used for static data).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The static JSON configuration element.</returns>
     public override Task<JsonElement> FetchConfigurationAsync(StaticJsonProviderQueryOptions query,
         CancellationToken ct = default)
     {
@@ -16,9 +32,22 @@ public sealed class StaticJsonProvider(StaticJsonProviderOptions options)
         return Task.FromResult(json);
     }
 
+    /// <summary>
+    /// Returns an empty observable as static configuration never changes.
+    /// </summary>
+    /// <param name="queryOptions">Query options (not used for static data).</param>
+    /// <returns>An empty observable sequence.</returns>
     public override IObservable<JsonElement> Changes(StaticJsonProviderQueryOptions queryOptions)
         => Observable.Empty<JsonElement>();
 
+    /// <summary>
+    /// Creates a configuration rule from a JsonElement.
+    /// </summary>
+    /// <typeparam name="TConfigType">The type of configuration object to bind to.</typeparam>
+    /// <param name="value">The JSON element containing the configuration data.</param>
+    /// <param name="useWhen">Optional condition for when this rule should be used.</param>
+    /// <param name="required">Whether this configuration is required.</param>
+    /// <returns>A configured rule for the specified type.</returns>
     public static ConfigRule CreateRule<TConfigType>(JsonElement value, Func<bool>? useWhen = null,
         bool required = false)
     {
@@ -28,5 +57,23 @@ public sealed class StaticJsonProvider(StaticJsonProviderOptions options)
             _ => new StaticJsonProviderQueryOptions(),
             typeof(TConfigType),
             opts);
+    }
+
+    /// <summary>
+    /// Creates a configuration rule from a JSON string.
+    /// </summary>
+    /// <typeparam name="TConfigType">The type of configuration object to bind to.</typeparam>
+    /// <param name="jsonString">The JSON string containing the configuration data.</param>
+    /// <param name="useWhen">Optional condition for when this rule should be used.</param>
+    /// <param name="required">Whether this configuration is required.</param>
+    /// <returns>A configured rule for the specified type.</returns>
+    /// <exception cref="JsonException">Thrown when the JSON string is invalid.</exception>
+    public static ConfigRule CreateRule<TConfigType>(string jsonString, Func<bool>? useWhen = null,
+        bool required = false)
+    {
+        // Parse and clone the JsonElement to avoid lifetime issues
+        using var document = JsonDocument.Parse(jsonString);
+        var jsonElement = document.RootElement.Clone();
+        return CreateRule<TConfigType>(jsonElement, useWhen, required);
     }
 }

--- a/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticJsonProviderOptions.cs
+++ b/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticJsonProviderOptions.cs
@@ -7,6 +7,7 @@ public sealed class StaticJsonProviderOptions(JsonElement value) : IProviderConf
 {
     public JsonElement Value { get; } = value;
 
-    // Static value; reuse under a constant key to avoid unnecessary churn
-    public string GenerateProviderKey() => "Static";
+    // Return null to indicate this provider should never be reused
+    // Each static provider instance should have its own unique data
+    public string? GenerateProviderKey() => null;
 }

--- a/src/Examples/README.md
+++ b/src/Examples/README.md
@@ -12,7 +12,7 @@ This directory contains runnable examples for **Cocoar.Configuration**. Each sub
 - **HttpPollingExample** – Demonstrates pattern for remote/polling configuration
 - **MicrosoftAdapterExample** – Integrating `IConfigurationSource` providers
 - **ServiceLifetimes** – Controlling DI lifetimes and keyed registrations
-- **StaticProviderExample** – Static seeding and dependent recompute
+- **StaticProviderExample** – Static seeding with JSON strings and factory functions
 - **DIExample** – Comprehensive DI integration patterns with advanced service registration
 - **SimplifiedCoreExample** – Pure core library usage without DI (ConfigManager only)
 - **BindingExample** – Interface binding without DI frameworks

--- a/src/Examples/StaticProviderExample/Program.cs
+++ b/src/Examples/StaticProviderExample/Program.cs
@@ -1,4 +1,5 @@
 // Migrated from root Examples/StaticProviderExample.cs
+// Demonstrates both JSON string and factory-based static configuration
 
 using Cocoar.Configuration;
 using Cocoar.Configuration.Fluent;
@@ -8,6 +9,14 @@ public sealed class CoreDefaults
 {
     public string Feature { get; set; } = "A";
     public bool Enabled { get; set; } = true;
+    public int Priority { get; set; } = 1;
+}
+
+public sealed class DatabaseSettings
+{
+    public string ConnectionString { get; set; } = string.Empty;
+    public int TimeoutSeconds { get; set; } = 30;
+    public bool EnableRetries { get; set; } = true;
 }
 
 public sealed class Wrapper
@@ -19,19 +28,70 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        Console.WriteLine("=== StaticJsonProvider Demo: JSON Strings + Factory Functions ===\n");
+
         var rules = new []
         {
-            Rule.From.Static(_ => new CoreDefaults { Feature = "A", Enabled = true })
-                .For<CoreDefaults>()
-                .Required()
-                .Build(),
-            Rule.From.Static(cm => new Wrapper { Inner = cm.GetRequiredConfig<CoreDefaults>() })
-                .For<Wrapper>()
-                .Required()
-                .Build()
+            // 1. JSON string approach - great for configuration templates, testing, defaults
+            Rule.From.StaticJson("""
+            {
+                "Feature": "JsonBasedFeature",
+                "Enabled": true,
+                "Priority": 5
+            }
+            """).For<CoreDefaults>(),
+
+            // 2. Direct JSON string for database configuration  
+            Rule.From.StaticJson("""
+            {
+                "ConnectionString": "Server=localhost;Database=MyApp;Integrated Security=true",
+                "TimeoutSeconds": 45,
+                "EnableRetries": true
+            }
+            """).For<DatabaseSettings>(),
+
+            // 3. Factory approach - dynamic composition using previously resolved configs
+            Rule.From.Static(cm => {
+                var coreConfig = cm.GetRequiredConfig<CoreDefaults>();
+                return new Wrapper { 
+                    Inner = new CoreDefaults {
+                        Feature = $"Enhanced_{coreConfig.Feature}",
+                        Enabled = coreConfig.Enabled,
+                        Priority = coreConfig.Priority + 10
+                    }
+                };
+            }).For<Wrapper>()
         };
+
         var manager = new ConfigManager(rules).Initialize();
+
+        // Retrieve and display configurations
+        var coreDefaults = manager.GetRequiredConfig<CoreDefaults>();
+        var dbSettings = manager.GetRequiredConfig<DatabaseSettings>();  
         var wrapper = manager.GetRequiredConfig<Wrapper>();
-        Console.WriteLine($"Wrapper has feature: {wrapper.Inner?.Feature}");
+
+        Console.WriteLine("📋 Core Configuration (from JSON string):");
+        Console.WriteLine($"   Feature: {coreDefaults.Feature}");
+        Console.WriteLine($"   Enabled: {coreDefaults.Enabled}");
+        Console.WriteLine($"   Priority: {coreDefaults.Priority}");
+        Console.WriteLine();
+
+        Console.WriteLine("🗄️  Database Configuration (from JSON string):");
+        Console.WriteLine($"   Connection: {dbSettings.ConnectionString}");
+        Console.WriteLine($"   Timeout: {dbSettings.TimeoutSeconds}s");
+        Console.WriteLine($"   Retries: {dbSettings.EnableRetries}");
+        Console.WriteLine();
+
+        Console.WriteLine("🔧 Wrapper Configuration (from factory using dependency):");
+        Console.WriteLine($"   Enhanced Feature: {wrapper.Inner?.Feature}");
+        Console.WriteLine($"   Enabled: {wrapper.Inner?.Enabled}");
+        Console.WriteLine($"   Enhanced Priority: {wrapper.Inner?.Priority}");
+        Console.WriteLine();
+
+        Console.WriteLine("✅ Demonstrates:");
+        Console.WriteLine("   • JSON string support for StaticJsonProvider");
+        Console.WriteLine("   • Factory functions for dynamic composition"); 
+        Console.WriteLine("   • Layered configuration with dependency injection");
+        Console.WriteLine("   • Each rule gets isolated provider instances (no sharing)");
     }
 }

--- a/src/Examples/StaticProviderExample/StaticProviderExample.csproj
+++ b/src/Examples/StaticProviderExample/StaticProviderExample.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/tests/Cocoar.Configuration.Tests/Providers/StaticJsonProviderTests.cs
+++ b/src/tests/Cocoar.Configuration.Tests/Providers/StaticJsonProviderTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using Cocoar.Configuration.Providers.StaticJsonProvider;
+using Cocoar.Configuration;
+using Cocoar.Configuration.Fluent;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Cocoar.Configuration.Tests.Providers;
+
+public class StaticJsonProviderTests
+{
+    private record TestConfig(string Name, int Value);
+    private record OtherConfig(string Description, bool Enabled);
+
+    [Fact]
+    public void CreateRule_WithJsonElement_ShouldCreateValidRule()
+    {
+        // Arrange
+        var json = JsonDocument.Parse("""{"Name": "Test", "Value": 42}""").RootElement;
+
+        // Act
+        var rule = StaticJsonProvider.CreateRule<TestConfig>(json);
+
+        // Assert
+        Assert.NotNull(rule);
+        Assert.Equal(typeof(StaticJsonProvider), rule.ProviderType);
+    }
+
+    [Fact]
+    public void CreateRule_WithJsonString_ShouldCreateValidRule()
+    {
+        // Arrange
+        var jsonString = """{"Name": "Test", "Value": 42}""";
+
+        // Act
+        var rule = StaticJsonProvider.CreateRule<TestConfig>(jsonString);
+
+        // Assert
+        Assert.NotNull(rule);
+        Assert.Equal(typeof(StaticJsonProvider), rule.ProviderType);
+    }
+
+    [Fact]
+    public void CreateRule_WithJsonString_ShouldParseCorrectly()
+    {
+        // Arrange
+        var jsonString = """{"Name": "TestApp", "Value": 123}""";
+        
+        // Act
+        var rule = StaticJsonProvider.CreateRule<TestConfig>(jsonString);
+        var configManager = new ConfigManager([rule], null, NullLogger.Instance).Initialize();
+        var success = configManager.TryGetConfig<TestConfig>(out var config);
+
+        // Assert
+        Assert.True(success);
+        Assert.NotNull(config);
+        Assert.Equal("TestApp", config.Name);
+        Assert.Equal(123, config.Value);
+    }
+
+    [Fact]
+    public void MultipleRules_WithDifferentJsonStrings_ShouldNotShareProviderInstances()
+    {
+        // Arrange - This test prevents the bug we discovered where providers were shared
+        var json1 = """{"Name": "Config1", "Value": 1}""";
+        var json2 = """{"Description": "Config2", "Enabled": true}""";
+
+        // Act
+        var rule1 = StaticJsonProvider.CreateRule<TestConfig>(json1);
+        var rule2 = StaticJsonProvider.CreateRule<OtherConfig>(json2);
+        
+        var configManager = new ConfigManager([rule1, rule2], null, NullLogger.Instance).Initialize();
+        
+        var success1 = configManager.TryGetConfig<TestConfig>(out var config1);
+        var success2 = configManager.TryGetConfig<OtherConfig>(out var config2);
+
+        // Assert - Each rule should get its own data, not shared instances
+        Assert.True(success1);
+        Assert.NotNull(config1);
+        Assert.Equal("Config1", config1.Name);
+        Assert.Equal(1, config1.Value);
+        
+        Assert.True(success2);
+        Assert.NotNull(config2);
+        Assert.Equal("Config2", config2.Description);
+        Assert.True(config2.Enabled);
+    }
+
+    [Fact]
+    public void MultipleRules_WithSameJsonString_ShouldNotShareProviderInstances()
+    {
+        // Arrange - Even identical JSON should create separate providers
+        var json = """{"Name": "SameData", "Value": 999}""";
+
+        // Act
+        var rule1 = StaticJsonProvider.CreateRule<TestConfig>(json);
+        var rule2 = StaticJsonProvider.CreateRule<TestConfig>(json); // Same JSON, same type
+        
+        var configManager = new ConfigManager([rule1, rule2], null, NullLogger.Instance).Initialize();
+        
+        // This would have failed in the old implementation due to provider sharing
+        var success = configManager.TryGetConfig<TestConfig>(out var config);
+
+        // Assert
+        Assert.True(success);
+        Assert.NotNull(config);
+        Assert.Equal("SameData", config.Name);
+        Assert.Equal(999, config.Value);
+    }
+
+    [Fact]
+    public void StaticJsonProviderOptions_GenerateProviderKey_ShouldReturnNull()
+    {
+        // Arrange - Test the null-key pattern that prevents sharing
+        var json = JsonDocument.Parse("""{"Name": "Test", "Value": 42}""").RootElement;
+        var options = new StaticJsonProviderOptions(json);
+
+        // Act
+        var key = options.GenerateProviderKey();
+
+        // Assert - Null key means no sharing
+        Assert.Null(key);
+    }
+
+    [Fact]
+    public void FluentAPI_StaticJson_ShouldWork()
+    {
+        // Arrange
+        var jsonString = """{"Name": "FluentTest", "Value": 456}""";
+
+        // Act
+        var rule = Rule.From.StaticJson(jsonString).For<TestConfig>();
+        var configManager = new ConfigManager([rule], null, NullLogger.Instance).Initialize();
+        var success = configManager.TryGetConfig<TestConfig>(out var config);
+
+        // Assert
+        Assert.True(success);
+        Assert.NotNull(config);
+        Assert.Equal("FluentTest", config.Name);
+        Assert.Equal(456, config.Value);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{"Name": null, "Value": 0}""")]
+    [InlineData("""{"Name": "", "Value": -1}""")]
+    public void CreateRule_WithVariousJsonInputs_ShouldHandleGracefully(string jsonInput)
+    {
+        // Act & Assert - Should not throw
+        var rule = StaticJsonProvider.CreateRule<TestConfig>(jsonInput);
+        Assert.NotNull(rule);
+        
+        // Verify it can be used
+        var configManager = new ConfigManager([rule], null, NullLogger.Instance).Initialize();
+        var success = configManager.TryGetConfig<TestConfig>(out var config);
+        Assert.True(success);
+        Assert.NotNull(config);
+    }
+
+    [Fact]
+    public void CreateRule_WithInvalidJson_ShouldThrow()
+    {
+        // Arrange
+        var invalidJson = """{"Name": "Test", "Value":}"""; // Missing value
+
+        // Act & Assert - JsonReaderException is a subclass of JsonException
+        Assert.ThrowsAny<JsonException>(() => 
+            StaticJsonProvider.CreateRule<TestConfig>(invalidJson));
+    }
+}


### PR DESCRIPTION
## ✨ New Features
- Added `Rule.From.StaticJson(jsonString)` fluent API
- Added `StaticJsonProvider.CreateRule<T>(jsonString)` static method  
- Enhanced documentation with examples and use cases

## 🐛 Bug Fixes
- Fixes #18 
- Implemented null-key pattern to prevent provider instance sharing

## 🧪 Testing
- Added comprehensive unit tests (11 new tests)
- Added regression tests to prevent future instance sharing bugs
- Updated StaticProviderExample to demonstrate both approaches

Closes #18 