### PR TITLE
Multi-arity IReactiveConfig<(…)> for coordinated emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [1.1.0] - 2025-09-25
+
+`IReactiveConfig<T>` now supports tuples as the generic type, e.g.
+`IReactiveConfig<(AppSettings, DbSettings)>`.
+When used with a tuple, all element types are recomputed and emitted atomically in the same pass.
+This guarantees you never see a mix of old and new values across different configs.
 
 ## [1.0.0] - 2025-09-21
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ### 🚀 Key Innovations
 
 * **Auto-Registered Reactive Config** – Every config type gets [`IReactiveConfig<T>`](./docs/reactive-config.md) in DI automatically
+* **Atomic Tuple Reactive Configs** – Use `IReactiveConfig<(T1,T2,...,TN)>` for aligned, change-filtered multi-config snapshots (any arity) with strict element validation
 * [**Health Monitoring Service**](./docs/health-monitoring.md) – Real-time health snapshots, metrics export, and resilience tracking
 * **Streaming MD5 Change Detection** – High-performance hashing pipeline for file/HTTP providers
 
@@ -60,6 +61,7 @@
 
 * **Minimal Boilerplate** – Define a class, add a rule, done.
 * **Auto-Registered Reactive Config** – [`IReactiveConfig<T>`](./docs/reactive-config.md) registered automatically in DI.
+* **Tuple Multi-Config** – Inject `IReactiveConfig<(A,B,C)>` (any tuple size) for atomic multi-config snapshots (only configured types or bound interfaces allowed).
 * **Interface binding** – map POCOs to read-only interfaces (`Bind.Type<T>().To<IMyConfig>()`) for clean contracts.
 * **Service Lifetime Control** – Scoped, Singleton, Transient, and Keyed registrations supported.
 * **Test-Friendly** – Static/observable providers make testing easy.
@@ -97,6 +99,20 @@ app.MapGet("/feature", (AppSettings cfg) => new {
     snapshotFlag = cfg.FeatureFlag,  // Value at scope start (request)
     message = cfg.Message
 });
+
+// Tuple reactive usage example (arbitrary arity)
+app.MapGet("/composite", (IReactiveConfig<(AppSettings App, FeatureFlags Flags, LoggingConfig Log)> composite) =>
+{
+    var (appCfg, flags, log) = composite.CurrentValue;
+    return new {
+        feature = flags.Enabled.Contains("NewX"),
+        level = log.Level,
+        appCfg.Version
+    };
+});
+
+// Guard: invalid tuple (e.g. unbound interface) throws immediately
+// var bad = manager.GetReactiveConfig<(UnconfiguredType, IUnboundInterface)>(); // -> InvalidOperationException
 ```
 
 ## Examples
@@ -117,6 +133,7 @@ Each example is a standalone runnable project under `src/Examples/`:
 | [DIExample](src/Examples/DIExample) | Comprehensive DI patterns & overrides |
 | [SimplifiedCoreExample](src/Examples/SimplifiedCoreExample) | Pure core (no DI) with `ConfigManager` |
 | [BindingExample](src/Examples/BindingExample) | Interface binding without DI |
+| [TupleReactiveExample](src/Examples/TupleReactiveExample) | Tuple-based reactive multi-config snapshot with dynamic updates |
 
 More details: [Examples README](src/Examples/README.md).
 

--- a/docs/reactive-config.md
+++ b/docs/reactive-config.md
@@ -70,6 +70,69 @@ using var sub = reactive.Subscribe(cfg =>
 Console.WriteLine($"Current value: {reactive.CurrentValue}");
 ```
 
+### Tuple-Based Multi-Config Snapshots (Arbitrary Arity)
+
+Sometimes you need a consistent snapshot spanning several configuration types (e.g., `AppSettings`, `FeatureFlags`, `LoggingConfig`, `Pricing`, etc.). Naïvely combining individual `IReactiveConfig<T>` streams with `CombineLatest` risks mixing values from different recompute passes when only one type changed.
+
+Instead of fixed multi-arity interfaces, Cocoar now supports **any ValueTuple** shape via the regular API:
+
+```csharp
+var trio = manager.GetReactiveConfig<(AppSettings, FeatureFlags, LoggingConfig)>();
+var octo = manager.GetReactiveConfig<(A,B,C,D,E,F,G,H)>();
+```
+
+Properties:
+* Emits **at most once per recompute pass**, and only if at least one element changed during that pass
+* Elements in each emission are **atomically aligned** (all from the same recompute cycle)
+* Supports tuples beyond 7 elements (uses nested ValueTuple `Rest` under the hood) transparently
+* No emission spam when nothing changed
+
+Usage:
+
+```csharp
+public sealed class CompositeHandler(IReactiveConfig<(AppSettings App, FeatureFlags Flags, LoggingConfig Log)> reactive)
+{
+    public object Get()
+    {
+        var snapshot = reactive.CurrentValue; // (App, Flags, Log)
+        var (app, flags, log) = snapshot;
+        return new { app.Version, Experimental = flags.Enabled.Contains("NewUI"), log.Level };
+    }
+}
+
+using var sub = reactive.Subscribe(tuple => {
+    var (app, flags, log) = tuple;
+    Console.WriteLine($"Aligned pass -> v={app.Version} flags={flags.Enabled.Length} log={log.Level}");
+});
+```
+
+#### Why Not CombineLatest?
+
+`CombineLatest` can interleave new + stale values when only one underlying type changes—leading to logically inconsistent composite state. The tuple reactive config internally uses per-pass alignment events so each emission corresponds to a single orchestrator recompute.
+
+#### Initial Emission Behavior
+
+Tuple configs behave like single-type reactive configs: they only emit after a recompute pass where at least one of their member types changed. You can always access the current atomic snapshot synchronously via `.CurrentValue`.
+
+#### Tuple Element Eligibility & Validation
+
+Only two kinds of types are allowed as tuple elements:
+
+1. Concrete types that have a configuration rule (i.e. appear as a `.For<ConcreteType>()` in your rules).
+2. Interfaces that are explicitly bound to a concrete type via `Bind.Type<Concrete>().To<IMyInterface>()` (or equivalent binding helpers).
+
+If any tuple element is not one of those, construction of `IReactiveConfig<(...)>` throws immediately with a detailed message listing each invalid element and why it is invalid ("not a configured type" or "interface not bound"). This prevents silent default/null values inside composite snapshots.
+
+Example failure:
+
+```
+Cannot create IReactiveConfig<(PricingConfig, IUnboundFeature, int)>. The following tuple element types are not configured/bound: IUnboundFeature (interface not bound), Int32 (not a configured type)
+```
+
+This guard ensures tuple snapshots are always composed exclusively of legitimate, fully managed configuration types.
+
+---
+
 ---
 
 ## Why It Matters

--- a/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
+++ b/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Cocoar.Configuration.DI;
@@ -160,6 +161,9 @@ public static class CocoarConfigurationExtensions
                     }
                 }
             }
+
+            // Multi-arity cohort interfaces removed in favor of tuple-based IReactiveConfig<(T1,...,Tn)>.
+            // No open generic registrations needed; tuple reactive configs are created on demand via ConfigManager.
         }
 
         // Auto-register rule types with default lifetime (if default lifetime is set and not explicitly removed)

--- a/src/Cocoar.Configuration/ConfigManager.cs
+++ b/src/Cocoar.Configuration/ConfigManager.cs
@@ -222,6 +222,12 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     /// <returns>A reactive configuration that emits configuration values and provides current value access</returns>
     public IReactiveConfig<T> GetReactiveConfig<T>()
     {
+        var t = typeof(T);
+        if (IsValueTupleType(t))
+        {
+            // Build tuple reactive config dynamically
+            return (IReactiveConfig<T>)CreateTupleReactiveConfig(t);
+        }
         return _reactiveConfigManager.GetReactiveConfig(() => GetConfig<T>()!);
     }
 
@@ -406,4 +412,60 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     /// Gets the current health information.
     /// </summary>
     public IConfigurationHealthService GetHealthService() => _healthService;
+
+    private static bool IsValueTupleType(Type t) => t.IsValueType && t.FullName != null && t.FullName.StartsWith("System.ValueTuple");
+
+    private object CreateTupleReactiveConfig(Type tupleType)
+    {
+        // Determine element types (flattened) and validate each is a configured concrete type or bound interface
+        var elementTypes = FlattenTuple(tupleType).ToArray();
+        if (elementTypes.Length == 0)
+            throw new InvalidOperationException($"Type {tupleType.Name} is not a non-empty ValueTuple");
+
+        var allowedConcrete = new HashSet<Type>(_rules.Select(r => r.ConcreteType));
+        var allowedInterfaces = new HashSet<Type>(_bindings.SelectMany(b => b.BoundInterfaces));
+        var invalid = new List<string>();
+        foreach (var et in elementTypes)
+        {
+            if (et.IsInterface)
+            {
+                if (!allowedInterfaces.Contains(et)) invalid.Add(et.Name + " (interface not bound)");
+            }
+            else
+            {
+                if (!allowedConcrete.Contains(et)) invalid.Add(et.Name + " (not a configured type)");
+            }
+        }
+        if (invalid.Count > 0)
+            throw new InvalidOperationException($"Cannot create IReactiveConfig<{tupleType.Name}>. The following tuple element types are not configured/bound: {string.Join(", ", invalid)}");
+
+        // Prime all element types so ReactiveConfigManager tracks them and emits per-pass events
+        foreach (var et in elementTypes.Distinct())
+        {
+            try
+            {
+                var m = GetType().GetMethod("GetReactiveConfig")!.MakeGenericMethod(et);
+                _ = m.Invoke(this, null);
+            }
+            catch { /* non-fatal */ }
+        }
+        var generic = typeof(ReactiveTupleConfig<>).MakeGenericType(tupleType);
+        // constructor: (ConfigManager, ReactiveConfigManager, ILogger)
+        var instance = Activator.CreateInstance(generic, this, _reactiveConfigManager, _logger)!;
+        return instance;
+    }
+
+    private static IEnumerable<Type> FlattenTuple(Type t)
+    {
+        if (!(t.IsValueType && t.FullName != null && t.FullName.StartsWith("System.ValueTuple"))) yield break;
+        var fields = t.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        foreach (var f in fields)
+        {
+            if (f.Name == "Rest" && f.FieldType.FullName != null && f.FieldType.FullName.StartsWith("System.ValueTuple"))
+            {
+                foreach (var inner in FlattenTuple(f.FieldType)) yield return inner;
+            }
+            else yield return f.FieldType;
+        }
+    }
 }

--- a/src/Cocoar.Configuration/IReactiveConfig.Multi.cs
+++ b/src/Cocoar.Configuration/IReactiveConfig.Multi.cs
@@ -1,0 +1,177 @@
+using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Cocoar.Configuration;
+
+/// <summary>
+/// Multi-arity reactive configuration delivering atomic, pass-aligned snapshots for two configuration types.
+/// Emits once per recompute pass only if at least one member changed.
+/// </summary>
+public interface IReactiveConfig<T1, T2> : IObservable<(T1, T2)>
+{
+    (T1, T2) Current { get; }
+}
+
+/// <summary>
+/// Multi-arity reactive configuration delivering atomic, pass-aligned snapshots for three configuration types.
+/// </summary>
+public interface IReactiveConfig<T1, T2, T3> : IObservable<(T1, T2, T3)>
+{
+    (T1, T2, T3) Current { get; }
+}
+
+public interface IReactiveConfig<T1, T2, T3, T4> : IObservable<(T1, T2, T3, T4)>
+{
+    (T1, T2, T3, T4) Current { get; }
+}
+
+public interface IReactiveConfig<T1, T2, T3, T4, T5> : IObservable<(T1, T2, T3, T4, T5)>
+{
+    (T1, T2, T3, T4, T5) Current { get; }
+}
+
+internal sealed class ReactiveCohort<T1, T2> : IReactiveConfig<T1, T2>, IDisposable
+{
+    private readonly IObservable<(T1, T2)> _changes;
+    private readonly Func<T1> _get1;
+    private readonly Func<T2> _get2;
+    private readonly IDisposable _anchor;
+
+    public ReactiveCohort(ReactiveConfigManager manager, ILogger logger, Func<T1> get1, Func<T2> get2)
+    {
+        _get1 = get1; _get2 = get2;
+        var s1 = manager.ObservePerPass<T1>();
+        var s2 = manager.ObservePerPass<T2>();
+
+        _changes = s1.Zip(s2, (e1, e2) => (e1, e2))
+            .Where(t => t.e1.PassId == t.e2.PassId) // defensive alignment
+            .Where(t => t.e1.Changed || t.e2.Changed)
+            .Select(t => (t.e1.Value, t.e2.Value))
+            .Catch<(T1, T2), Exception>(ex =>
+            {
+                logger.LogWarning(ex, "Cohort<T1,T2> stream error ignored to keep alive");
+                return Observable.Empty<(T1, T2)>();
+            })
+            .Retry()
+            .Publish()
+            .RefCount();
+
+        // Anchor keeps the published observable hot even with zero subscribers (optional semantics)
+        _anchor = _changes.Subscribe(_ => { }, _ => { });
+    }
+
+    public (T1, T2) Current => (_get1(), _get2());
+    public IDisposable Subscribe(IObserver<(T1, T2)> observer) => _changes.Subscribe(observer);
+    public void Dispose() => _anchor.Dispose();
+}
+
+internal sealed class ReactiveCohort<T1, T2, T3> : IReactiveConfig<T1, T2, T3>, IDisposable
+{
+    private readonly IObservable<(T1, T2, T3)> _changes;
+    private readonly Func<T1> _get1; private readonly Func<T2> _get2; private readonly Func<T3> _get3;
+    private readonly IDisposable _anchor;
+
+    public ReactiveCohort(ReactiveConfigManager manager, ILogger logger, Func<T1> g1, Func<T2> g2, Func<T3> g3)
+    {
+        _get1 = g1; _get2 = g2; _get3 = g3;
+        var s1 = manager.ObservePerPass<T1>();
+        var s2 = manager.ObservePerPass<T2>();
+        var s3 = manager.ObservePerPass<T3>();
+
+        _changes = s1.Zip(s2, (a, b) => (a, b))
+            .Zip(s3, (ab, c) => (ab.a, ab.b, c))
+            .Where(t => t.a.PassId == t.b.PassId && t.a.PassId == t.c.PassId)
+            .Where(t => t.a.Changed || t.b.Changed || t.c.Changed)
+            .Select(t => (t.a.Value, t.b.Value, t.c.Value))
+            .Catch<(T1, T2, T3), Exception>(ex =>
+            {
+                logger.LogWarning(ex, "Cohort<T1,T2,T3> stream error ignored to keep alive");
+                return Observable.Empty<(T1, T2, T3)>();
+            })
+            .Retry()
+            .Publish()
+            .RefCount();
+
+        _anchor = _changes.Subscribe(_ => { }, _ => { });
+    }
+
+    public (T1, T2, T3) Current => (_get1(), _get2(), _get3());
+    public IDisposable Subscribe(IObserver<(T1, T2, T3)> observer) => _changes.Subscribe(observer);
+    public void Dispose() => _anchor.Dispose();
+}
+
+internal sealed class ReactiveCohort<T1, T2, T3, T4> : IReactiveConfig<T1, T2, T3, T4>, IDisposable
+{
+    private readonly IObservable<(T1, T2, T3, T4)> _changes;
+    private readonly Func<T1> _g1; private readonly Func<T2> _g2; private readonly Func<T3> _g3; private readonly Func<T4> _g4;
+    private readonly IDisposable _anchor;
+
+    public ReactiveCohort(ReactiveConfigManager manager, ILogger logger, Func<T1> g1, Func<T2> g2, Func<T3> g3, Func<T4> g4)
+    {
+        _g1 = g1; _g2 = g2; _g3 = g3; _g4 = g4;
+        var s1 = manager.ObservePerPass<T1>();
+        var s2 = manager.ObservePerPass<T2>();
+        var s3 = manager.ObservePerPass<T3>();
+        var s4 = manager.ObservePerPass<T4>();
+
+        _changes = s1.Zip(s2, (a,b) => (a,b))
+            .Zip(s3, (ab,c) => (ab.a, ab.b, c))
+            .Zip(s4, (abc,d) => (abc.a, abc.b, abc.c, d))
+            .Where(t => t.a.PassId == t.b.PassId && t.a.PassId == t.c.PassId && t.a.PassId == t.d.PassId)
+            .Where(t => t.a.Changed || t.b.Changed || t.c.Changed || t.d.Changed)
+            .Select(t => (t.a.Value, t.b.Value, t.c.Value, t.d.Value))
+            .Catch<(T1, T2, T3, T4), Exception>(ex =>
+            {
+                logger.LogWarning(ex, "Cohort<T1..T4> stream error ignored to keep alive");
+                return Observable.Empty<(T1, T2, T3, T4)>();
+            })
+            .Retry()
+            .Publish()
+            .RefCount();
+
+        _anchor = _changes.Subscribe(_ => { }, _ => { });
+    }
+
+    public (T1, T2, T3, T4) Current => (_g1(), _g2(), _g3(), _g4());
+    public IDisposable Subscribe(IObserver<(T1, T2, T3, T4)> o) => _changes.Subscribe(o);
+    public void Dispose() => _anchor.Dispose();
+}
+
+internal sealed class ReactiveCohort<T1, T2, T3, T4, T5> : IReactiveConfig<T1, T2, T3, T4, T5>, IDisposable
+{
+    private readonly IObservable<(T1, T2, T3, T4, T5)> _changes;
+    private readonly Func<T1> _g1; private readonly Func<T2> _g2; private readonly Func<T3> _g3; private readonly Func<T4> _g4; private readonly Func<T5> _g5;
+    private readonly IDisposable _anchor;
+
+    public ReactiveCohort(ReactiveConfigManager manager, ILogger logger, Func<T1> g1, Func<T2> g2, Func<T3> g3, Func<T4> g4, Func<T5> g5)
+    {
+        _g1 = g1; _g2 = g2; _g3 = g3; _g4 = g4; _g5 = g5;
+        var s1 = manager.ObservePerPass<T1>();
+        var s2 = manager.ObservePerPass<T2>();
+        var s3 = manager.ObservePerPass<T3>();
+        var s4 = manager.ObservePerPass<T4>();
+        var s5 = manager.ObservePerPass<T5>();
+
+        _changes = s1.Zip(s2, (a,b) => (a,b))
+            .Zip(s3, (ab,c) => (ab.a, ab.b, c))
+            .Zip(s4, (abc,d) => (abc.a, abc.b, abc.c, d))
+            .Zip(s5, (abcd,e) => (abcd.a, abcd.b, abcd.c, abcd.d, e))
+            .Where(t => t.a.PassId == t.b.PassId && t.a.PassId == t.c.PassId && t.a.PassId == t.d.PassId && t.a.PassId == t.e.PassId)
+            .Where(t => t.a.Changed || t.b.Changed || t.c.Changed || t.d.Changed || t.e.Changed)
+            .Select(t => (t.a.Value, t.b.Value, t.c.Value, t.d.Value, t.e.Value))
+            .Catch<(T1, T2, T3, T4, T5), Exception>(ex =>
+            {
+                logger.LogWarning(ex, "Cohort<T1..T5> stream error ignored to keep alive");
+                return Observable.Empty<(T1, T2, T3, T4, T5)>();
+            })
+            .Retry()
+            .Publish()
+            .RefCount();
+
+        _anchor = _changes.Subscribe(_ => { }, _ => { });
+    }
+
+    public (T1, T2, T3, T4, T5) Current => (_g1(), _g2(), _g3(), _g4(), _g5());
+    public IDisposable Subscribe(IObserver<(T1, T2, T3, T4, T5)> o) => _changes.Subscribe(o);
+    public void Dispose() => _anchor.Dispose();
+}

--- a/src/Cocoar.Configuration/Properties/AssemblyInfo.cs
+++ b/src/Cocoar.Configuration/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Cocoar.Configuration.Tests")]
+[assembly: InternalsVisibleTo("Cocoar.Configuration.Core.Tests")]

--- a/src/Cocoar.Configuration/ReactiveConfigManager.cs
+++ b/src/Cocoar.Configuration/ReactiveConfigManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Subjects;
+using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -18,6 +19,10 @@ internal sealed class ReactiveConfigManager : IDisposable
     private readonly ConcurrentDictionary<Type, object> _configObservables = new();
     private readonly ConcurrentDictionary<Type, string> _previousConfigHashes = new();
     private readonly object _observableLock = new();
+
+    // Per-pass subjects emit once per recompute pass (even if value unchanged)
+    private readonly ConcurrentDictionary<Type, object> _perPassSubjects = new();
+    private long _passId; // monotonically increasing recompute pass id
 
     /// <summary>
     /// Optimized JSON serialization options for hashing performance.
@@ -67,7 +72,39 @@ internal sealed class ReactiveConfigManager : IDisposable
             });
 
         // Return error-resilient reactive config wrapper
+        // Ensure per-pass subject exists for this type (lazy creation)
+        _perPassSubjects.GetOrAdd(type, _ => new Subject<PassEvent<T>>());
+
         return new ReactiveConfig<T>(subject, _logger);
+    }
+
+    /// <summary>
+    /// Internal per-pass event used to align multi-arity reactive configs on recompute boundaries.
+    /// Always emitted once per pass for each observed type, regardless of whether the value changed.
+    /// </summary>
+    internal readonly struct PassEvent<T>
+    {
+        public PassEvent(T value, bool changed, long passId)
+        {
+            Value = value;
+            Changed = changed;
+            PassId = passId;
+        }
+        public T Value { get; }
+        public bool Changed { get; }
+        public long PassId { get; }
+    }
+
+    /// <summary>
+    /// Gets the per-pass observable for a type. Always emits once per recompute pass with PassEvent metadata.
+    /// </summary>
+    internal IObservable<PassEvent<T>> ObservePerPass<T>()
+    {
+        if (_perPassSubjects.TryGetValue(typeof(T), out var existing) && existing is Subject<PassEvent<T>> subject)
+            return subject.AsObservable();
+
+        var created = (Subject<PassEvent<T>>)_perPassSubjects.GetOrAdd(typeof(T), _ => new Subject<PassEvent<T>>());
+        return created.AsObservable();
     }
 
     /// <summary>
@@ -102,69 +139,77 @@ internal sealed class ReactiveConfigManager : IDisposable
     /// <param name="configAccessor">Function to get current configuration values by type</param>
     public void NotifyConfigurationObservers(Func<Type, object?> configAccessor)
     {
-        foreach (var kvp in _configObservables.ToArray()) // ToArray to avoid collection modification issues
+        var passId = Interlocked.Increment(ref _passId);
+
+        foreach (var kvp in _configObservables.ToArray()) // snapshot to avoid enumeration issues
         {
+            var type = kvp.Key;
+            var subject = kvp.Value;
+            object? currentConfig;
+            bool changed = false;
             try
             {
-                var type = kvp.Key;
-                var subject = kvp.Value;
-                
-                // Safely get the current configuration value for this type
-                object? currentConfig;
-                try
-                {
-                    currentConfig = configAccessor(type);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to get current config for type {Type} during notification, skipping update", type);
-                    continue; // Skip this observer but continue with others
-                }
-                
-                // Check if the config value has actually changed using hash comparison
+                currentConfig = configAccessor(type);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to get current config for type {Type} during notification, skipping update", type);
+                continue;
+            }
+
+            try
+            {
+                // Change detection against previous hash (as before)
                 var currentHash = ComputeConfigHash(currentConfig);
                 var previousHash = _previousConfigHashes.GetValueOrDefault(type, string.Empty);
-                
-                if (currentHash == previousHash && !string.IsNullOrEmpty(previousHash))
+                changed = currentHash != previousHash || string.IsNullOrEmpty(previousHash);
+                if (changed)
                 {
-                    // No change detected, skip emission
-                    continue;
-                }
-                
-                // Store the new hash for next comparison
-                _previousConfigHashes[type] = currentHash;
-                
-                // Emit the current value to the subject
-                if (subject is ISubject<object?> objectSubject)
-                {
-                    objectSubject.OnNext(currentConfig);
-                }
-                else
-                {
-                    // For generic subjects, we need to call OnNext with the proper type
-                    var onNextMethod = subject.GetType().GetMethod("OnNext");
-                    if (onNextMethod != null)
+                    _previousConfigHashes[type] = currentHash;
+                    // Emit to behavior subject only when changed (preserve existing semantics)
+                    if (subject is ISubject<object?> objectSubject)
                     {
-                        // Convert to the specific generic type if needed
-                        var convertedValue = currentConfig;
-                        if (currentConfig != null && !type.IsAssignableFrom(currentConfig.GetType()))
+                        objectSubject.OnNext(currentConfig);
+                    }
+                    else
+                    {
+                        var onNextMethod = subject.GetType().GetMethod("OnNext");
+                        if (onNextMethod != null)
                         {
-                            // Try to handle interface bindings
-                            if (_bindingRegistry.TryGetConcreteType(type, out var concreteType) &&
-                                concreteType.IsAssignableFrom(currentConfig.GetType()))
+                            var convertedValue = currentConfig;
+                            if (currentConfig != null && !type.IsAssignableFrom(currentConfig.GetType()))
                             {
-                                convertedValue = currentConfig;
+                                if (_bindingRegistry.TryGetConcreteType(type, out var concreteType) &&
+                                    concreteType.IsAssignableFrom(currentConfig.GetType()))
+                                {
+                                    convertedValue = currentConfig;
+                                }
                             }
+                            onNextMethod.Invoke(subject, new[] { convertedValue });
                         }
-                        
-                        onNextMethod.Invoke(subject, new[] { convertedValue });
                     }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to notify configuration observer for type {Type}", kvp.Key);
-                // Continue with other observers even if this one fails
+                _logger.LogWarning(ex, "Failed change emission for type {Type}", type);
+            }
+
+            // Always emit per-pass event (even if not changed)
+            try
+            {
+                if (_perPassSubjects.TryGetValue(type, out var perPassObj))
+                {
+                    var passEventType = typeof(PassEvent<>).MakeGenericType(type);
+                    // Activator.CreateInstance arguments must match ctor: (value, changed, passId)
+                    var evt = Activator.CreateInstance(passEventType, new[] { currentConfig!, changed, passId })!;
+                    var onNextMethod = perPassObj.GetType().GetMethod("OnNext");
+                    onNextMethod?.Invoke(perPassObj, new[] { evt });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed per-pass emission for type {Type}", type);
             }
         }
     }
@@ -221,5 +266,10 @@ internal sealed class ReactiveConfigManager : IDisposable
         
         _configObservables.Clear();
         _previousConfigHashes.Clear();
+        foreach (var perPass in _perPassSubjects.Values.ToArray())
+        {
+            try { (perPass as IDisposable)?.Dispose(); } catch { /* ignore */ }
+        }
+        _perPassSubjects.Clear();
     }
 }

--- a/src/Cocoar.Configuration/ReactiveTupleConfig.cs
+++ b/src/Cocoar.Configuration/ReactiveTupleConfig.cs
@@ -1,0 +1,273 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.Logging;
+
+namespace Cocoar.Configuration;
+
+/// <summary>
+/// Unified tuple-capable IReactiveConfig implementation. Supports any System.ValueTuple shape.
+/// Semantics:
+///  * Single-type (non-tuple) behaves like original ReactiveConfig<T> (change-only emissions).
+///  * Tuple types emit once per recompute pass iff any element changed in that pass, with an atomic aligned snapshot.
+/// </summary>
+internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDisposable where TTuple : struct
+{
+    private readonly ILogger _logger;
+    private readonly IDisposable _subscription; // anchor
+    private readonly IObservable<TTuple> _observable; // resilient merged observable
+    private readonly Func<object?[], object> _builder; // creates tuple instance
+    private readonly Type[] _elementTypes;
+    private volatile object?[] _latestValues; // last known element snapshots
+    private readonly ConfigManager _configManager;
+
+    public ReactiveTupleConfig(
+        ConfigManager configManager,
+        ReactiveConfigManager reactiveConfigManager,
+        ILogger logger)
+    {
+        _configManager = configManager;
+        _logger = logger;
+        (_elementTypes, _builder) = TupleShapeCache.Get(typeof(TTuple));
+        if (_elementTypes.Length == 0)
+            throw new InvalidOperationException($"{typeof(TTuple).Name} is not a ValueTuple with elements.");
+
+        // Validate existence of each config upfront
+        var missing = new List<string>();
+        _latestValues = new object?[_elementTypes.Length];
+        for (int i = 0; i < _elementTypes.Length; i++)
+        {
+            var val = configManager.GetConfig(_elementTypes[i]);
+            if (val is null)
+                missing.Add(_elementTypes[i].Name);
+            _latestValues[i] = val; // may be null initially
+        }
+        if (missing.Count > 0)
+            throw new InvalidOperationException(
+                $"Cannot create IReactiveConfig<{typeof(TTuple).Name}>. Missing configuration for: {string.Join(", ", missing)}");
+
+        var merged = CreateMergedPerPassObservable(reactiveConfigManager);
+        _observable = merged
+            .Catch<TTuple, Exception>(ex =>
+            {
+                _logger.LogWarning(ex, "Tuple reactive config stream error ignored to keep alive for {TupleType}", typeof(TTuple).Name);
+                return Observable.Empty<TTuple>();
+            })
+            .Retry()
+            .Publish()
+            .RefCount();
+
+        _subscription = _observable.Subscribe(_ => { }, _ => { }); // anchor keep-hot semantics
+    }
+
+    public TTuple CurrentValue
+    {
+        get
+        {
+            try
+            {
+                // Refresh each slot lazily (cheap calls)
+                for (int i = 0; i < _elementTypes.Length; i++)
+                {
+                    var value = _configManager.GetConfig(_elementTypes[i]);
+                    if (value != null)
+                        _latestValues[i] = value;
+                }
+                return (TTuple)_builder(_latestValues);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to build CurrentValue for tuple {TupleType}", typeof(TTuple).Name);
+                return default;
+            }
+        }
+    }
+
+    public IDisposable Subscribe(IObserver<TTuple> observer) => _observable.Subscribe(observer);
+
+    private IObservable<TTuple> CreateMergedPerPassObservable(ReactiveConfigManager manager)
+    {
+        var streams = new IObservable<object>[_elementTypes.Length];
+        for (int i = 0; i < _elementTypes.Length; i++)
+        {
+            // Use reflection to call generic ObservePerPass<T>
+            var method = typeof(ReactiveConfigManager).GetMethod("ObservePerPass", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)!;
+            var g = method.MakeGenericMethod(_elementTypes[i]);
+            var passObservable = g.Invoke(manager, null)!; // IObservable<PassEvent<Ti>>
+            // Project to a uniform shape
+            var projected = (IObservable<object>)typeof(ReactiveTupleConfig<TTuple>)
+                .GetMethod(nameof(Project), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+                .MakeGenericMethod(_elementTypes[i])
+                .Invoke(null, new[] { passObservable, i })!;
+            streams[i] = projected;
+        }
+
+        var merged = streams.Merge();
+        return Observable.Create<TTuple>(observer =>
+        {
+            var gate = new object();
+            long currentPassId = -1;
+            int received = 0;
+            var changedAny = false;
+            var slotChanged = new bool[_elementTypes.Length];
+
+            void Reset(long passId)
+            {
+                currentPassId = passId;
+                received = 0;
+                changedAny = false;
+                Array.Clear(slotChanged, 0, slotChanged.Length);
+            }
+
+            Reset(-1);
+
+            return merged.Subscribe(evtObj =>
+            {
+                if (evtObj is not PassEnvelope env) return; // safety
+                lock (gate)
+                {
+                    if (received == 0)
+                    {
+                        Reset(env.PassId);
+                    }
+                    else if (env.PassId != currentPassId)
+                    {
+                        // Out-of-alignment event (should not happen). Start new pass cautiously.
+                        _logger.LogDebug("Tuple pass alignment discrepancy for {TupleType}: got {IncomingPass} expected {CurrentPass}", typeof(TTuple).Name, env.PassId, currentPassId);
+                        Reset(env.PassId);
+                    }
+
+                    if (!slotChanged[env.Index])
+                    {
+                        slotChanged[env.Index] = true;
+                        received++;
+                        if (env.Changed) changedAny = true;
+                        _latestValues[env.Index] = env.Value; // update snapshot (even if unchanged to keep reference freshness)
+                    }
+
+                    if (received == _elementTypes.Length)
+                    {
+                        if (changedAny)
+                        {
+                            try
+                            {
+                                var tuple = (TTuple)_builder(_latestValues);
+                                observer.OnNext(tuple);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, "Failed building tuple emission for {TupleType}", typeof(TTuple).Name);
+                            }
+                        }
+                        // ready for next pass
+                        currentPassId = -1; // force re-init next event
+                    }
+                }
+            }, ex =>
+            {
+                observer.OnError(ex); // upstream Catch/Retry wraps this
+            }, () =>
+            {
+                observer.OnCompleted();
+            });
+        });
+    }
+
+    private static IObservable<object> Project<T>(IObservable<ReactiveConfigManager.PassEvent<T>> source, int index)
+    {
+        return source.Select(e => (object)new PassEnvelope(index, e.PassId, e.Changed, e.Value));
+    }
+
+    private readonly record struct PassEnvelope(int Index, long PassId, bool Changed, object? Value);
+
+    public void Dispose() => _subscription.Dispose();
+}
+
+/// <summary>
+/// Caches flattened element type arrays and compiled tuple builder delegates.
+/// Handles nested ValueTuple (Rest) expansion.
+/// </summary>
+internal static class TupleShapeCache
+{
+    private static readonly ConcurrentDictionary<Type, (Type[] Elements, Func<object?[], object> Builder)> _cache = new();
+
+    public static (Type[] Elements, Func<object?[], object> Builder) Get(Type tupleType)
+    {
+        return _cache.GetOrAdd(tupleType, t =>
+        {
+            var elements = Flatten(t).ToArray();
+            var builder = CompileBuilder(t, elements);
+            return (elements, builder);
+        });
+    }
+
+    private static IEnumerable<Type> Flatten(Type t)
+    {
+        if (!IsValueTuple(t)) yield break;
+        var fields = t.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        for (int i = 0; i < fields.Length; i++)
+        {
+            var f = fields[i];
+            if (f.Name == "Rest" && IsValueTuple(f.FieldType))
+            {
+                foreach (var nested in Flatten(f.FieldType))
+                    yield return nested;
+            }
+            else
+            {
+                yield return f.FieldType;
+            }
+        }
+    }
+
+    private static bool IsValueTuple(Type t) => t.IsValueType && t.FullName != null && t.FullName.StartsWith("System.ValueTuple");
+
+    private static Func<object?[], object> CompileBuilder(Type tupleType, Type[] elements)
+    {
+        // Build nested constructor chain according to ValueTuple nesting rules
+        // ValueTuple packs first 7 elements then a Rest = ValueTuple<remaining>
+        var param = Expression.Parameter(typeof(object?[]), "arr");
+        Expression Build(int start)
+        {
+            int remaining = elements.Length - start;
+            if (remaining <= 7)
+            {
+                var ctorTypes = elements.Skip(start).Take(remaining).ToArray();
+                var ctors = GetTupleType(remaining, ctorTypes);
+                var args = ctorTypes.Select((t,i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t));
+                return Expression.New(ctors.GetConstructors()[0], args);
+            }
+            else
+            {
+                var headTypes = elements.Skip(start).Take(7).ToArray();
+                var restExpr = Build(start + 7);
+                var tupleTypeHead = GetTupleType(8, headTypes.Concat(new[]{ restExpr.Type }).ToArray());
+                var args = headTypes.Select((t,i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t))
+                    .Concat(new[]{ restExpr });
+                return Expression.New(tupleTypeHead.GetConstructors()[0], args);
+            }
+        }
+
+        var body = Build(0);
+        var lambda = Expression.Lambda<Func<object?[], object>>(Expression.Convert(body, typeof(object)), param);
+        return lambda.Compile();
+    }
+
+    private static Type GetTupleType(int count, Type[] types)
+    {
+        return count switch
+        {
+            <= 0 => throw new ArgumentOutOfRangeException(nameof(count)),
+            1 => typeof(ValueTuple<>).MakeGenericType(types),
+            2 => typeof(ValueTuple<,>).MakeGenericType(types),
+            3 => typeof(ValueTuple<,,>).MakeGenericType(types),
+            4 => typeof(ValueTuple<,,,>).MakeGenericType(types),
+            5 => typeof(ValueTuple<,,,,>).MakeGenericType(types),
+            6 => typeof(ValueTuple<,,,,,>).MakeGenericType(types),
+            7 => typeof(ValueTuple<,,,,,,>).MakeGenericType(types),
+            8 => typeof(ValueTuple<,,,,,,,>).MakeGenericType(types),
+            _ => throw new NotSupportedException("Unsupported tuple arity segment")
+        };
+    }
+}

--- a/src/Examples/Examples.slnx
+++ b/src/Examples/Examples.slnx
@@ -16,4 +16,5 @@
   <Project Path="ServiceLifetimes/ServiceLifetimes.csproj" />
   <Project Path="SimplifiedCoreExample/SimplifiedCoreExample.csproj" />
   <Project Path="StaticProviderExample/StaticProviderExample.csproj" />
+  <Project Path="TupleReactiveExample/TupleReactiveExample.csproj" />
 </Solution>

--- a/src/Examples/README.md
+++ b/src/Examples/README.md
@@ -16,6 +16,7 @@ This directory contains runnable examples for **Cocoar.Configuration**. Each sub
 - **DIExample** – Comprehensive DI integration patterns with advanced service registration
 - **SimplifiedCoreExample** – Pure core library usage without DI (ConfigManager only)
 - **BindingExample** – Interface binding without DI frameworks
+ - **TupleReactiveExample** – Tuple-based reactive multi-config snapshot & aligned emission demo
 
 ## Running an Example
 ```pwsh

--- a/src/Examples/TupleReactiveExample/Program.cs
+++ b/src/Examples/TupleReactiveExample/Program.cs
@@ -1,0 +1,115 @@
+using Cocoar.Configuration;
+using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.DI; // AddCocoarConfiguration IServiceCollection extension
+using Cocoar.Configuration.Providers; // StaticJson / Observable provider DSL extensions
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+// Example: Demonstrates tuple-based reactive configuration snapshots with arbitrary arity
+// and interface binding eligibility guard.
+//
+// Run:
+//   dotnet run
+// Then browse:
+//   http://localhost:5088/snapshot
+//   http://localhost:5088/raw
+//   http://localhost:5088/update
+//
+// The /update endpoint simulates a change to one config type; the tuple stream emits
+// at most once per recompute pass with aligned values.
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Subjects to simulate runtime changes (Observable provider emits these)
+var appSubject = new System.Reactive.Subjects.BehaviorSubject<AppSettings>(new AppSettings { Message = "Hello World", Counter = 0 });
+var flagsSubject = new System.Reactive.Subjects.BehaviorSubject<FeatureFlags>(new FeatureFlags { Flags = new [] { "Alpha", "Beta" } });
+
+// Define configuration rules using observable providers for dynamic types and static JSON for logging
+builder.Services.AddCocoarConfiguration([
+    Rule.From.Observable(appSubject).For<AppSettings>(),
+    Rule.From.Observable(flagsSubject).For<FeatureFlags>(),
+    Rule.From.StaticJson("{ \"Level\": \"Info\" }").For<LoggingConfig>()
+]);
+
+// Bind interface to concrete (eligible for tuple usage)
+Bind.Type<AppSettings>().To<IAppSettings>();
+
+var app = builder.Build();
+
+// Grab single reactive configs (auto-registered)
+var appReactive = app.Services.GetRequiredService<IReactiveConfig<AppSettings>>();
+var flagsReactive = app.Services.GetRequiredService<IReactiveConfig<FeatureFlags>>();
+var logReactive = app.Services.GetRequiredService<IReactiveConfig<LoggingConfig>>();
+
+// Grab tuple reactive config (atomic, aligned)
+var composite = app.Services.GetRequiredService<IReactiveConfig<(AppSettings App, FeatureFlags Flags, LoggingConfig Log)>>();
+
+// Subscribe (fire-and-forget) for demonstration
+_ = composite.Subscribe(t =>
+{
+    var (a, f, l) = t;
+    Console.WriteLine($"Tuple emission -> Counter={a.Counter} Flags={string.Join(',', f.Flags)} Level={l.Level}");
+});
+
+app.MapGet("/snapshot", (IReactiveConfig<(AppSettings App, FeatureFlags Flags, LoggingConfig Log)> tuple) =>
+{
+    var currentValue = tuple.CurrentValue;
+    return Results.Ok(new
+    {
+        currentValue.App.Message,
+        currentValue.App.Counter,
+        currentValue.Flags.Flags,
+        currentValue.Log.Level
+    });
+});
+
+app.MapGet("/raw", (AppSettings a, FeatureFlags f, LoggingConfig l) => new
+{
+    a.Message,
+    a.Counter,
+    f.Flags,
+    l.Level
+});
+
+// Simulate an update by layering a later (higher precedence) dynamic rule.
+// In real scenarios you'd have file / http / environment providers triggering changes.
+app.MapPost("/update", () =>
+{
+    // Push new values through subjects; tuple reactive config will emit once with aligned snapshot.
+    var current = appReactive.CurrentValue;
+    appSubject.OnNext(new AppSettings { Message = current.Message, Counter = current.Counter + 1 });
+
+    var currentFlags = flagsReactive.CurrentValue;
+    if (!System.Linq.Enumerable.Contains(currentFlags.Flags, "Gamma"))
+    {
+        flagsSubject.OnNext(new FeatureFlags { Flags = currentFlags.Flags.Concat(["Gamma"]).ToArray() });
+    }
+    return Results.Accepted();
+});
+
+// Demonstrate guard (uncomment to see exception at runtime during resolution)
+// var bad = app.Services.GetRequiredService<IReactiveConfig<(AppSettings, IUnbound, LoggingConfig)>>();
+
+app.Run();
+
+// Types
+public sealed class AppSettings : IAppSettings
+{
+    public string Message { get; set; } = "";
+    public int Counter { get; set; }
+}
+public interface IAppSettings
+{
+    string Message { get; }
+    int Counter { get; }
+}
+public sealed class FeatureFlags
+{
+    public string[] Flags { get; set; } = System.Array.Empty<string>();
+}
+public sealed class LoggingConfig
+{
+    public string Level { get; set; } = "Info";
+}
+// public interface IUnbound { } // Example of an unbound interface that would fail eligibility

--- a/src/Examples/TupleReactiveExample/Properties/launchSettings.json
+++ b/src/Examples/TupleReactiveExample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TupleReactiveExample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:62455;http://localhost:62456"
+    }
+  }
+}

--- a/src/Examples/TupleReactiveExample/TupleReactiveExample.csproj
+++ b/src/Examples/TupleReactiveExample/TupleReactiveExample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsExampleProject>true</IsExampleProject>
+    <RootNamespace>Examples.TupleReactiveExample</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cocoar.Configuration\Cocoar.Configuration.csproj" />
+    <ProjectReference Include="..\..\Cocoar.Configuration.AspNetCore\Cocoar.Configuration.AspNetCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/MultiArityReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/MultiArityReactiveConfigTests.cs
@@ -1,0 +1,148 @@
+using System.Reactive.Subjects;
+using Cocoar.Configuration;
+using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Cocoar.Configuration.Core.Tests.WhiteBox;
+
+public class MultiArityReactiveConfigTests
+{
+    private sealed class A { public int Value { get; set; } }
+    private sealed class B { public string? Name { get; set; } }
+    private sealed class C { public bool Flag { get; set; } }
+    private sealed class D { public double Rate { get; set; } }
+    private sealed class E { public string? Mode { get; set; } }
+
+    private static ConfigRule RuleFromSubject<T>(BehaviorSubject<T> subject) where T : class
+        => Rule.From.Observable(subject).Required().For<T>().Build();
+
+    [Fact]
+    public async Task TwoArity_EmitsOnce_When_OneMemberChanges()
+    {
+        var subjA = new BehaviorSubject<A>(new A{Value=1});
+        var subjB = new BehaviorSubject<B>(new B{Name="x"});
+        var rules = new [] { RuleFromSubject(subjA), RuleFromSubject(subjB) };
+        using var manager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50).Initialize();
+
+    // Ensure single-type reactive configs are created so per-pass subjects are wired
+    manager.GetReactiveConfig<A>();
+    manager.GetReactiveConfig<B>();
+    var cohort = new ReactiveCohort<A,B>(GetManagerField(manager), NullLogger.Instance, () => manager.GetConfig<A>()!, () => manager.GetConfig<B>()!);
+        var emissions = new List<(A,B)>();
+        using var sub = cohort.Subscribe(t => emissions.Add(t));
+
+        // change only A
+        subjA.OnNext(new A{Value=2});
+        await Task.Delay(120); // allow debounce + recompute
+
+        Assert.Single(emissions); // only one pass emitted
+        Assert.Equal(2, emissions[0].Item1.Value);
+        Assert.Equal("x", emissions[0].Item2.Name);
+    }
+
+    [Fact]
+    public async Task ThreeArity_SinglePass_MultipleChanges_StillOneEmission()
+    {
+        var subjA = new BehaviorSubject<A>(new A{Value=1});
+        var subjB = new BehaviorSubject<B>(new B{Name="x"});
+        var subjC = new BehaviorSubject<C>(new C{Flag=false});
+        var rules = new [] { RuleFromSubject(subjA), RuleFromSubject(subjB), RuleFromSubject(subjC) };
+        using var manager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50).Initialize();
+
+    manager.GetReactiveConfig<A>();
+    manager.GetReactiveConfig<B>();
+    manager.GetReactiveConfig<C>();
+    var cohort = new ReactiveCohort<A,B,C>(GetManagerField(manager), NullLogger.Instance, () => manager.GetConfig<A>()!, () => manager.GetConfig<B>()!, () => manager.GetConfig<C>()!);
+        var emissions = new List<(A,B,C)>();
+        using var sub = cohort.Subscribe(t => emissions.Add(t));
+
+        // change all three nearly together (within debounce window)
+        subjA.OnNext(new A{Value=10});
+        subjB.OnNext(new B{Name="y"});
+        subjC.OnNext(new C{Flag=true});
+        await Task.Delay(120);
+
+        Assert.Single(emissions);
+        var (a,b,c) = emissions[0];
+        Assert.Equal(10, a.Value);
+        Assert.Equal("y", b.Name);
+        Assert.True(c.Flag);
+    }
+
+    [Fact]
+    public async Task Cohort_DoesNotEmit_When_NoMembersChange()
+    {
+        var subjA = new BehaviorSubject<A>(new A{Value=1});
+        var subjB = new BehaviorSubject<B>(new B{Name="x"});
+        var rules = new [] { RuleFromSubject(subjA), RuleFromSubject(subjB) };
+        using var manager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50).Initialize();
+
+    manager.GetReactiveConfig<A>();
+    manager.GetReactiveConfig<B>();
+    var cohort = new ReactiveCohort<A,B>(GetManagerField(manager), NullLogger.Instance, () => manager.GetConfig<A>()!, () => manager.GetConfig<B>()!);
+        var emissions = new List<(A,B)>();
+        using var sub = cohort.Subscribe(t => emissions.Add(t));
+
+        // Trigger recompute by re-emitting identical objects (no change detection => no emission)
+        subjA.OnNext(new A{Value=1});
+        subjB.OnNext(new B{Name="x"});
+        await Task.Delay(120);
+
+        Assert.Empty(emissions);
+    }
+
+    [Fact]
+    public async Task FourArity_EmitsOnce_When_AnyChanges()
+    {
+        var sa = new BehaviorSubject<A>(new A{Value=1});
+        var sb = new BehaviorSubject<B>(new B{Name="b1"});
+        var sc = new BehaviorSubject<C>(new C{Flag=false});
+        var sd = new BehaviorSubject<D>(new D{Rate=1.0});
+        var rules = new [] { RuleFromSubject(sa), RuleFromSubject(sb), RuleFromSubject(sc), RuleFromSubject(sd) };
+        using var manager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50).Initialize();
+        manager.GetReactiveConfig<A>(); manager.GetReactiveConfig<B>(); manager.GetReactiveConfig<C>(); manager.GetReactiveConfig<D>();
+        var cohort = new ReactiveCohort<A,B,C,D>(GetManagerField(manager), NullLogger.Instance, () => manager.GetConfig<A>()!, () => manager.GetConfig<B>()!, () => manager.GetConfig<C>()!, () => manager.GetConfig<D>()!);
+        var emissions = new List<(A,B,C,D)>();
+        using var sub = cohort.Subscribe(x => emissions.Add(x));
+        // change one
+        sd.OnNext(new D{Rate=2.5});
+        await Task.Delay(120);
+        Assert.Single(emissions);
+        Assert.Equal(2.5, emissions[0].Item4.Rate);
+    }
+
+    [Fact]
+    public async Task FiveArity_SingleEmission_ForMultipleChangesSamePass()
+    {
+        var sa = new BehaviorSubject<A>(new A{Value=1});
+        var sb = new BehaviorSubject<B>(new B{Name="b1"});
+        var sc = new BehaviorSubject<C>(new C{Flag=false});
+        var sd = new BehaviorSubject<D>(new D{Rate=1.0});
+        var se = new BehaviorSubject<E>(new E{Mode="m1"});
+        var rules = new [] { RuleFromSubject(sa), RuleFromSubject(sb), RuleFromSubject(sc), RuleFromSubject(sd), RuleFromSubject(se) };
+        using var manager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50).Initialize();
+        manager.GetReactiveConfig<A>(); manager.GetReactiveConfig<B>(); manager.GetReactiveConfig<C>(); manager.GetReactiveConfig<D>(); manager.GetReactiveConfig<E>();
+        var cohort = new ReactiveCohort<A,B,C,D,E>(GetManagerField(manager), NullLogger.Instance, () => manager.GetConfig<A>()!, () => manager.GetConfig<B>()!, () => manager.GetConfig<C>()!, () => manager.GetConfig<D>()!, () => manager.GetConfig<E>()!);
+        var emissions = new List<(A,B,C,D,E)>();
+        using var sub = cohort.Subscribe(x => emissions.Add(x));
+        // multiple changes within debounce window
+        sa.OnNext(new A{Value=9});
+        sd.OnNext(new D{Rate=3.14});
+        se.OnNext(new E{Mode="m2"});
+        await Task.Delay(140);
+        Assert.Single(emissions);
+        var last = emissions[0];
+        Assert.Equal(9, last.Item1.Value);
+        Assert.Equal(3.14, last.Item4.Rate);
+        Assert.Equal("m2", last.Item5.Mode);
+    }
+
+    private static ReactiveConfigManager GetManagerField(ConfigManager manager)
+    {
+        // Reflect private field _reactiveConfigManager
+        var field = typeof(ConfigManager).GetField("_reactiveConfigManager", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (ReactiveConfigManager)field!.GetValue(manager)!;
+    }
+}

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Cocoar.Configuration.Providers;
+
+namespace Cocoar.Configuration.Core.Tests.WhiteBox;
+
+public class TupleReactiveConfigGuardTests
+{
+    private interface IApp { int V { get; } }
+    private record App(int V) : IApp;
+
+    private static ConfigRule Rule<T>(T value)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(value);
+        return global::Cocoar.Configuration.Providers.StaticJsonProvider.CreateRule<T>(json, required: true);
+    }
+
+    [Fact]
+    public void Tuple_With_Unconfigured_Primitive_Fails()
+    {
+        var mgr = new ConfigManager(new[]{ Rule(new App(1)) }, logger: NullLogger.Instance).Initialize();
+        // int is not a configured type; guard should throw
+        Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(App,int)>());
+    }
+
+    [Fact]
+    public void Tuple_With_Bound_Interface_Succeeds()
+    {
+    var binding = Bind.Type<App>().To<IApp>();
+    var mgr = new ConfigManager(new[]{ Rule(new App(2)) }, new[]{ (BindingSpec)binding }, NullLogger.Instance).Initialize();
+        var cfg = mgr.GetReactiveConfig<(IApp,App)>();
+        var snapshot = cfg.CurrentValue;
+        Assert.Equal(2, snapshot.Item1.V);
+        Assert.Equal(2, snapshot.Item2.V);
+    }
+
+    [Fact]
+    public void Tuple_With_Unbound_Interface_Fails()
+    {
+        var mgr = new ConfigManager(new[]{ Rule(new App(3)) }, logger: NullLogger.Instance).Initialize();
+        Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(IApp,App)>());
+    }
+}

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
@@ -1,0 +1,101 @@
+using System.Reactive.Linq;
+using Cocoar.Configuration.Core.Tests.TestUtilities;
+using Cocoar.Configuration.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Cocoar.Configuration.Core.Tests.WhiteBox;
+
+public class TupleReactiveConfigTests
+{
+    // Simple POCO configs
+    private record A(int V);
+    private record B(string S);
+    private record C(bool Flag);
+    private record D(double X);
+    private record E(int Z);
+    private record F(Guid Id);
+    private record G(DateTime T);
+    private record H(long L);
+
+    private static ConfigManager Create(params ConfigRule[] rules)
+    {
+        var mgr = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 10).Initialize();
+        return mgr;
+    }
+
+    private static (ConfigRule Rule, System.Reactive.Subjects.BehaviorSubject<T> Subject) Rule<T>(T value)
+    {
+        var subject = new System.Reactive.Subjects.BehaviorSubject<T>(value);
+        var rule = ConfigRule.Create<global::Cocoar.Configuration.Providers.ObservableProvider<T>, global::Cocoar.Configuration.Providers.ObservableProviderOptions<T>, global::Cocoar.Configuration.Providers.ObservableProviderQuery>(
+            _ => new global::Cocoar.Configuration.Providers.ObservableProviderOptions<T>(subject),
+            _ => global::Cocoar.Configuration.Providers.ObservableProviderQuery.Default,
+            typeof(T),
+            new ConfigRuleOptions { Required = true });
+        return (rule, subject);
+    }
+
+    [Fact]
+    public async Task Tuple2_Emits_WhenEitherElementChanges()
+    {
+    var (ruleA, subjA) = Rule(new A(1));
+    var (ruleB, subjB) = Rule(new B("x"));
+    var mgr = Create(ruleA, ruleB);
+        var reactive = mgr.GetReactiveConfig<(A,B)>();
+        var emitted = new List<(A,B)>();
+        using var sub = reactive.Subscribe(v => emitted.Add(v));
+        subjA.OnNext(new A(2));
+        await Task.Delay(180); // debounce + recompute
+        Assert.Contains(emitted, t => t.Item1.V == 2 && t.Item2.S == "x");
+    }
+
+    [Fact]
+    public async Task Tuple5_Emits_SinglePass_WhenMultipleChange()
+    {
+        var rules = new List<ConfigRule>();
+    var (r1, s1) = Rule(new A(1)); rules.Add(r1);
+    var (r2, s2) = Rule(new B("a")); rules.Add(r2);
+    var (r3, s3) = Rule(new C(true)); rules.Add(r3);
+    var (r4, s4) = Rule(new D(1.0)); rules.Add(r4);
+    var (r5, s5) = Rule(new E(5)); rules.Add(r5);
+        var mgr = Create(rules.ToArray());
+        var reactive = mgr.GetReactiveConfig<(A,B,C,D,E)>();
+        var list = new List<(A,B,C,D,E)>();
+        using var sub = reactive.Subscribe(v => list.Add(v));
+        s1.OnNext(new A(9));
+        s3.OnNext(new C(false));
+        s5.OnNext(new E(42));
+        await Task.Delay(220);
+        var matching = list.Where(v => v.Item1.V==9 && v.Item3.Flag==false && v.Item5.Z==42).ToList();
+        Assert.Equal(1, matching.Count);
+    }
+
+    [Fact]
+    public async Task LargeTuple8_Supported_WithNestedRest()
+    {
+        var rules = new List<ConfigRule>();
+    var (r1, s1) = Rule(new A(1)); rules.Add(r1);
+    var (r2, s2) = Rule(new B("b")); rules.Add(r2);
+    var (r3, s3) = Rule(new C(true)); rules.Add(r3);
+    var (r4, s4) = Rule(new D(2.5)); rules.Add(r4);
+    var (r5, s5) = Rule(new E(7)); rules.Add(r5);
+    var (r6, s6) = Rule(new F(Guid.NewGuid())); rules.Add(r6);
+    var (r7, s7) = Rule(new G(DateTime.UtcNow)); rules.Add(r7);
+    var (r8, s8) = Rule(new H(1234)); rules.Add(r8);
+        var mgr = Create(rules.ToArray());
+        var reactive = mgr.GetReactiveConfig<(A,B,C,D,E,F,G,H)>();
+        var emissions = new List<(A,B,C,D,E,F,G,H)>();
+        using var sub = reactive.Subscribe(e => emissions.Add(e));
+        s8.OnNext(new H(9999));
+        await Task.Delay(180);
+        Assert.Contains(emissions, t => t.Item8.L == 9999);
+    }
+
+    [Fact]
+    public void MissingConfig_Throws()
+    {
+    var (only, _) = Rule(new A(1));
+    var mgr = Create(only);
+        Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(A,B)>());
+    }
+}


### PR DESCRIPTION
This PR introduces tuple support for IReactiveConfig<T>.

You can now inject IReactiveConfig<(AppSettings, DbSettings)> (or any other ValueTuple of config types).
Tuple-based reactive configs are recomputed atomically: all member types are aligned to the same recompute pass, and consumers receive a single emission if any member changed.