### PR TITLE
feat: add JsonStringEnumConverter to support enum string deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [3.1.0] - Unreleased
+## [3.1.1] - 2025-10-19
+
+### Fixed
+- **Enum String Conversion**: Added `JsonStringEnumConverter` to support deserializing enums from string values in JSON/environment variables
+  - Fixes issue where enum properties (e.g., `LogEventLevel.Debug`) would fail when provided as strings (e.g., `"Debug"`)
+  - Common scenario: Visual Studio setting `Logging={"LogLevel":{"Microsoft.AspNetCore.Watch":"Debug"}}` as environment variable
+  - Now supports case-insensitive string-to-enum conversion for all enum types
+
+## [3.1.0] - 2025-10-19
 
 ### Added
 - **Interface Deserialization Support**: New `setup.Interface<I>().DeserializeTo<T>()` API for deserializing interface-typed properties in configuration classes

--- a/src/Cocoar.Configuration/Utilities/ConfigurationDeserializer.cs
+++ b/src/Cocoar.Configuration/Utilities/ConfigurationDeserializer.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Cocoar.Configuration.Utilities;
 
@@ -33,6 +34,7 @@ internal static class ConfigurationDeserializer
         options.Converters.Add(new StringToPrimitiveConverter<float>());
         options.Converters.Add(new StringToPrimitiveConverter<long>());
         options.Converters.Add(new StringToPrimitiveConverter<DateTime>());
+        options.Converters.Add(new JsonStringEnumConverter());
 
         return options;
     }
@@ -47,6 +49,7 @@ internal static class ConfigurationDeserializer
         options.Converters.Add(new StringToPrimitiveConverter<float>());
         options.Converters.Add(new StringToPrimitiveConverter<long>());
         options.Converters.Add(new StringToPrimitiveConverter<DateTime>());
+        options.Converters.Add(new JsonStringEnumConverter());
         options.Converters.Add(new InterfaceConverter(new Dictionary<Type, Type>(deserializationMap)));
 
         return options;


### PR DESCRIPTION
**Enum String Conversion**: Added `JsonStringEnumConverter` to support deserializing enums from string values in JSON/environment variables
  - Fixes issue where enum properties (e.g., `LogEventLevel.Debug`) would fail when provided as strings (e.g., `"Debug"`)
  - Common scenario: Visual Studio setting `Logging={"LogLevel":{"Microsoft.AspNetCore.Watch":"Debug"}}` as environment variable
  - Now supports case-insensitive string-to-enum conversion for all enum types