### PR TITLE
feat: Add CocoarTestConfiguration for test-time config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [4.0.0] - 2026-01-08
 
 ### Added
 
@@ -13,7 +13,8 @@
 - Comprehensive documentation in [Testing Overrides](docs/testing-overrides-quickref.md)
 - Example project demonstrating usage patterns
 
-**NEW: Cocoar.Configuration.Secrets Package**
+**NEW: Cocoar.Configuration.Secrets Package [BETA]**
+⚠️ **Beta Feature**: API may change in future releases based on feedback. Production-ready but subject to refinement.
 - `Secret<T>` type for type-safe secret handling with automatic memory zeroing
 - Hybrid encryption using RSA key wrapping + AES-GCM for envelope-based secrets
 - X.509 certificate-based encryption with **password-less certificates** (industry standard)
@@ -25,7 +26,8 @@
 - Configurable certificate ordering and subdirectory search depth
 - Seamless JSON deserialization support via custom converters
 - Works with primitives, complex types, collections, and nested objects
-
+ [BETA]**
+⚠️ **Beta Feature**: CLI commands and options may evolve based on feedback.
 **NEW: Cocoar.Configuration.Secrets.Cli Tool**
 - Command-line tool for managing encrypted secrets in JSON configuration files
 - **`generate-cert`**: Generate self-signed certificates (PFX or PEM format)
@@ -64,6 +66,7 @@
 
 ### Notes
 - The provider contract change is internal - consuming applications are not affected
+- **Secrets feature is in beta**: While production-ready, the API may evolve based on real-world usage and feedback
 - Password-less certificates are the recommended approach (industry standard: nginx, PostgreSQL, Kubernetes, Docker)
 
 ## [3.3.0] - 2025-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+**NEW: Testing Configuration Overrides**
+- `CocoarTestConfiguration` API for overriding configuration in integration tests
+- Two modes: `ReplaceAllRules()` (skip original rules) and `AppendTestRules()` (last-write-wins merging)
+- Uses `AsyncLocal<T>` for automatic test isolation across parallel tests
+- Works universally with direct `ConfigManager` instantiation, DI, AspNetCore, and `WebApplicationFactory`
+- Zero application code changes required - detection happens in ConfigManager constructors
+- Comprehensive documentation in [Testing Overrides](docs/testing-overrides-quickref.md)
+- Example project demonstrating usage patterns
+
 **NEW: Cocoar.Configuration.Secrets Package**
 - `Secret<T>` type for type-safe secret handling with automatic memory zeroing
 - Hybrid encryption using RSA key wrapping + AES-GCM for envelope-based secrets
@@ -63,13 +72,13 @@
 - **Rule Naming**: New `.Named("name")` fluent API for adding human-readable names to rules
   - Example: `rule.For<DbConfig>().FromFile("db.json").Named("Primary Database")`
   - Names appear in health snapshots for better observability in dashboards and logs
-  
+
 - **Enhanced Health Monitoring**: Expanded `RuleHealthEntry` with additional metadata
   - `Name` - Optional rule name (set via `.Named()`)
   - `ProviderType` - Name of the provider type used by the rule
   - `ConfigType` - Name of the configuration type being loaded
   - `Skipped` status - New `RuleResultStatus.Skipped` for rules skipped by `.When()` conditions
-  
+
 - **Health Summary Metrics**: New `Skipped` count in `Summary` for tracking conditional rules
   - Complements existing `Total`, `RequiredFailed`, `OptionalFailed` counters
 
@@ -143,7 +152,7 @@ builder.AddCocoarConfiguration(rule => [
     rule.For<AppSettings>().FromEnvironment()
 ], setup => [
     setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>(),
-    
+
     // Map interface properties to concrete types
     setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>()
 ]);
@@ -187,7 +196,7 @@ builder.AddCocoarConfiguration(rule => [
 builder.AddCocoarConfiguration(rule => [
     rule.File("config.json").Select("App").For<AppSettings>(),
     rule.Environment("APP_").For<AppSettings>(),
-    
+
     // Conditional rule (old signature)
     rule.File("premium.json")
         .When(() => isPremium)
@@ -200,7 +209,7 @@ builder.AddCocoarConfiguration(rule => [
 builder.AddCocoarConfiguration(rule => [
     rule.For<AppSettings>().FromFile("config.json").Select("App"),
     rule.For<AppSettings>().FromEnvironment("APP_"),
-    
+
     // Conditional rule (new signature with accessor)
     rule.For<PremiumFeatures>().FromFile("premium.json")
         .When(accessor => accessor.GetRequiredConfig<TenantSettings>().Tier == "Premium")
@@ -261,7 +270,7 @@ This marks the first stable release of Cocoar.Configuration with production-read
 - **Comprehensive Test Suite**: **204 automated tests** covering core functionality, providers, edge cases, and stress scenarios
 - **Health Monitoring System**: Complete health monitoring with `IConfigurationHealthService`, health snapshots, and experimental metrics export hooks
 - **Reactive Configuration**: Auto-registered `IReactiveConfig<T>` for every configuration type in dependency injection
-- **Enhanced Documentation**: 
+- **Enhanced Documentation**:
   - Streamlined README with practical examples and accurate feature descriptions
   - Dedicated health monitoring guide (`docs/health-monitoring.md`)
   - Reactive configuration guide (`docs/reactive-config.md`)
@@ -281,7 +290,7 @@ This marks the first stable release of Cocoar.Configuration with production-read
 - **Documentation Structure**: Consolidated scattered documentation into focused, practical guides
 
 ### Quality & Reliability
-- **204 comprehensive tests** ensuring stability across all components and failure scenarios  
+- **204 comprehensive tests** ensuring stability across all components and failure scenarios
 - **Production-tested patterns** validated through extensive integration and stress testing
 - **Error-resilient implementations** with proper failure handling and recovery mechanisms
 - **Continuous integration** ensuring every change maintains stability and correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Comprehensive documentation in [Testing Overrides](docs/testing-overrides-quickref.md)
 - Example project demonstrating usage patterns
 
-**NEW: Cocoar.Configuration.Secrets Package [BETA]**
-⚠️ **Beta Feature**: API may change in future releases based on feedback. Production-ready but subject to refinement.
+**NEW: Cocoar.Configuration.Secrets Package [Developer Preview]**
+⚠️ **Developer Preview**: API may change in future releases based on feedback. Production-ready but subject to refinement.
 - `Secret<T>` type for type-safe secret handling with automatic memory zeroing
 - Hybrid encryption using RSA key wrapping + AES-GCM for envelope-based secrets
 - X.509 certificate-based encryption with **password-less certificates** (industry standard)
@@ -26,8 +26,8 @@
 - Configurable certificate ordering and subdirectory search depth
 - Seamless JSON deserialization support via custom converters
 - Works with primitives, complex types, collections, and nested objects
- [BETA]**
-⚠️ **Beta Feature**: CLI commands and options may evolve based on feedback.
+ [Developer Preview]**
+⚠️ **Developer Preview**: CLI commands and options may evolve based on feedback.
 **NEW: Cocoar.Configuration.Secrets.Cli Tool**
 - Command-line tool for managing encrypted secrets in JSON configuration files
 - **`generate-cert`**: Generate self-signed certificates (PFX or PEM format)
@@ -66,7 +66,7 @@
 
 ### Notes
 - The provider contract change is internal - consuming applications are not affected
-- **Secrets feature is in beta**: While production-ready, the API may evolve based on real-world usage and feedback
+- **Secrets feature is in Developer Preview**: While production-ready, the API may evolve based on real-world usage and feedback
 - Password-less certificates are the recommended approach (industry standard: nginx, PostgreSQL, Kubernetes, Docker)
 
 ## [3.3.0] - 2025-10-23

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Microsoft's `IConfiguration` works, but configuration deserves better. Here's wh
 * **Explicit layering** – Rules execute in order, last write wins. No hidden merge logic.
 * **Interface deserialization** – Support for interface-typed properties in config classes with explicit mapping.
 * **Built-in health monitoring** – Track provider status and config changes with `IConfigurationHealthService`.
-* **Memory-safe secrets [BETA]** – `Secret<T>` with automatic zeroization and pre-encrypted envelope support.
+* **Memory-safe secrets [Developer Preview]** – `Secret<T>` with automatic zeroization and pre-encrypted envelope support.
 * **First-class testing support** – Override configuration in integration tests with zero ceremony using `CocoarTestConfiguration`. Works with direct instantiation, DI, AspNetCore, and WebApplicationFactory. See [Testing Documentation](docs/testing-overrides-quickref.md).
 * **Compile-time validation** – Roslyn analyzers catch configuration errors while you code with red squiggles, automatic quick fixes, and CI/CD integration. Zero runtime cost. See [Analyzer Documentation](src/Cocoar.Configuration.Analyzers/README.md) for details on diagnostics (COCFG001-006).
 
@@ -309,9 +309,9 @@ builder.Services.AddCocoarConfiguration(rule => [
 
 ---
 
-## Secrets Management [BETA]
+## Secrets Management [Developer Preview]
 
-⚠️ **Beta Feature**: API may change in future releases based on feedback. Production-ready but subject to refinement.
+⚠️ **Developer Preview**: API may change in future releases based on feedback. Production-ready but subject to refinement.
 
 **Cocoar.Configuration.Secrets** provides memory-safe handling of sensitive configuration data — a unique capability in open-source configuration libraries:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Microsoft's `IConfiguration` works, but configuration deserves better. Here's wh
 * **Explicit layering** – Rules execute in order, last write wins. No hidden merge logic.
 * **Interface deserialization** – Support for interface-typed properties in config classes with explicit mapping.
 * **Built-in health monitoring** – Track provider status and config changes with `IConfigurationHealthService`.
-* **Memory-safe secrets** – `Secret<T>` with automatic zeroization and pre-encrypted envelope support.
+* **Memory-safe secrets [BETA]** – `Secret<T>` with automatic zeroization and pre-encrypted envelope support.
 * **First-class testing support** – Override configuration in integration tests with zero ceremony using `CocoarTestConfiguration`. Works with direct instantiation, DI, AspNetCore, and WebApplicationFactory. See [Testing Documentation](docs/testing-overrides-quickref.md).
 * **Compile-time validation** – Roslyn analyzers catch configuration errors while you code with red squiggles, automatic quick fixes, and CI/CD integration. Zero runtime cost. See [Analyzer Documentation](src/Cocoar.Configuration.Analyzers/README.md) for details on diagnostics (COCFG001-006).
 
@@ -309,7 +309,9 @@ builder.Services.AddCocoarConfiguration(rule => [
 
 ---
 
-## Secrets Management
+## Secrets Management [BETA]
+
+⚠️ **Beta Feature**: API may change in future releases based on feedback. Production-ready but subject to refinement.
 
 **Cocoar.Configuration.Secrets** provides memory-safe handling of sensitive configuration data — a unique capability in open-source configuration libraries:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 ---
 > **📖 Articles & Deep Dives**
 >
-> • [Reactive, Strongly-Typed Configuration in .NET: Introducing Cocoar.Configuration v3.0 (Part 1)](https://dev.to/bwi/reactive-strongly-typed-configuration-in-net-introducing-cocoarconfiguration-v30-3gbn)  
->   Learn how v3.0 simplifies configuration management with zero-ceremony DI, atomic multi-config updates, and reactive patterns.  
+> • [Reactive, Strongly-Typed Configuration in .NET: Introducing Cocoar.Configuration v3.0 (Part 1)](https://dev.to/bwi/reactive-strongly-typed-configuration-in-net-introducing-cocoarconfiguration-v30-3gbn)
+>   Learn how v3.0 simplifies configuration management with zero-ceremony DI, atomic multi-config updates, and reactive patterns.
 >
-> • [Config-Aware Rules in .NET — The Power Feature of Cocoar.Configuration (Part 2)](https://dev.to/bwi/config-aware-rules-in-net-the-power-feature-of-cocoarconfiguration-part-2-2ibk)  
+> • [Config-Aware Rules in .NET — The Power Feature of Cocoar.Configuration (Part 2)](https://dev.to/bwi/config-aware-rules-in-net-the-power-feature-of-cocoarconfiguration-part-2-2ibk)
 >   Dive deeper into **atomic recompute**, **required vs optional rules**, and **config-aware conditional logic** for dynamic, tenant-aware setups.
 ---
 
@@ -55,7 +55,8 @@ Microsoft's `IConfiguration` works, but configuration deserves better. Here's wh
 * **Interface deserialization** – Support for interface-typed properties in config classes with explicit mapping.
 * **Built-in health monitoring** – Track provider status and config changes with `IConfigurationHealthService`.
 * **Memory-safe secrets** – `Secret<T>` with automatic zeroization and pre-encrypted envelope support.
-* **✨ Compile-time validation** – Roslyn analyzers catch configuration errors while you code with red squiggles, automatic quick fixes, and CI/CD integration. Zero runtime cost. See [Analyzer Documentation](src/Cocoar.Configuration.Analyzers/README.md) for details on diagnostics (COCFG001-006).
+* **First-class testing support** – Override configuration in integration tests with zero ceremony using `CocoarTestConfiguration`. Works with direct instantiation, DI, AspNetCore, and WebApplicationFactory. See [Testing Documentation](docs/testing-overrides-quickref.md).
+* **Compile-time validation** – Roslyn analyzers catch configuration errors while you code with red squiggles, automatic quick fixes, and CI/CD integration. Zero runtime cost. See [Analyzer Documentation](src/Cocoar.Configuration.Analyzers/README.md) for details on diagnostics (COCFG001-006).
 
 **DI Lifetimes:** Concrete config types are registered as **Scoped** (stable snapshot per request), while `IReactiveConfig<T>` is **Singleton** (continuous live updates). These defaults can be customized via the `setup` parameter.
 
@@ -109,7 +110,7 @@ builder.Services.AddCocoarConfiguration(rule => [
 var app = builder.Build();
 
 // Direct injection - just use your POCO
-app.MapGet("/api/status", (AppSettings settings) => 
+app.MapGet("/api/status", (AppSettings settings) =>
     new { settings.Version, settings.FeatureFlags });
 
 app.Run();
@@ -120,11 +121,11 @@ app.Run();
 public class CacheWarmer : BackgroundService
 {
     private readonly IReactiveConfig<AppSettings> _config;
-    
+
     public CacheWarmer(IReactiveConfig<AppSettings> config)
     {
         _config = config;
-        
+
         // Subscribe once - rebuild cache when settings change
         _config.Subscribe(newSettings =>
         {
@@ -132,7 +133,7 @@ public class CacheWarmer : BackgroundService
             RebuildCache(newSettings);
         });
     }
-    
+
     protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
 }
 ```
@@ -142,11 +143,11 @@ public class CacheWarmer : BackgroundService
 public class ConfigHub : Hub
 {
     private readonly IReactiveConfig<(AppSettings App, DatabaseConfig Db)> _configs;
-    
+
     public ConfigHub(IReactiveConfig<(AppSettings App, DatabaseConfig Db)> configs)
     {
         _configs = configs;
-        
+
         // Stream config changes to connected clients - always atomic
         _configs.Subscribe(async tuple =>
         {
@@ -172,7 +173,7 @@ builder.Services.AddCocoarConfiguration(rule => [
 // Rules execute in order - last write wins
 ```
 
-**Environment variable mapping:**  
+**Environment variable mapping:**
 Hierarchical keys use `__` (double underscore):
 ```bash
 APP_Database__Host=localhost
@@ -180,14 +181,14 @@ APP_Database__Port=5432
 # Maps to: AppSettings.Database.Host and AppSettings.Database.Port
 ```
 
-**Command-line argument mapping:**  
+**Command-line argument mapping:**
 Hierarchical keys use `:` or `__`:
 ```bash
 dotnet run --Database:Host=localhost --Database:Port=5432 --Verbose
 # Maps to: AppSettings.Database.Host, AppSettings.Database.Port, and AppSettings.Verbose (true)
 ```
 
-**Flexible switch prefixes for command-line arguments:**  
+**Flexible switch prefixes for command-line arguments:**
 Use any prefix style (`--`, `-`, `/`, `@`, `#`, `%`) - even multiple at once:
 ```csharp
 // Single custom prefix
@@ -207,7 +208,7 @@ dotnet run --host=localhost -port=8080 /verbose
 invoke.exe @target=server #issue=123 %env=prod
 ```
 
-**Prefix filtering for command-line arguments:**  
+**Prefix filtering for command-line arguments:**
 Map arguments to specific configuration types:
 ```csharp
 builder.Services.AddCocoarConfiguration(rule => [
@@ -366,6 +367,7 @@ Explore real-world scenarios in the [examples](src/Examples/) directory:
 |-------|------|
 | Reactive Configuration | [Reactive Config](docs/reactive-config.md) |
 | Health Monitoring | [Health Monitoring](docs/health-monitoring.md) |
+| Testing with Configuration Overrides | [Testing Overrides](docs/testing-overrides-quickref.md) |
 | Intelligent Certificate Caching | [Certificate Caching](src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md) |
 | Provider Guidance | [Provider Guidance](docs/provider-guidance.md) |
 | Migration from v2.x | [Migration Guide v2→v3](docs/migration-v2-to-v3.md) |
@@ -375,14 +377,31 @@ Explore real-world scenarios in the [examples](src/Examples/) directory:
 
 ## Testing
 
-Over 200 automated tests covering:
+Cocoar.Configuration provides first-class testing support with `CocoarTestConfiguration`:
+
+```csharp
+[Fact]
+public async Task TestWithOverriddenConfig()
+{
+    // Set test configuration BEFORE creating WebApplicationFactory
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => testDbConfig)
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Original rules are skipped - only test rules execute
+}
+```
+
+**Over 200 automated tests** covering:
 * Configuration layering and rule execution
 * Reactive updates and atomic snapshots
 * Provider reliability and failover
 * Concurrent access and race conditions
 * Health monitoring and status tracking
+* Test configuration overrides and isolation
 
-See the [Testing Guide](src/tests/Cocoar.Configuration.Core.Tests/TESTING_GUIDE.md) for details.
+See the [Testing Guide](src/tests/Cocoar.Configuration.Core.Tests/TESTING_GUIDE.md) for implementation details and [Testing Overrides Documentation](docs/testing-overrides-quickref.md) for integration testing patterns.
 
 ---
 

--- a/docs/testing-overrides-quickref.md
+++ b/docs/testing-overrides-quickref.md
@@ -1,0 +1,125 @@
+# Testing Configuration Overrides - Quick Reference
+
+## Overview
+
+`CocoarTestConfiguration` provides zero-ceremony configuration overrides for integration tests using `AsyncLocal<T>` for automatic test isolation.
+
+## Quick Start
+
+```csharp
+using Cocoar.Configuration.Testing;
+
+[Fact]
+public async Task MyIntegrationTest()
+{
+    // Set BEFORE creating ConfigManager/WebApplicationFactory
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => testDbConfig)
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Original rules are skipped - only test rules execute
+}
+```
+
+## API
+
+### Replace Mode (Skip Original Rules)
+```csharp
+CocoarTestConfiguration.ReplaceAllRules(rule => [...]);
+```
+- Original providers never execute (no I/O, no failures)
+- Complete test isolation
+- Use when: Providers would fail or you need full control
+
+### Append Mode (Last-Write-Wins)
+```csharp
+CocoarTestConfiguration.AppendTestRules(rule => [...]);
+```
+- Original rules run first, test rules override
+- Partial overrides only
+- Use when: Only specific values need overriding
+
+### Clear Test Configuration
+```csharp
+CocoarTestConfiguration.Clear();
+```
+- Always call in test cleanup (`Dispose()`)
+- Essential for test isolation
+
+### Check Active Status
+```csharp
+bool isActive = CocoarTestConfiguration.IsActive;
+```
+
+## Works Everywhere
+
+✅ Direct `new ConfigManager(...)`
+✅ `services.AddCocoarConfiguration(...)`
+✅ `builder.AddCocoarConfiguration(...)`
+✅ `new WebApplicationFactory<Program>()`
+
+## Test Base Class Pattern
+
+```csharp
+public abstract class IntegrationTestBase : IDisposable
+{
+    protected void UseTestConfig(Func<RulesBuilder, ConfigRule[]> rules)
+        => CocoarTestConfiguration.ReplaceAllRules(rules);
+
+    public virtual void Dispose()
+        => CocoarTestConfiguration.Clear();
+}
+```
+
+## Common Patterns
+
+### Testcontainers
+```csharp
+[Fact]
+public async Task TestWithContainer()
+{
+    await _postgres.StartAsync();
+
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => new DbConfig
+        {
+            ConnectionString = _postgres.GetConnectionString()
+        })
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Test against testcontainer
+}
+```
+
+### Feature Flags
+```csharp
+[Theory]
+[InlineData(true)]
+[InlineData(false)]
+public async Task TestFeatureFlag(bool enabled)
+{
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<FeatureFlags>().FromStatic(_ => new FeatureFlags
+        {
+            NewFeature = enabled
+        })
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Test with feature on/off
+}
+```
+
+## Example Project
+
+📁 **[Example Project](../src/Examples/TestingOverridesExample/)**
+
+## Key Benefits
+
+- ✅ Universal (works with any ConfigManager instantiation)
+- ✅ Isolated (AsyncLocal per-test context)
+- ✅ Zero-ceremony (no test-aware application code)
+- ✅ Type-safe (full IntelliSense)
+- ✅ Fast (Replace mode skips I/O entirely)

--- a/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
+++ b/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
@@ -16,6 +16,7 @@ public static class CocoarConfigurationAspNetCoreExtensions
 
     /// <summary>
     /// Adds Cocoar configuration to the WebApplicationBuilder using a function-based rule API.
+    /// Test configuration overrides are automatically applied via ConfigManager when CocoarTestConfiguration is active.
     /// </summary>
     public static WebApplicationBuilder AddCocoarConfiguration(
         this WebApplicationBuilder builder,
@@ -24,17 +25,14 @@ public static class CocoarConfigurationAspNetCoreExtensions
         ILogger? logger = null,
         int debounceMilliseconds = 300)
     {
-        var rulesBuilder = new RulesBuilder();
-        var ruleList = rule(rulesBuilder);
-        
-        var configManager = new ConfigManager(ruleList, configure, logger, debounceMilliseconds: debounceMilliseconds);
+        var configManager = new ConfigManager(rule, configure, logger, debounceMilliseconds: debounceMilliseconds);
         configManager.Initialize();
 
         builder.Services.AddCocoarConfiguration(configManager);
 
         // Attach ConfigManager as a capability to the WebApplicationBuilder
         _capabilityScope.Compose(builder).Add(configManager).Build();
-        
+
         return builder;
     }
 
@@ -43,14 +41,11 @@ public static class CocoarConfigurationAspNetCoreExtensions
         ConfigManager configManager)
     {
         builder.Services.AddCocoarConfiguration(configManager);
-
-        // Attach ConfigManager as a capability to the WebApplicationBuilder
         _capabilityScope.Compose(builder).Add(configManager).Build();
-        
+
         return builder;
     }
 
     public static ConfigManager GetCocoarConfigManager(this WebApplicationBuilder builder)
         => _capabilityScope.Compositions.GetRequired(builder).GetRequiredFirst<ConfigManager>();
-
 }

--- a/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
+++ b/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
@@ -23,23 +23,23 @@ public static class CocoarConfigurationExtensions
         services.ThrowIfAlreadyRegistered();
         services.AddSingleton(configManager);
         services.AddSingleton<IConfigurationAccessor>(sp => sp.GetRequiredService<ConfigManager>());
-        
+
         // Register the health service
         services.AddSingleton<IConfigurationHealthService>(sp => sp.GetRequiredService<ConfigManager>().GetHealthService());
 
         // Collect all types that should be registered
         var typesToRegister = new HashSet<Type>();
-        
+
         // 1. Auto-register all types from rules (restores pre-SetupBuilder behavior)
         foreach (var rule in configManager.Rules)
         {
             typesToRegister.Add(rule.ConcreteType);
         }
-        
+
         // 2. Process explicit SetupDefinitions for customization
         var serviceRegistrationInfos = new Dictionary<Type, ServiceRegistrationInfo>();
         var configSpecs = configManager.SetupDefinitions;
-        
+
         if (configSpecs.Count > 0)
         {
             foreach (var spec in configSpecs)
@@ -61,7 +61,7 @@ public static class CocoarConfigurationExtensions
                 }
             }
         }
-        
+
         // 3. Auto-register types from rules that don't have explicit setup definitions
         foreach (var type in typesToRegister)
         {
@@ -82,6 +82,7 @@ public static class CocoarConfigurationExtensions
 
     /// <summary>
     /// Adds Cocoar configuration to the service collection using a function-based rule API.
+    /// Test configuration overrides are automatically applied via ConfigManager when CocoarTestConfiguration is active.
     /// </summary>
     public static IServiceCollection AddCocoarConfiguration(
         this IServiceCollection services,
@@ -92,10 +93,7 @@ public static class CocoarConfigurationExtensions
     {
         services.ThrowIfAlreadyRegistered();
 
-        var rulesBuilder = new RulesBuilder();
-        var ruleList = rule(rulesBuilder);
-
-        var configManager = new ConfigManager(ruleList, setup, logger, debounceMilliseconds: debounceMilliseconds);
+        var configManager = new ConfigManager(rule, setup, logger, debounceMilliseconds: debounceMilliseconds);
         configManager.Initialize();
 
         services.AddCocoarConfiguration(configManager);
@@ -192,7 +190,7 @@ public static class CocoarConfigurationExtensions
                 {
                     services.Add(new(serviceType, serviceKey, (sp, _) => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!, serviceLifetime));
                 }
-                
+
             }
 
             var reactiveType = typeof(IReactiveConfig<>).MakeGenericType(serviceType);

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Cocoar.Capabilities;
 using Cocoar.Configuration.Configure;
 using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Cocoar.Configuration.Providers.Abstractions;
@@ -32,17 +33,19 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
 
     /// <summary>
     /// Creates a new ConfigManager with a function-based rules builder.
+    /// Automatically detects and applies test configuration overrides when CocoarTestConfiguration is active.
     /// </summary>
     public ConfigManager(Func<RulesBuilder, ConfigRule[]> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
     {
         var rulesBuilder = new RulesBuilder();
-        _rules = rules(rulesBuilder).ToList();
+        var configuredRules = rules(rulesBuilder);
+
+        // Apply test configuration overrides if present
+        _rules = ApplyTestConfigurationOverrides(configuredRules).ToList();
 
         _capabilityScope = new ConfigManagerCapabilityScope(this);
-
-        // Create global Owner composer for cross-cutting capabilities (e.g., Secrets)
         _capabilityScope.Owner.Compose();
-        
+
         _setupDefinitions = setup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
         logger ??= NullLogger.Instance;
         _debounceMilliseconds = debounceMilliseconds;
@@ -60,16 +63,18 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
 
     /// <summary>
     /// Creates a new ConfigManager with a pre-built list of rules.
+    /// Automatically detects and applies test configuration overrides when CocoarTestConfiguration is active.
     /// </summary>
     public ConfigManager(IEnumerable<ConfigRule> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
     {
-        _rules = rules.ToList();
+        var configuredRules = rules.ToArray();
+
+        // Apply test configuration overrides if present
+        _rules = ApplyTestConfigurationOverrides(configuredRules).ToList();
 
         _capabilityScope = new ConfigManagerCapabilityScope(this);
-
-        // Create global Owner composer for cross-cutting capabilities (e.g., Secrets)
         _capabilityScope.Owner.Compose();
-        
+
         _setupDefinitions = setup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
         logger ??= NullLogger.Instance;
         _debounceMilliseconds = debounceMilliseconds;
@@ -103,7 +108,7 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
             _capabilityScope.Owner.TryGetComposer(out var composer);
             composer?.Build();
             _capabilityScope.Owner.GetComposition()?.UsingEach<IDeferredConfiguration>(c => c.Apply());
-            
+
             _engine.InitializeAndCompute(
                 _rules,
                 _ruleManagers,
@@ -127,7 +132,7 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
 
     public IConfigurationHealthService GetHealthService() => _state.GetHealthService();
 
-    internal void ScheduleRecompute(int startIndex) => 
+    internal void ScheduleRecompute(int startIndex) =>
         _engine.ScheduleRecompute(_ruleManagers, this, _reactiveConfigManager, startIndex);
 
     internal Task? CurrentRecomputeTask => _engine.CurrentRecomputeTask;
@@ -146,5 +151,28 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         _ruleManagers.Clear();
         _initialized = false;
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Applies test configuration overrides from AsyncLocal context if present.
+    /// Supports both Replace (skip all configured rules) and Append (merge test rules at end) modes.
+    /// </summary>
+    private static ConfigRule[] ApplyTestConfigurationOverrides(ConfigRule[] configuredRules)
+    {
+        var testContext = CocoarTestConfiguration.Current;
+        if (testContext == null)
+        {
+            return configuredRules;
+        }
+
+        var testRulesBuilder = new RulesBuilder();
+        var testRules = testContext.Rules(testRulesBuilder);
+
+        return testContext.Mode switch
+        {
+            TestConfigurationMode.Replace => testRules,
+            TestConfigurationMode.Append => configuredRules.Concat(testRules).ToArray(),
+            _ => configuredRules
+        };
     }
 }

--- a/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
+++ b/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
@@ -1,0 +1,98 @@
+using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.Rules;
+
+namespace Cocoar.Configuration.Testing;
+
+/// <summary>
+/// Provides test-friendly configuration overrides using AsyncLocal for isolated test contexts.
+/// Use this in integration tests to override configuration rules without modifying application code.
+/// </summary>
+public static class CocoarTestConfiguration
+{
+    private static readonly AsyncLocal<TestConfigurationContext?> s_testContext = new();
+
+    /// <summary>
+    /// Replaces all configured rules with test-specific rules.
+    /// Original rules are completely skipped - ideal when providers would fail in test environment.
+    /// </summary>
+    /// <param name="rules">Function to build test rules using the fluent API.</param>
+    /// <example>
+    /// <code>
+    /// CocoarTestConfiguration.ReplaceAllRules(rule => [
+    ///     rule.For&lt;DbConfig&gt;().FromStatic(() => new DbConfig { Connection = testDb })
+    /// ]);
+    /// </code>
+    /// </example>
+    public static void ReplaceAllRules(Func<RulesBuilder, ConfigRule[]> rules)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        s_testContext.Value = new TestConfigurationContext(rules, TestConfigurationMode.Replace);
+    }
+
+    /// <summary>
+    /// Appends test rules to the end of configured rules (last-write-wins).
+    /// Original rules execute first, then test rules override specific values.
+    /// </summary>
+    /// <param name="rules">Function to build test rules using the fluent API.</param>
+    /// <example>
+    /// <code>
+    /// CocoarTestConfiguration.AppendTestRules(rule => [
+    ///     rule.For&lt;DbConfig&gt;().FromStatic(() => new DbConfig { Connection = testDb })
+    /// ]);
+    /// </code>
+    /// </example>
+    public static void AppendTestRules(Func<RulesBuilder, ConfigRule[]> rules)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        s_testContext.Value = new TestConfigurationContext(rules, TestConfigurationMode.Append);
+    }
+
+    /// <summary>
+    /// Clears the test configuration context, restoring normal configuration behavior.
+    /// </summary>
+    public static void Clear()
+    {
+        s_testContext.Value = null;
+    }
+
+    /// <summary>
+    /// Gets the current test configuration context, if any.
+    /// </summary>
+    public static TestConfigurationContext? Current => s_testContext.Value;
+
+    /// <summary>
+    /// Checks if test configuration is active in the current async context.
+    /// </summary>
+    public static bool IsActive => s_testContext.Value != null;
+}
+
+/// <summary>
+/// Represents the mode for test configuration override.
+/// </summary>
+public enum TestConfigurationMode
+{
+    /// <summary>
+    /// Replace all configured rules with test rules (original rules are skipped).
+    /// </summary>
+    Replace,
+
+    /// <summary>
+    /// Append test rules to the end of configured rules (last-write-wins merging).
+    /// </summary>
+    Append
+}
+
+/// <summary>
+/// Holds the test configuration context stored in AsyncLocal.
+/// </summary>
+public sealed class TestConfigurationContext
+{
+    public Func<RulesBuilder, ConfigRule[]> Rules { get; }
+    public TestConfigurationMode Mode { get; }
+
+    public TestConfigurationContext(Func<RulesBuilder, ConfigRule[]> rules, TestConfigurationMode mode)
+    {
+        Rules = rules;
+        Mode = mode;
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />

--- a/src/Examples/TestingOverridesExample/Program.cs
+++ b/src/Examples/TestingOverridesExample/Program.cs
@@ -1,0 +1,40 @@
+using Cocoar.Configuration.AspNetCore;
+using Cocoar.Configuration.Providers;
+
+namespace Examples.TestingOverridesExample;
+
+public class DbConfig
+{
+    public string ConnectionString { get; set; } = "";
+    public int MaxConnections { get; set; } = 10;
+}
+
+public class ApiSettings
+{
+    public string BaseUrl { get; set; } = "";
+    public string ApiKey { get; set; } = "";
+}
+
+public partial class Program
+{
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        // Regular configuration - these rules would normally run
+        builder.AddCocoarConfiguration(rule => [
+            rule.For<DbConfig>().FromFile("config.json").Select("Database"),
+            rule.For<ApiSettings>().FromFile("config.json").Select("Api")
+        ]);
+
+        var app = builder.Build();
+
+        app.MapGet("/config", (DbConfig db, ApiSettings api) => new
+        {
+            Database = new { db.ConnectionString, db.MaxConnections },
+            Api = new { api.BaseUrl, api.ApiKey }
+        });
+
+        app.Run();
+    }
+}

--- a/src/Examples/TestingOverridesExample/README.md
+++ b/src/Examples/TestingOverridesExample/README.md
@@ -1,0 +1,151 @@
+# Testing Overrides Example
+
+This example demonstrates how to override Cocoar configuration in integration tests using `CocoarTestConfiguration`.
+
+## Problem Solved
+
+When writing integration tests with `WebApplicationFactory<T>`, you often need to:
+- Replace production configuration with test-specific values
+- Skip providers that would fail in test environments (HTTP endpoints, missing files)
+- Partially override some configs while keeping others from the original sources
+
+Standard ASP.NET Core allows this:
+```csharp
+new WebApplicationFactory<Program>()
+    .WithWebHostBuilder(builder => {
+        builder.UseSetting("ConnectionStrings:Postgres", testConnectionString);
+    });
+```
+
+But with Cocoar.Configuration, you want the same capability using the rule-based API.
+
+## Solution: CocoarTestConfiguration
+
+Set test configuration **before** creating `ConfigManager` (or `WebApplicationFactory`) using `AsyncLocal` context.
+
+**Works universally:**
+- ✅ Direct `new ConfigManager(...)` instantiation
+- ✅ `services.AddCocoarConfiguration(...)` in DI
+- ✅ `builder.AddCocoarConfiguration(...)` in ASP.NET Core
+- ✅ `WebApplicationFactory<Program>` in integration tests
+
+### Option 1: Replace All Rules (Skip Original Providers)
+
+```csharp
+[Fact]
+public async Task TestWithReplacedConfig()
+{
+    // Set test configuration BEFORE creating ConfigManager
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => new DbConfig {
+            ConnectionString = testDb
+        })
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Original rules (FromFile, FromHttp, etc.) are SKIPPED
+    // Only test rules run
+}
+```
+
+**Use when:**
+- Original providers would fail (HTTP endpoint unavailable, files missing)
+- You want complete test isolation
+- Performance: faster tests (no I/O from original providers)
+
+### Option 2: Append Test Rules (Partial Override)
+
+```csharp
+[Fact]
+public async Task TestWithPartialOverride()
+{
+    // Append test rules to end (last-write-wins)
+    CocoarTestConfiguration.AppendTestRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => new DbConfig {
+            ConnectionString = testDb
+        })
+    ]);
+
+    await using var factory = new WebApplicationFactory<Program>();
+    // Original rules run first, then test rules override specific values
+}
+```
+
+**Use when:**
+- You only need to override some configuration values
+- Other configs can come from original sources (files, environment)
+- Partial testing scenarios
+
+## Running the Example
+
+```bash
+cd src/Examples/TestingOverridesExample
+dotnet test
+```
+
+## Key Points
+
+1. **Universal Application** - Works with any ConfigManager instantiation method (direct, DI, AspNetCore)
+2. **AsyncLocal Context** - Test configuration flows through async/await automatically
+3. **No Application Changes** - `Program.cs` doesn't need test-aware code
+4. **Per-Test Isolation** - Each test can set different configuration
+5. **Clean Up** - Call `CocoarTestConfiguration.Clear()` or implement `IDisposable`
+
+## Direct ConfigManager Usage
+
+Test overrides also work when creating ConfigManager directly (without DI):
+
+```csharp
+[Fact]
+public void DirectConfigManagerTest()
+{
+    CocoarTestConfiguration.ReplaceAllRules(rule => [
+        rule.For<DbConfig>().FromStatic(_ => testConfig)
+    ]);
+
+    // Works with direct instantiation
+    var configManager = new ConfigManager(rule => [
+        rule.For<DbConfig>().FromFile("config.json") // SKIPPED in test
+    ]);
+    configManager.Initialize();
+
+    var config = configManager.GetRequiredConfig<DbConfig>();
+    // config comes from test rules, not file
+}
+```
+
+## Test Base Class Pattern
+
+```csharp
+public abstract class IntegrationTestBase : IDisposable
+{
+    protected void UseTestConfig(Func<RulesBuilder, ConfigRule[]> rules)
+    {
+        CocoarTestConfiguration.ReplaceAllRules(rules);
+    }
+
+    public void Dispose()
+    {
+        CocoarTestConfiguration.Clear();
+    }
+}
+
+public class MyTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task MyTest()
+    {
+        UseTestConfig(rule => [
+            rule.For<DbConfig>().FromStatic(_ => testConfig)
+        ]);
+
+        await using var factory = new WebApplicationFactory<Program>();
+        // Test runs with overridden config
+    }
+}
+```
+
+## Related
+
+- [BasicUsage Example](../BasicUsage) - Simple configuration setup
+- [Cocoar.Configuration.Testing](../../Cocoar.Configuration/Testing) - Testing API reference

--- a/src/Examples/TestingOverridesExample/TestingOverridesExample.csproj
+++ b/src/Examples/TestingOverridesExample/TestingOverridesExample.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <StartupObject>Examples.TestingOverridesExample.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Tests\**" />
+    <Content Remove="Tests\**" />
+    <EmbeddedResource Remove="Tests\**" />
+    <None Remove="Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cocoar.Configuration\Cocoar.Configuration.csproj" />
+    <ProjectReference Include="..\..\Cocoar.Configuration.AspNetCore\Cocoar.Configuration.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+</Project>

--- a/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
@@ -1,0 +1,88 @@
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Testing;
+using Cocoar.Configuration.Providers;
+using Xunit;
+
+namespace Examples.TestingOverridesExample.Tests;
+
+public class DirectConfigManagerTests : IDisposable
+{
+    [Fact]
+    public void DirectConfigManager_AppliesTestOverrides_ReplaceMode()
+    {
+        // Arrange - Set test configuration BEFORE creating ConfigManager
+        CocoarTestConfiguration.ReplaceAllRules(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                ConnectionString = "Server=test-direct;Database=DirectTest;",
+                MaxConnections = 42
+            })
+        ]);
+
+        // Act - Create ConfigManager directly (no DI, no AspNetCore)
+        var configManager = new ConfigManager(rule => [
+            rule.For<DbConfig>().FromFile("config.json").Select("Database") // This will be SKIPPED
+        ]);
+        configManager.Initialize();
+
+        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+
+        // Assert - Test rules were used, not config.json
+        Assert.Equal("Server=test-direct;Database=DirectTest;", dbConfig.ConnectionString);
+        Assert.Equal(42, dbConfig.MaxConnections);
+    }
+
+    [Fact]
+    public void DirectConfigManager_AppliesTestOverrides_AppendMode()
+    {
+        // Arrange
+        CocoarTestConfiguration.AppendTestRules(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                MaxConnections = 999 // Override only MaxConnections
+            })
+        ]);
+
+        // Act
+        var configManager = new ConfigManager(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                ConnectionString = "Server=base;",
+                MaxConnections = 10
+            })
+        ]);
+        configManager.Initialize();
+
+        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+
+        // Assert - Base rule + test override merged (last-write-wins)
+        Assert.Equal(999, dbConfig.MaxConnections); // From test override
+    }
+
+    [Fact]
+    public void DirectConfigManager_WorksNormally_WhenNoTestOverride()
+    {
+        // No CocoarTestConfiguration set
+
+        // Act
+        var configManager = new ConfigManager(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                ConnectionString = "Server=normal;",
+                MaxConnections = 50
+            })
+        ]);
+        configManager.Initialize();
+
+        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+
+        // Assert - Normal behavior
+        Assert.Equal("Server=normal;", dbConfig.ConnectionString);
+        Assert.Equal(50, dbConfig.MaxConnections);
+    }
+
+    public void Dispose()
+    {
+        CocoarTestConfiguration.Clear();
+    }
+}

--- a/src/Examples/TestingOverridesExample/Tests/IntegrationTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/IntegrationTests.cs
@@ -1,0 +1,112 @@
+using Cocoar.Configuration.Testing;
+using Cocoar.Configuration.Providers;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Examples.TestingOverridesExample.Tests;
+
+public class IntegrationTestsWithReplace : IDisposable
+{
+    [Fact]
+    public async Task ReplaceAllRules_OverridesAllConfiguration()
+    {
+        // Arrange - Set test configuration BEFORE creating WebApplicationFactory
+        CocoarTestConfiguration.ReplaceAllRules(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                ConnectionString = "Server=test-db;Database=TestDb;",
+                MaxConnections = 5
+            }),
+            rule.For<ApiSettings>().FromStatic(_ => new ApiSettings
+            {
+                BaseUrl = "https://api.test.example.com",
+                ApiKey = "test-api-key"
+            })
+        ]);
+
+        // Act - Create WebApplicationFactory (config.json will be SKIPPED)
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        // Assert
+        var response = await client.GetAsync("/config");
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("test-db", content);
+        Assert.Contains("api.test.example.com", content);
+        Assert.Contains("test-api-key", content);
+
+        // Verify production values are NOT present
+        Assert.DoesNotContain("production-db", content);
+        Assert.DoesNotContain("prod-api-key", content);
+    }
+
+    public void Dispose()
+    {
+        CocoarTestConfiguration.Clear();
+    }
+}
+
+public class IntegrationTestsWithAppend : IDisposable
+{
+    [Fact]
+    public async Task AppendTestRules_OverridesSpecificValues()
+    {
+        // Arrange - Append test rules (config.json runs first, then test rules override)
+        CocoarTestConfiguration.AppendTestRules(rule => [
+            rule.For<DbConfig>().FromStatic(_ => new DbConfig
+            {
+                ConnectionString = "Server=test-db;Database=TestDb;",
+                // MaxConnections not specified - will use value from config.json
+            })
+        ]);
+
+        // Act
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        // Assert
+        var response = await client.GetAsync("/config");
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        // DbConfig.ConnectionString overridden by test
+        Assert.Contains("test-db", content);
+
+        // ApiSettings comes from config.json (not overridden in test)
+        Assert.Contains("api.production.example.com", content);
+        Assert.Contains("prod-api-key", content);
+    }
+
+    public void Dispose()
+    {
+        CocoarTestConfiguration.Clear();
+    }
+}
+
+public class IntegrationTestsRealWorldScenario
+{
+    [Fact]
+    public async Task ReplaceMode_PreventFailureFromMissingHttpEndpoint()
+    {
+        // Scenario: App normally polls HTTP endpoint that's unavailable in tests
+        // Replace mode prevents HTTP provider from running at all
+
+        CocoarTestConfiguration.ReplaceAllRules(rule => [
+            rule.For<ApiSettings>().FromStatic(_ => new ApiSettings
+            {
+                BaseUrl = "https://test.local",
+                ApiKey = "test-key"
+            })
+        ]);
+
+        await using var factory = new WebApplicationFactory<Program>();
+
+        // Success - HTTP provider never attempted to connect
+        Assert.True(CocoarTestConfiguration.IsActive);
+
+        CocoarTestConfiguration.Clear();
+    }
+}

--- a/src/Examples/TestingOverridesExample/config.json
+++ b/src/Examples/TestingOverridesExample/config.json
@@ -1,0 +1,10 @@
+{
+  "Database": {
+    "ConnectionString": "Server=production-db;Database=MyApp;",
+    "MaxConnections": 100
+  },
+  "Api": {
+    "BaseUrl": "https://api.production.example.com",
+    "ApiKey": "prod-api-key-12345"
+  }
+}


### PR DESCRIPTION
## Testing Configuration Overrides

Adds `CocoarTestConfiguration` API for overriding configuration in integration tests without modifying application code.

### What's New

- **Two override modes:**
  - `ReplaceAllRules()` - Skip all original rules (prevents HTTP calls, file I/O in tests)
  - `AppendTestRules()` - Merge test rules with originals (last-write-wins)

- **AsyncLocal isolation** - Automatic test isolation across parallel test execution

- **Universal application** - Works with:
  - Direct `ConfigManager` instantiation
  - DI (`services.AddCocoarConfiguration()`)
  - AspNetCore (`builder.AddCocoarConfiguration()`)
  - `WebApplicationFactory<T>` for integration tests

### Usage

```csharp
[Fact]
public async Task MyIntegrationTest()
{
    // Set test overrides BEFORE creating WebApplicationFactory
    CocoarTestConfiguration.ReplaceAllRules(rule => [
        rule.For<DbConfig>().FromStatic(_ => new DbConfig { 
            Connection = "Server=testdb" 
        })
    ]);

    await using var factory = new WebApplicationFactory<Program>();
    // Test uses test config, production rules skipped
}