### PR TITLE
Master Backplane Architecture for Atomic Configuration Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,5 @@ dist/
 
 local/
 .local/
+
+nul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [4.2.0] - 2026-02-03
 
 ### Added
 
@@ -32,6 +32,8 @@
 
 ### Fixed
 - **Deserialization failure logging**: `GetConfig<T>()` now logs an error (EventId 5100) when deserialization fails due to missing `required` properties or type mismatches, instead of silently returning `null`. This helps diagnose configuration issues while maintaining backward-compatible behavior (still returns `null`, `GetRequiredConfig<T>()` still throws).
+- **DI registration ordering**: Service descriptors are now emitted in deterministic order (sorted by type full name). Previously, dictionary iteration order could vary between runs, affecting test assertions and diagnostic logging.
+- **Provider rebuild callback ordering**: Fixed callback timing in `RuleProviderLease` to invoke the subscription reset callback *before* rebuilding the provider, matching original `RuleManager` behavior. This prevents spurious change notifications that could occur if a provider's `Dispose()` triggers events while the subscription is still active.
 
 ### Changed
 - **Type Relocation with Forwarding**: Moved core interfaces to abstractions packages with type forwarding for full backward compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```powershell
+# Build
+dotnet build ./src -c Release
+
+# Run all tests (excluding performance tests)
+dotnet test ./src -c Release --filter "Type!=Performance"
+
+# Run specific test project
+dotnet test ./src/tests/Cocoar.Configuration.Core.Tests -c Release
+
+# Run specific test by name pattern
+dotnet test ./src -c Release --filter "FullyQualifiedName~TestMethodName"
+
+# Run tests by trait (Unit, Performance, Concurrency, Stress)
+dotnet test ./src -c Release --filter "Type=Unit"
+
+# Run tests without rebuilding (faster iteration)
+dotnet test ./src -c Release --no-build --filter "Type!=Performance"
+
+# Pack NuGet packages
+dotnet pack ./src -c Release
+```
+
+## Architecture Overview
+
+**Cocoar.Configuration** is a reactive, strongly-typed configuration library for .NET 9.0. The architecture follows a modular, capabilities-driven design.
+
+### Core Components
+
+- **ConfigManager** (`src/Cocoar.Configuration/Core/`) - Central orchestrator that manages configuration lifecycle, rule execution, and reactive updates
+- **Providers** (`src/Cocoar.Configuration/Providers/`) - Abstract configuration sources (File, Environment, CommandLine, HTTP, Static, Observable)
+- **Fluent Builders** (`src/Cocoar.Configuration/Fluent/`) - `RulesBuilder` for defining configuration rules with `.For<T>().FromFile()` pattern
+- **SetupBuilder** (`src/Cocoar.Configuration/Configure/`) - DI registration with `.ConcreteType<T>()` and `.Interface<T>()` patterns
+
+### Recompute Pipeline
+
+The configuration engine follows a transactional recompute model:
+
+1. **Change Detection** - Provider signals change (file modified, HTTP poll, observable emission)
+2. **Debouncing** - `RecomputeScheduler` coalesces rapid changes (default 300ms)
+3. **Rule Execution** - Rules execute sequentially via `RuleManager` instances
+4. **Atomic Commit** - `ConfigurationState` commits all changes atomically or rolls back entirely
+5. **Reactive Notification** - `ReactiveConfigManager` emits to subscribers (hash-based change detection)
+
+### RuleManager Coordination
+
+Each rule has a `RuleManager` that coordinates:
+- **RuleProviderLease** - Provider lifecycle (acquisition, key-based caching, disposal)
+- **TransformCache** - Caches transformed bytes with hash-based invalidation
+- **ChangeSubscription** - Manages provider change subscriptions
+
+**Important ordering**: When providers change, the callback fires *before* rebuild to unsubscribe first, preventing spurious notifications from dispose events.
+
+### Key Design Patterns
+
+**Capabilities System** - Cross-assembly metadata composition without circular dependencies. Core defines builders; DI extends them via `Cocoar.Capabilities`:
+```csharp
+// Core: Defines primary capability
+capabilityScope.Compose(this).WithPrimary(new ConcreteTypePrimary<T>(...));
+// DI: Extends without coupling
+SetupDefinition.GetComposer(builder).Add(new ServiceLifetimeCapability<T>(...));
+```
+
+**Reactive Tuples** - `IReactiveConfig<(T1, T2)>` provides atomic multi-config updates. Multiple configs always update together, preventing inconsistent state.
+
+**Provider Consistency** - All providers return empty `{}` on failure (not null). Optional rules degrade gracefully with C# defaults; required rules roll back the entire recompute.
+
+**Test Configuration** - `CocoarTestConfiguration` uses `AsyncLocal<T>` for test isolation. Supports `ReplaceAllRules()` (skip originals) and `AppendTestRules()` (override).
+
+### Project Structure
+
+| Project | Purpose |
+|---------|---------|
+| `Cocoar.Configuration.Abstractions` | Lightweight interfaces (`IConfigurationAccessor`, `IReactiveConfig<T>`) |
+| `Cocoar.Configuration` | Main library with providers, builders, and reactive engine |
+| `Cocoar.Configuration.Secrets` | Memory-safe `Secret<T>` with RSA-OAEP + AES-256-GCM encryption |
+| `Cocoar.Configuration.DI` | `AddCocoarConfiguration()` for Microsoft.Extensions.DI |
+| `Cocoar.Configuration.AspNetCore` | ASP.NET Core integration and health endpoints |
+| `Cocoar.Configuration.HttpPolling` | Remote config polling provider |
+| `Cocoar.Configuration.MicrosoftAdapter` | Bridge to existing `IConfiguration` sources |
+| `Cocoar.Configuration.Analyzers` | Roslyn analyzers (COCFG001-006) with quick fixes |
+
+### DI Registration (Deterministic Ordering)
+
+Service descriptors are emitted in deterministic order (sorted by type full name). The registration flow:
+1. `ServiceRegistrationPlanner.CreatePlan()` - Builds plan from rules and setup definitions
+2. `ServiceDescriptorEmitter.Emit()` - Applies plan to `IServiceCollection`
+
+### DI Lifetimes
+
+- **Scoped**: Concrete config types (stable snapshot per request)
+- **Singleton**: `IReactiveConfig<T>` (continuous live updates)
+- Customizable via `.AsSingleton()`, `.AsTransient()`
+
+## Code Style
+
+- **Comments explain *why*, not *what*** - Self-documenting code through clear naming is preferred
+- **No commented-out code or debug statements**
+- **Async patterns**: Use `Task`/`ValueTask`, no `async void`, `CancellationToken` as last parameter, `Async` suffix
+- **Nullable reference types enabled** - Ensure annotations are accurate
+- **Follow .NET conventions**: PascalCase, interfaces for inputs, concrete for outputs
+
+## Key Architecture Decisions
+
+Read these ADRs to understand important design choices:
+- **ADR-001** (`docs/adr/`) - Capabilities system for cross-assembly extensibility
+- **ADR-002** (`docs/adr/`) - Atomic reactive configuration updates (tuple semantics)
+- **ADR-003** (`docs/adr/`) - Provider consistency (empty objects on failure)
+
+## Documentation
+
+- `/docs/` - Health monitoring, testing patterns, ADRs, migration guides
+- `/docs/adr/` - Architecture Decision Records (ADR-001 through ADR-003)
+- Project READMEs in `src/Cocoar.Configuration.Secrets/` and `src/Cocoar.Configuration.Analyzers/`
+- Examples in `src/Examples/` demonstrate real-world usage patterns
+
+## Local Working Files
+
+The `.local/` folder (git-ignored) is for ephemeral work like release checklists and scratch notes. Never store secrets there or reference it from code/docs.

--- a/src/Cocoar.Configuration.Abstractions/Core/IConfigurationAccessor.cs
+++ b/src/Cocoar.Configuration.Abstractions/Core/IConfigurationAccessor.cs
@@ -6,18 +6,67 @@ namespace Cocoar.Configuration.Core;
 /// Provides access to configuration snapshots.
 /// Used by rule factories to reference earlier configuration state when building dependent rules.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>DO NOT mutate configuration instances.</b> All GetConfig methods return cached,
+/// shared instances. Mutations would affect all consumers and cause inconsistent behavior.
+/// </para>
+/// </remarks>
 public interface IConfigurationAccessor
 {
-    T? GetConfig<T>();
+    /// <summary>
+    /// Gets a configuration instance from the cached snapshot.
+    /// </summary>
+    /// <remarks>
+    /// After initialization completes, this method returns the cached instance for registered types.
+    /// Throws <see cref="InvalidOperationException"/> if no rule is registered for the type.
+    /// <para><b>DO NOT mutate the returned instance.</b></para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No configuration rule is registered for type T.</exception>
+    T GetConfig<T>();
+
+    /// <summary>
+    /// Tries to get a configuration instance without throwing.
+    /// </summary>
+    /// <returns>True if configuration exists for the type; false otherwise.</returns>
     bool TryGetConfig<T>(out T? value);
 
     /// <summary>
     /// Gets configuration, throwing if not found.
-    /// Use this in rule factories when a dependent configuration must exist before the rule can execute.
     /// </summary>
+    /// <remarks>
+    /// This method is deprecated. GetConfig now has the same behavior - it throws if no rule is registered.
+    /// </remarks>
+    [Obsolete("Use GetConfig<T>() instead - it now throws if no rule is registered. " +
+              "This method will be removed in a future version.")]
     T GetRequiredConfig<T>();
-    object? GetConfig(Type type);
+
+    /// <summary>
+    /// Gets a configuration instance from the cached snapshot.
+    /// </summary>
+    /// <remarks>
+    /// After initialization completes, this method returns the cached instance for registered types.
+    /// Throws <see cref="InvalidOperationException"/> if no rule is registered for the type.
+    /// <para><b>DO NOT mutate the returned instance.</b></para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No configuration rule is registered for the type.</exception>
+    object GetConfig(Type type);
+
+    /// <summary>
+    /// Tries to get a configuration instance without throwing.
+    /// </summary>
+    /// <returns>True if configuration exists for the type; false otherwise.</returns>
     bool TryGetConfig(Type type, out object? value);
+
+    /// <summary>
+    /// Gets configuration, throwing if not found.
+    /// </summary>
+    /// <remarks>
+    /// This method is deprecated. GetConfig now has the same behavior - it throws if no rule is registered.
+    /// </remarks>
+    [Obsolete("Use GetConfig(Type) instead - it now throws if no rule is registered. " +
+              "This method will be removed in a future version.")]
     object GetRequiredConfig(Type type);
+
     JsonElement? GetConfigAsJson(Type type);
 }

--- a/src/Cocoar.Configuration.Analyzers/Cocoar.Configuration.Analyzers.csproj
+++ b/src/Cocoar.Configuration.Analyzers/Cocoar.Configuration.Analyzers.csproj
@@ -12,6 +12,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <!-- Required for analyzer projects to satisfy RS1036 -->
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Analyzers don't need symbols - prevents snupkg validation errors when referenced by other packages -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
+++ b/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
@@ -1,81 +1,29 @@
-using System.Collections;
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Fluent;
 using Cocoar.Configuration.Configure;
+using Cocoar.Configuration.Health;
+using Cocoar.Configuration.Rules;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Cocoar.Configuration.Core;
-using Cocoar.Configuration.Rules;
-using Cocoar.Configuration.Fluent;
-using Cocoar.Capabilities;
-using Cocoar.Configuration.Reactive;
-using Cocoar.Configuration.DI.Capabilities;
-using Cocoar.Configuration.Health;
 
 namespace Cocoar.Configuration.DI;
 
-
 public static class CocoarConfigurationExtensions
 {
-
     public static IServiceCollection AddCocoarConfiguration(
         this IServiceCollection services,
         ConfigManager configManager)
     {
         services.ThrowIfAlreadyRegistered();
+
+        // Register core services
         services.AddSingleton(configManager);
         services.AddSingleton<IConfigurationAccessor>(sp => sp.GetRequiredService<ConfigManager>());
-
-        // Register the health service
         services.AddSingleton<IConfigurationHealthService>(sp => sp.GetRequiredService<ConfigManager>().GetHealthService());
 
-        // Collect all types that should be registered
-        var typesToRegister = new HashSet<Type>();
-
-        // 1. Auto-register all types from rules (restores pre-SetupBuilder behavior)
-        foreach (var rule in configManager.Rules)
-        {
-            typesToRegister.Add(rule.ConcreteType);
-        }
-
-        // 2. Process explicit SetupDefinitions for customization
-        var serviceRegistrationInfos = new Dictionary<Type, ServiceRegistrationInfo>();
-        var configSpecs = configManager.SetupDefinitions;
-
-        if (configSpecs.Count > 0)
-        {
-            foreach (var spec in configSpecs)
-            {
-                // Get the capability bag from the registry using the ConfigureSpec as key
-                if (!configManager.CapabilityScope.Compositions.TryGet(spec, out var bag))
-                {
-                    continue;
-                }
-
-                if (bag.TryGetPrimaryAs<ConcreteTypePrimary<SetupDefinition>>(out var typeCapability))
-                {
-                    ProcessConcreteType(serviceRegistrationInfos, typeCapability!, bag);
-                }
-
-                if (bag.TryGetPrimaryAs<ExposedTypePrimary<SetupDefinition>>(out var exposedCapability))
-                {
-                    ProcessExposedType(serviceRegistrationInfos, exposedCapability!, bag);
-                }
-            }
-        }
-
-        // 3. Auto-register types from rules that don't have explicit setup definitions
-        foreach (var type in typesToRegister)
-        {
-            if (!serviceRegistrationInfos.ContainsKey(type))
-            {
-                serviceRegistrationInfos[type] = new ServiceRegistrationInfo
-                {
-                    Type = type,
-                    DisableDefault = false
-                };
-            }
-        }
-
-        ProcessServiceRegistration(services, serviceRegistrationInfos);
+        // Build registration plan and apply it
+        var plan = ServiceRegistrationPlanner.CreatePlan(configManager);
+        ServiceDescriptorEmitter.Emit(services, plan);
 
         return services;
     }
@@ -100,111 +48,6 @@ public static class CocoarConfigurationExtensions
         return services;
     }
 
-
-    private static void ProcessConcreteType(Dictionary<Type, ServiceRegistrationInfo> serviceRegistrationInfos,
-        ConcreteTypePrimary<SetupDefinition> primaryCapability, IComposition bag)
-    {
-
-        if (!serviceRegistrationInfos.TryGetValue(primaryCapability.SelectedType, out var serviceRegistrationInfo))
-        {
-            serviceRegistrationInfo = new ServiceRegistrationInfo
-            {
-                Type = primaryCapability.SelectedType,
-            };
-        }
-
-        if (bag.Has<DisableAutoRegistrationCapability<SetupDefinition>>())
-        {
-            serviceRegistrationInfo.DisableDefault = true;
-        }
-
-        var lifetimeCapabilities = bag.GetAll<ServiceLifetimeCapability<SetupDefinition>>();
-        var keyedLifetimeMap = ResolveLifetimeSelections(lifetimeCapabilities);
-        foreach (var (key, value) in keyedLifetimeMap)
-        {
-            serviceRegistrationInfo.ServiceLifetimes[key] = value;
-        }
-
-        serviceRegistrationInfos[primaryCapability.SelectedType] = serviceRegistrationInfo;
-
-        var exposeAsCapabilities = bag.GetAll<ExposeAsCapability<SetupDefinition>>();
-        var exposedInterfaces = exposeAsCapabilities.Select(x => x.ContractType).Distinct().ToList();
-
-        foreach (var it in exposedInterfaces)
-        {
-            if (!serviceRegistrationInfos.ContainsKey(it))
-            {
-                serviceRegistrationInfos[it] = new ServiceRegistrationInfo
-                {
-                    Type = it,
-                };
-            }
-        }
-
-    }
-
-    private static void ProcessExposedType(Dictionary<Type, ServiceRegistrationInfo> serviceRegistrationInfos,
-        ExposedTypePrimary<SetupDefinition> primaryCapability, IComposition bag)
-    {
-
-        if (!serviceRegistrationInfos.TryGetValue(primaryCapability.SelectedType, out var serviceRegistrationInfo))
-        {
-            serviceRegistrationInfo = new ServiceRegistrationInfo
-            {
-                Type = primaryCapability.SelectedType,
-            };
-        }
-
-        if (bag.Has<DisableAutoRegistrationCapability<SetupDefinition>>())
-        {
-            serviceRegistrationInfo.DisableDefault = true;
-        }
-
-        var lifetimeCapabilities = bag.GetAll<ServiceLifetimeCapability<SetupDefinition>>();
-        var keyedLifetimeMap = ResolveLifetimeSelections(lifetimeCapabilities);
-        foreach (var (key, value) in keyedLifetimeMap)
-        {
-            serviceRegistrationInfo.ServiceLifetimes[key] = value;
-        }
-
-        serviceRegistrationInfos[primaryCapability.SelectedType] = serviceRegistrationInfo;
-
-    }
-
-    private static void ProcessServiceRegistration(IServiceCollection services, Dictionary<Type, ServiceRegistrationInfo> serviceRegistrationInfos)
-    {
-
-        foreach (var (serviceType, value) in serviceRegistrationInfos)
-        {
-            if (value is { DisableDefault: false, OverwriteDefault: false })
-            {
-                services.Add(new(serviceType, sp => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!, ServiceLifetime.Scoped));
-            }
-
-            foreach (var (serviceKey, serviceLifetime) in value.ServiceLifetimes)
-            {
-                if (serviceKey is "")
-                {
-                    services.Add(new(serviceType, (sp) => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!, serviceLifetime));
-                } else
-                {
-                    services.Add(new(serviceType, serviceKey, (sp, _) => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!, serviceLifetime));
-                }
-
-            }
-
-            var reactiveType = typeof(IReactiveConfig<>).MakeGenericType(serviceType);
-            services.AddSingleton(reactiveType, sp =>
-            {
-                var mgr = sp.GetRequiredService<ConfigManager>();
-                var method = mgr.GetType().GetMethod("GetReactiveConfig")!.MakeGenericMethod(serviceType);
-                return method.Invoke(mgr, null)!;
-            });
-        }
-
-    }
-
-
     private static void ThrowIfAlreadyRegistered(this IServiceCollection services)
     {
         if (services.Any(s => s.ServiceType == typeof(ConfigManager)))
@@ -212,15 +55,4 @@ public static class CocoarConfigurationExtensions
             throw new InvalidOperationException("Cocoar Configuration has already been registered. AddCocoarConfiguration should only be called once.");
         }
     }
-
-    private static Dictionary<object, ServiceLifetime> ResolveLifetimeSelections(IEnumerable<ServiceLifetimeCapability<SetupDefinition>> lifetimeCapabilities)
-    {
-        var keyed = new Dictionary<object, ServiceLifetime>();
-        foreach (var cap in lifetimeCapabilities)
-        {
-            keyed[cap.Key ?? ""] = cap.Lifetime;
-        }
-        return keyed;
-    }
-
 }

--- a/src/Cocoar.Configuration.DI/ServiceDescriptorEmitter.cs
+++ b/src/Cocoar.Configuration.DI/ServiceDescriptorEmitter.cs
@@ -1,0 +1,73 @@
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Reactive;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cocoar.Configuration.DI;
+
+/// <summary>
+/// Applies a service registration plan to an IServiceCollection.
+/// Separates DI manipulation from interpretation logic.
+/// </summary>
+internal static class ServiceDescriptorEmitter
+{
+    /// <summary>
+    /// Applies the registration plan to the service collection.
+    /// </summary>
+    public static void Emit(
+        IServiceCollection services,
+        Dictionary<Type, ServiceRegistrationInfo> plan)
+    {
+        // Explicit ordering for deterministic emission (belt-and-suspenders with planner sort)
+        foreach (var (serviceType, value) in plan.OrderBy(kvp => kvp.Key.FullName))
+        {
+            EmitConfigService(services, serviceType, value);
+            EmitReactiveService(services, serviceType);
+        }
+    }
+
+    private static void EmitConfigService(
+        IServiceCollection services,
+        Type serviceType,
+        ServiceRegistrationInfo info)
+    {
+        // Default registration (scoped) if not disabled and not overwritten
+        if (info is { DisableDefault: false, OverwriteDefault: false })
+        {
+            services.Add(new ServiceDescriptor(
+                serviceType,
+                sp => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!,
+                ServiceLifetime.Scoped));
+        }
+
+        // Custom lifetime registrations (keyed or unkeyed)
+        foreach (var (serviceKey, serviceLifetime) in info.ServiceLifetimes)
+        {
+            if (serviceKey is "")
+            {
+                services.Add(new ServiceDescriptor(
+                    serviceType,
+                    sp => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!,
+                    serviceLifetime));
+            }
+            else
+            {
+                services.Add(new ServiceDescriptor(
+                    serviceType,
+                    serviceKey,
+                    (sp, _) => sp.GetRequiredService<ConfigManager>().GetConfig(serviceType)!,
+                    serviceLifetime));
+            }
+        }
+    }
+
+    private static void EmitReactiveService(IServiceCollection services, Type serviceType)
+    {
+        var reactiveType = typeof(IReactiveConfig<>).MakeGenericType(serviceType);
+        services.AddSingleton(reactiveType, sp =>
+        {
+            var mgr = sp.GetRequiredService<ConfigManager>();
+            var method = mgr.GetType().GetMethod("GetReactiveConfig")!.MakeGenericMethod(serviceType);
+            return method.Invoke(mgr, null)!;
+        });
+    }
+}

--- a/src/Cocoar.Configuration.DI/ServiceRegistrationPlanner.cs
+++ b/src/Cocoar.Configuration.DI/ServiceRegistrationPlanner.cs
@@ -1,0 +1,151 @@
+using Cocoar.Capabilities;
+using Cocoar.Configuration.Configure;
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.DI.Capabilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cocoar.Configuration.DI;
+
+/// <summary>
+/// Builds an in-memory service registration plan from ConfigManager setup.
+/// Separates interpretation logic from IServiceCollection manipulation.
+/// </summary>
+internal static class ServiceRegistrationPlanner
+{
+    /// <summary>
+    /// Creates a registration plan from the ConfigManager's rules and setup definitions.
+    /// </summary>
+    public static Dictionary<Type, ServiceRegistrationInfo> CreatePlan(ConfigManager configManager)
+    {
+        var serviceRegistrationInfos = new Dictionary<Type, ServiceRegistrationInfo>();
+
+        // 1. Collect all types from rules
+        var typesFromRules = new HashSet<Type>();
+        foreach (var rule in configManager.Rules)
+        {
+            typesFromRules.Add(rule.ConcreteType);
+        }
+
+        // 2. Process explicit SetupDefinitions for customization
+        var configSpecs = configManager.SetupDefinitions;
+        if (configSpecs.Count > 0)
+        {
+            foreach (var spec in configSpecs)
+            {
+                if (!configManager.CapabilityScope.Compositions.TryGet(spec, out var bag))
+                {
+                    continue;
+                }
+
+                if (bag.TryGetPrimaryAs<ConcreteTypePrimary<SetupDefinition>>(out var typeCapability))
+                {
+                    ProcessConcreteType(serviceRegistrationInfos, typeCapability!, bag);
+                }
+
+                if (bag.TryGetPrimaryAs<ExposedTypePrimary<SetupDefinition>>(out var exposedCapability))
+                {
+                    ProcessExposedType(serviceRegistrationInfos, exposedCapability!, bag);
+                }
+            }
+        }
+
+        // 3. Auto-register types from rules that don't have explicit setup definitions
+        foreach (var type in typesFromRules)
+        {
+            if (!serviceRegistrationInfos.ContainsKey(type))
+            {
+                serviceRegistrationInfos[type] = new ServiceRegistrationInfo
+                {
+                    Type = type,
+                    DisableDefault = false
+                };
+            }
+        }
+
+        // Sort by type name for deterministic ordering
+        return serviceRegistrationInfos
+            .OrderBy(kvp => kvp.Key.FullName)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    private static void ProcessConcreteType(
+        Dictionary<Type, ServiceRegistrationInfo> serviceRegistrationInfos,
+        ConcreteTypePrimary<SetupDefinition> primaryCapability,
+        IComposition bag)
+    {
+        if (!serviceRegistrationInfos.TryGetValue(primaryCapability.SelectedType, out var serviceRegistrationInfo))
+        {
+            serviceRegistrationInfo = new ServiceRegistrationInfo
+            {
+                Type = primaryCapability.SelectedType,
+            };
+        }
+
+        if (bag.Has<DisableAutoRegistrationCapability<SetupDefinition>>())
+        {
+            serviceRegistrationInfo.DisableDefault = true;
+        }
+
+        var lifetimeCapabilities = bag.GetAll<ServiceLifetimeCapability<SetupDefinition>>();
+        var keyedLifetimeMap = ResolveLifetimeSelections(lifetimeCapabilities);
+        foreach (var (key, value) in keyedLifetimeMap)
+        {
+            serviceRegistrationInfo.ServiceLifetimes[key] = value;
+        }
+
+        serviceRegistrationInfos[primaryCapability.SelectedType] = serviceRegistrationInfo;
+
+        var exposeAsCapabilities = bag.GetAll<ExposeAsCapability<SetupDefinition>>();
+        var exposedInterfaces = exposeAsCapabilities.Select(x => x.ContractType).Distinct().ToList();
+
+        foreach (var it in exposedInterfaces)
+        {
+            if (!serviceRegistrationInfos.ContainsKey(it))
+            {
+                serviceRegistrationInfos[it] = new ServiceRegistrationInfo
+                {
+                    Type = it,
+                };
+            }
+        }
+    }
+
+    private static void ProcessExposedType(
+        Dictionary<Type, ServiceRegistrationInfo> serviceRegistrationInfos,
+        ExposedTypePrimary<SetupDefinition> primaryCapability,
+        IComposition bag)
+    {
+        if (!serviceRegistrationInfos.TryGetValue(primaryCapability.SelectedType, out var serviceRegistrationInfo))
+        {
+            serviceRegistrationInfo = new ServiceRegistrationInfo
+            {
+                Type = primaryCapability.SelectedType,
+            };
+        }
+
+        if (bag.Has<DisableAutoRegistrationCapability<SetupDefinition>>())
+        {
+            serviceRegistrationInfo.DisableDefault = true;
+        }
+
+        var lifetimeCapabilities = bag.GetAll<ServiceLifetimeCapability<SetupDefinition>>();
+        var keyedLifetimeMap = ResolveLifetimeSelections(lifetimeCapabilities);
+        foreach (var (key, value) in keyedLifetimeMap)
+        {
+            serviceRegistrationInfo.ServiceLifetimes[key] = value;
+        }
+
+        serviceRegistrationInfos[primaryCapability.SelectedType] = serviceRegistrationInfo;
+    }
+
+    private static Dictionary<object, ServiceLifetime> ResolveLifetimeSelections(
+        IEnumerable<ServiceLifetimeCapability<SetupDefinition>> lifetimeCapabilities)
+    {
+        var keyed = new Dictionary<object, ServiceLifetime>();
+        foreach (var cap in lifetimeCapabilities)
+        {
+            keyed[cap.Key ?? ""] = cap.Lifetime;
+        }
+        return keyed;
+    }
+}

--- a/src/Cocoar.Configuration.Secrets/Converters/SecretJsonConverter.cs
+++ b/src/Cocoar.Configuration.Secrets/Converters/SecretJsonConverter.cs
@@ -7,6 +7,26 @@ using Cocoar.Configuration.Secrets.SecretTypes;
 namespace Cocoar.Configuration.Secrets.Converters;
 
 /// <summary>
+/// Shared helper for determining if a type can hold null values.
+/// Used by both SecretJsonConverter and ISecretJsonConverter.
+/// </summary>
+internal static class SecretNullabilityHelper
+{
+    /// <summary>
+    /// Returns true if type T can legally hold a null value.
+    /// This includes reference types (string?, object?) and nullable value types (int?, bool?).
+    /// </summary>
+    public static bool TypeAcceptsNull<T>()
+    {
+        // Reference types where default is null
+        if (!typeof(T).IsValueType)
+            return true;
+        // Nullable<T> value types (int?, bool?, etc.)
+        return Nullable.GetUnderlyingType(typeof(T)) != null;
+    }
+}
+
+/// <summary>
 /// JSON converter for ISecret&lt;T&gt; interface types.
 /// Deserializes to Secret&lt;T&gt; instances, enabling interface-typed properties in configuration classes.
 /// </summary>
@@ -18,6 +38,11 @@ internal sealed class ISecretJsonConverter<T> : JsonConverter<ISecret<T>>
     {
         _innerConverter = new SecretJsonConverter<T>(scope);
     }
+
+    /// <summary>
+    /// Always handle null JSON values - delegate to inner converter for proper error handling.
+    /// </summary>
+    public override bool HandleNull => true;
 
     public override ISecret<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -39,6 +64,14 @@ internal sealed class SecretJsonConverter<T> : JsonConverter<Secret<T>>
         _scope = scope ?? throw new ArgumentNullException(nameof(scope));
     }
 
+    /// <summary>
+    /// Always handle null JSON values so we can:
+    /// - Create a Secret containing null for nullable types (T?)
+    /// - Throw a clear error for non-nullable types (T)
+    /// Without this, System.Text.Json silently sets the property to null.
+    /// </summary>
+    public override bool HandleNull => true;
+
     private bool GetAllowPlaintextSetting()
     {
         var composition = _scope.Owner.GetComposition();
@@ -55,38 +88,50 @@ internal sealed class SecretJsonConverter<T> : JsonConverter<Secret<T>>
         {
             using var doc = JsonDocument.ParseValue(ref reader);
             var element = doc.RootElement;
-            
+
             if (SecretEnvelopeWrapper.IsEnvelope(element))
             {
                 if (!SecretEnvelopeWrapper.TryParse(element, out var env) || env is null)
                 {
                     throw new JsonException($"Invalid secret envelope for Secret<{typeof(T).Name}>");
                 }
-                
+
                 return new Secret<T>(env, resolver);
             }
-            
+
             var plainValue = JsonSerializer.Deserialize<T>(element.GetRawText(), options);
-            if (plainValue is null)
+            if (plainValue is null && !SecretNullabilityHelper.TypeAcceptsNull<T>())
             {
                 throw new JsonException($"Failed to deserialize plain value for Secret<{typeof(T).Name}>");
             }
-            return new Secret<T>(plainValue, resolver, allowPlaintext: GetAllowPlaintextSetting());
+            return new Secret<T>(plainValue!, resolver, allowPlaintext: GetAllowPlaintextSetting());
+        }
+
+        // Handle explicit null token
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            if (!SecretNullabilityHelper.TypeAcceptsNull<T>())
+            {
+                throw new JsonException(
+                    $"Cannot deserialize null to Secret<{typeof(T).Name}>. " +
+                    $"Use Secret<{typeof(T).Name}?> if the value can be null.");
+            }
+            // For nullable types, create a Secret containing null
+            return new Secret<T>(default!, resolver, allowPlaintext: GetAllowPlaintextSetting());
         }
 
         if (reader.TokenType == JsonTokenType.String ||
             reader.TokenType == JsonTokenType.Number ||
             reader.TokenType == JsonTokenType.True ||
-            reader.TokenType == JsonTokenType.False ||
-            reader.TokenType == JsonTokenType.Null)
+            reader.TokenType == JsonTokenType.False)
         {
             using var tempDoc = JsonDocument.ParseValue(ref reader);
             var plainValue = JsonSerializer.Deserialize<T>(tempDoc.RootElement.GetRawText(), options);
-            if (plainValue is null)
+            if (plainValue is null && !SecretNullabilityHelper.TypeAcceptsNull<T>())
             {
                 throw new JsonException($"Failed to deserialize plain value for Secret<{typeof(T).Name}>");
             }
-            return new Secret<T>(plainValue, resolver, allowPlaintext: GetAllowPlaintextSetting());
+            return new Secret<T>(plainValue!, resolver, allowPlaintext: GetAllowPlaintextSetting());
         }
 
         throw new JsonException($"Unexpected token type '{reader.TokenType}' for Secret<{typeof(T).Name}>");

--- a/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
@@ -124,8 +124,8 @@ public sealed class Secret<T> : ISecret<T>
 
         if (value is null)
         {
-            // Allow null for nullable types
-            if (!typeof(T).IsValueType && default(T) is null)
+            // Allow null for types that accept null: reference types and Nullable<T> value types
+            if (TypeAcceptsNull())
             {
                 return new SecretLease<T>(value!, CreateCleanupAction(bytes, needsCleanup));
             }
@@ -134,6 +134,19 @@ public sealed class Secret<T> : ISecret<T>
         }
 
         return new SecretLease<T>(value, CreateCleanupAction(bytes, needsCleanup));
+    }
+
+    /// <summary>
+    /// Returns true if type T can legally hold a null value.
+    /// This includes reference types (string?, object?) and nullable value types (int?, bool?).
+    /// </summary>
+    private static bool TypeAcceptsNull()
+    {
+        // Reference types where default is null
+        if (!typeof(T).IsValueType)
+            return true;
+        // Nullable<T> value types (int?, bool?, etc.)
+        return Nullable.GetUnderlyingType(typeof(T)) != null;
     }
 
     private static Action CreateCleanupAction(byte[] bytes, bool needsCleanup)

--- a/src/Cocoar.Configuration/Core/ConfigJsonRepository.cs
+++ b/src/Cocoar.Configuration/Core/ConfigJsonRepository.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Cocoar.Json.Mutable;
+
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Pure storage for configuration JSON data.
+/// Manages committed and pending configurations with transaction-like semantics.
+/// </summary>
+internal sealed class ConfigJsonRepository
+{
+    private volatile Dictionary<Type, MutableJsonObject> _configs = new();
+    private volatile Dictionary<Type, MutableJsonObject>? _pendingConfigurations;
+
+    /// <summary>
+    /// Gets the current configuration dictionary (pending if in transaction, otherwise committed).
+    /// Thread-safe via volatile field access.
+    /// </summary>
+    public Dictionary<Type, MutableJsonObject> CurrentConfigurations
+    {
+        get
+        {
+            // Capture volatile field once to avoid torn reads
+            var pending = _pendingConfigurations;
+            return pending ?? _configs;
+        }
+    }
+
+    /// <summary>
+    /// Gets the committed configurations (ignores any pending transaction).
+    /// </summary>
+    public Dictionary<Type, MutableJsonObject> CommittedConfigurations => _configs;
+
+    /// <summary>
+    /// Indicates whether a transaction is in progress.
+    /// </summary>
+    public bool HasPendingTransaction => _pendingConfigurations != null;
+
+    /// <summary>
+    /// Begins a new update transaction.
+    /// </summary>
+    public void BeginUpdate()
+    {
+        _pendingConfigurations = new();
+    }
+
+    /// <summary>
+    /// Updates a configuration within the current transaction.
+    /// </summary>
+    public void UpdateConfiguration(Type type, MutableJsonObject value)
+    {
+        if (_pendingConfigurations == null)
+        {
+            throw new InvalidOperationException("Must call BeginUpdate() before updating configurations");
+        }
+
+        _pendingConfigurations[type] = value;
+    }
+
+    /// <summary>
+    /// Commits the transaction with the given final configurations.
+    /// </summary>
+    public void CommitUpdate(Dictionary<Type, MutableJsonObject> finalConfigurations)
+    {
+        _configs = finalConfigurations;
+        _pendingConfigurations = null;
+    }
+
+    /// <summary>
+    /// Rolls back the current transaction, discarding pending changes.
+    /// </summary>
+    public void RollbackUpdate()
+    {
+        _pendingConfigurations = null;
+    }
+
+    /// <summary>
+    /// Finds a configuration registration by type.
+    /// </summary>
+    public Type? FindRegistration<T>() => FindRegistration(typeof(T));
+
+    /// <summary>
+    /// Finds a configuration registration by type.
+    /// Thread-safe to avoid race conditions.
+    /// </summary>
+    public Type? FindRegistration(Type type)
+    {
+        var currentConfigs = CurrentConfigurations;
+        return currentConfigs.ContainsKey(type) ? type : null;
+    }
+
+    /// <summary>
+    /// Tries to get a configuration value by type.
+    /// </summary>
+    public bool TryGetConfiguration<T>(out MutableJsonObject? value) => TryGetConfiguration(typeof(T), out value);
+
+    /// <summary>
+    /// Tries to get a configuration value by type.
+    /// Thread-safe to avoid race conditions with volatile fields.
+    /// </summary>
+    public bool TryGetConfiguration(Type type, out MutableJsonObject? value)
+    {
+        var foundType = FindRegistration(type);
+        if (foundType != null)
+        {
+            var currentConfigs = CurrentConfigurations;
+            if (currentConfigs.TryGetValue(foundType, out value))
+            {
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets a configuration as a JsonElement.
+    /// </summary>
+    public JsonElement? GetConfigurationAsJson(Type type)
+    {
+        var currentConfigs = CurrentConfigurations;
+        if (currentConfigs.TryGetValue(type, out var value))
+        {
+            byte[] bytes;
+            lock (value)
+            {
+                bytes = MutableJsonDocument.ToUtf8Bytes(value);
+            }
+            using var doc = JsonDocument.Parse(bytes);
+            return doc.RootElement.Clone();
+        }
+        return null;
+    }
+}

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -27,6 +27,8 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     private readonly ConfigurationEngine _engine;
     private readonly ConfigurationState _state;
     private readonly ProviderRegistry _providerRegistry;
+    private readonly ExposureRegistry _bindingRegistry;
+    private readonly ILogger _logger;
     private readonly int _debounceMilliseconds;
 
     private volatile bool _initialized;
@@ -49,18 +51,19 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         // Apply test setup overrides if present
         var effectiveSetup = ApplyTestSetupOverrides(setup);
         _setupDefinitions = effectiveSetup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
-        logger ??= NullLogger.Instance;
+        _logger = logger ?? NullLogger.Instance;
         _debounceMilliseconds = debounceMilliseconds;
 
-        _state = new ConfigurationState(_ruleManagers, _rules);
-        _providerRegistry = new ProviderRegistry(logger, enableDiagnostics: false, factory: providerFactory);
-        var bindingRegistry = new ExposureRegistry(_setupDefinitions, logger, _capabilityScope);
+        _state = new ConfigurationState(_ruleManagers, _rules, _logger);
+        _providerRegistry = new ProviderRegistry(_logger, enableDiagnostics: false, factory: providerFactory);
+        _bindingRegistry = new ExposureRegistry(_setupDefinitions, _logger, _capabilityScope);
 
-        _accessor = new(_state, bindingRegistry, _capabilityScope, logger);
-        _reactiveConfigManager = new(logger, bindingRegistry);
-        _reactiveFactory = new(_reactiveConfigManager, _rules, logger, this, bindingRegistry);
+        _accessor = new(_state, _bindingRegistry, _logger);
+        _accessor.SetCapabilityScope(_capabilityScope);
+        _reactiveConfigManager = new(_logger, _bindingRegistry);
+        _reactiveFactory = new(_reactiveConfigManager, _rules, _logger, this, _bindingRegistry);
 
-        _engine = new ConfigurationEngine(_state, logger);
+        _engine = new ConfigurationEngine(_state, _logger);
     }
 
     /// <summary>
@@ -80,18 +83,19 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         // Apply test setup overrides if present
         var effectiveSetup = ApplyTestSetupOverrides(setup);
         _setupDefinitions = effectiveSetup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
-        logger ??= NullLogger.Instance;
+        _logger = logger ?? NullLogger.Instance;
         _debounceMilliseconds = debounceMilliseconds;
 
-        _state = new ConfigurationState(_ruleManagers, _rules);
-        _providerRegistry = new ProviderRegistry(logger, enableDiagnostics: false, factory: providerFactory);
-        var bindingRegistry = new ExposureRegistry(_setupDefinitions, logger, _capabilityScope);
+        _state = new ConfigurationState(_ruleManagers, _rules, _logger);
+        _providerRegistry = new ProviderRegistry(_logger, enableDiagnostics: false, factory: providerFactory);
+        _bindingRegistry = new ExposureRegistry(_setupDefinitions, _logger, _capabilityScope);
 
-        _accessor = new(_state, bindingRegistry, _capabilityScope, logger);
-        _reactiveConfigManager = new(logger, bindingRegistry);
-        _reactiveFactory = new(_reactiveConfigManager, _rules, logger, this, bindingRegistry);
+        _accessor = new(_state, _bindingRegistry, _logger);
+        _accessor.SetCapabilityScope(_capabilityScope);
+        _reactiveConfigManager = new(_logger, _bindingRegistry);
+        _reactiveFactory = new(_reactiveConfigManager, _rules, _logger, this, _bindingRegistry);
 
-        _engine = new ConfigurationEngine(_state, logger);
+        _engine = new ConfigurationEngine(_state, _logger);
     }
 
     public IReadOnlyList<ConfigRule> Rules => _rules.AsReadOnly();
@@ -118,26 +122,39 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
                 _ruleManagers,
                 _providerRegistry,
                 this,
+                _bindingRegistry,
+                _capabilityScope,
                 ScheduleRecompute,
                 _debounceMilliseconds);
+
+            // Wire up the reactive config manager to use the backplane
+            _reactiveConfigManager.SetBackplane(_state.Backplane);
         }
         return this;
     }
 
-    public T? GetConfig<T>() => _accessor.GetConfig<T>();
+    public T GetConfig<T>() => _accessor.GetConfig<T>();
     public bool TryGetConfig<T>(out T? value) => _accessor.TryGetConfig(out value);
+
+#pragma warning disable CS0618 // Type or member is obsolete
     public T GetRequiredConfig<T>() => _accessor.GetRequiredConfig<T>();
-    public object? GetConfig(Type type) => _accessor.GetConfig(type);
+#pragma warning restore CS0618
+
+    public object GetConfig(Type type) => _accessor.GetConfig(type);
     public bool TryGetConfig(Type type, out object? value) => _accessor.TryGetConfig(type, out value);
+
+#pragma warning disable CS0618 // Type or member is obsolete
     public object GetRequiredConfig(Type type) => _accessor.GetRequiredConfig(type);
+#pragma warning restore CS0618
+
     public JsonElement? GetConfigAsJson(Type type) => _accessor.GetConfigAsJson(type);
 
-    public IReactiveConfig<T> GetReactiveConfig<T>() => _reactiveFactory.GetReactiveConfig(() => GetConfig<T>()!);
+    public IReactiveConfig<T> GetReactiveConfig<T>() => _reactiveFactory.GetReactiveConfig<T>(() => GetConfig<T>());
 
     public IConfigurationHealthService GetHealthService() => _state.GetHealthService();
 
     internal void ScheduleRecompute(int startIndex) =>
-        _engine.ScheduleRecompute(_ruleManagers, this, _reactiveConfigManager, startIndex);
+        _engine.ScheduleRecompute(_ruleManagers, this, startIndex);
 
     internal Task? CurrentRecomputeTask => _engine.CurrentRecomputeTask;
 

--- a/src/Cocoar.Configuration/Core/ConfigSnapshot.cs
+++ b/src/Cocoar.Configuration/Core/ConfigSnapshot.cs
@@ -1,0 +1,102 @@
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Immutable container for all configuration instances at a point in time.
+/// Provides thread-safe, cached access to deserialized configuration objects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>DO NOT mutate configuration instances.</b> Instances are shared across
+/// GetConfig calls and IReactiveConfig subscriptions. Mutations would affect
+/// all consumers and cause inconsistent behavior.
+/// </para>
+/// </remarks>
+public sealed class ConfigSnapshot
+{
+    private readonly IReadOnlyDictionary<Type, object> _instances;
+
+    /// <summary>
+    /// Monotonically increasing version number for this snapshot.
+    /// </summary>
+    public long Version { get; }
+
+    /// <summary>
+    /// UTC timestamp when this snapshot was created.
+    /// </summary>
+    public DateTime TimestampUtc { get; }
+
+    private ConfigSnapshot(IReadOnlyDictionary<Type, object> instances, long version, DateTime timestampUtc)
+    {
+        _instances = instances;
+        Version = version;
+        TimestampUtc = timestampUtc;
+    }
+
+    /// <summary>
+    /// Gets a configuration instance by type from the cached snapshot.
+    /// No deserialization occurs - returns the pre-computed instance.
+    /// </summary>
+    /// <typeparam name="T">The configuration type to retrieve.</typeparam>
+    /// <returns>The configuration instance, or null if not found.</returns>
+    /// <remarks>
+    /// <b>DO NOT mutate the returned instance.</b> It is shared across all consumers.
+    /// </remarks>
+    public T? GetConfig<T>() where T : class
+    {
+        if (_instances.TryGetValue(typeof(T), out var instance))
+        {
+            return (T)instance;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Gets a configuration instance by type from the cached snapshot.
+    /// No deserialization occurs - returns the pre-computed instance.
+    /// </summary>
+    /// <param name="type">The configuration type to retrieve.</param>
+    /// <returns>The configuration instance, or null if not found.</returns>
+    /// <remarks>
+    /// <b>DO NOT mutate the returned instance.</b> It is shared across all consumers.
+    /// </remarks>
+    public object? GetConfig(Type type)
+    {
+        return _instances.TryGetValue(type, out var instance) ? instance : null;
+    }
+
+    /// <summary>
+    /// Checks if this snapshot contains a configuration of the specified type.
+    /// </summary>
+    public bool HasConfig<T>() where T : class => _instances.ContainsKey(typeof(T));
+
+    /// <summary>
+    /// Checks if this snapshot contains a configuration of the specified type.
+    /// </summary>
+    public bool HasConfig(Type type) => _instances.ContainsKey(type);
+
+    /// <summary>
+    /// Gets all configuration types registered in this snapshot.
+    /// </summary>
+    public IEnumerable<Type> ConfigTypes => _instances.Keys;
+
+    /// <summary>
+    /// Gets the number of configuration types in this snapshot.
+    /// </summary>
+    public int Count => _instances.Count;
+
+    /// <summary>
+    /// Creates a new snapshot with the specified instances.
+    /// </summary>
+    internal static ConfigSnapshot Create(IReadOnlyDictionary<Type, object> instances, long version)
+    {
+        return new ConfigSnapshot(instances, version, DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// An empty snapshot with no configuration instances.
+    /// </summary>
+    public static ConfigSnapshot Empty { get; } = new(
+        new Dictionary<Type, object>(),
+        version: 0,
+        timestampUtc: DateTime.MinValue);
+}

--- a/src/Cocoar.Configuration/Core/ConfigSnapshotBuilder.cs
+++ b/src/Cocoar.Configuration/Core/ConfigSnapshotBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Cocoar.Capabilities;
@@ -50,11 +51,11 @@ public sealed class ConfigurationDeserializationException : Exception
         }
 
         var sb = new StringBuilder();
-        sb.Append($"Configuration deserialization failed for {failures.Count} types:");
+        sb.Append(CultureInfo.InvariantCulture, $"Configuration deserialization failed for {failures.Count} types:");
         foreach (var failure in failures)
         {
             sb.AppendLine();
-            sb.Append($"  - {failure.ConfigType.Name}: {failure.Message}");
+            sb.Append(CultureInfo.InvariantCulture, $"  - {failure.ConfigType.Name}: {failure.Message}");
         }
         return sb.ToString();
     }

--- a/src/Cocoar.Configuration/Core/ConfigSnapshotBuilder.cs
+++ b/src/Cocoar.Configuration/Core/ConfigSnapshotBuilder.cs
@@ -1,0 +1,188 @@
+using System.Text;
+using System.Text.Json;
+using Cocoar.Capabilities;
+using Cocoar.Configuration.Infrastructure;
+using Cocoar.Configuration.Utilities;
+using Cocoar.Json.Mutable;
+
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Records a single deserialization failure during snapshot building.
+/// </summary>
+/// <param name="ConfigType">The configuration type that failed to deserialize.</param>
+/// <param name="Message">A human-readable description of the failure.</param>
+/// <param name="Exception">The underlying exception, if any.</param>
+/// <param name="JsonPreview">A preview of the JSON that failed to deserialize (truncated for safety).</param>
+public sealed record DeserializationFailure(
+    Type ConfigType,
+    string Message,
+    Exception? Exception,
+    string? JsonPreview);
+
+/// <summary>
+/// Exception thrown when one or more configuration types fail to deserialize during startup.
+/// </summary>
+public sealed class ConfigurationDeserializationException : Exception
+{
+    /// <summary>
+    /// The list of deserialization failures that caused this exception.
+    /// </summary>
+    public IReadOnlyList<DeserializationFailure> Failures { get; }
+
+    public ConfigurationDeserializationException(IReadOnlyList<DeserializationFailure> failures)
+        : base(BuildMessage(failures))
+    {
+        Failures = failures;
+    }
+
+    private static string BuildMessage(IReadOnlyList<DeserializationFailure> failures)
+    {
+        if (failures.Count == 0)
+        {
+            return "Configuration deserialization failed with no specific failures recorded.";
+        }
+
+        if (failures.Count == 1)
+        {
+            var f = failures[0];
+            return $"Configuration deserialization failed for {f.ConfigType.Name}: {f.Message}";
+        }
+
+        var sb = new StringBuilder();
+        sb.Append($"Configuration deserialization failed for {failures.Count} types:");
+        foreach (var failure in failures)
+        {
+            sb.AppendLine();
+            sb.Append($"  - {failure.ConfigType.Name}: {failure.Message}");
+        }
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Builds a <see cref="ConfigSnapshot"/> by eagerly deserializing all configuration types.
+/// Collects failures and supports both fail-fast (startup) and resilient (runtime) modes.
+/// </summary>
+internal sealed class ConfigSnapshotBuilder
+{
+    private readonly Dictionary<Type, object> _instances = new();
+    private readonly List<DeserializationFailure> _failures = new();
+    private readonly ExposureRegistry _bindingRegistry;
+    private readonly ConfigManagerCapabilityScope _capabilityScope;
+
+    public ConfigSnapshotBuilder(ExposureRegistry bindingRegistry, ConfigManagerCapabilityScope capabilityScope)
+    {
+        _bindingRegistry = bindingRegistry;
+        _capabilityScope = capabilityScope;
+    }
+
+    /// <summary>
+    /// Deserializes a configuration type from the merged JSON object.
+    /// Failures are collected rather than thrown immediately.
+    /// </summary>
+    /// <param name="type">The configuration type to deserialize.</param>
+    /// <param name="json">The merged JSON object for this type.</param>
+    public void DeserializeType(Type type, MutableJsonObject json)
+    {
+        byte[] bytes;
+        lock (json)
+        {
+            bytes = MutableJsonDocument.ToUtf8Bytes(json);
+        }
+
+        string? jsonPreview = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(bytes);
+            var jsonElement = doc.RootElement.Clone();
+
+            jsonPreview = CreateJsonPreview(jsonElement);
+
+            var instance = ConfigurationDeserializer.Deserialize(
+                jsonElement,
+                type,
+                _bindingRegistry.DeserializationMap,
+                _capabilityScope);
+
+            if (instance == null)
+            {
+                _failures.Add(new DeserializationFailure(
+                    type,
+                    "Deserializer returned null (possible missing required properties)",
+                    null,
+                    jsonPreview));
+                return;
+            }
+
+            _instances[type] = instance;
+        }
+        catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException or NotSupportedException)
+        {
+            _failures.Add(new DeserializationFailure(
+                type,
+                ex.Message,
+                ex,
+                jsonPreview));
+        }
+    }
+
+    /// <summary>
+    /// Indicates whether any deserialization failures occurred.
+    /// </summary>
+    public bool HasFailures => _failures.Count > 0;
+
+    /// <summary>
+    /// Gets the list of deserialization failures.
+    /// </summary>
+    public IReadOnlyList<DeserializationFailure> Failures => _failures;
+
+    /// <summary>
+    /// Builds the snapshot, throwing if any failures occurred.
+    /// Use this during startup for fail-fast behavior.
+    /// </summary>
+    /// <param name="version">The version number for this snapshot.</param>
+    /// <returns>A new ConfigSnapshot containing all successfully deserialized instances.</returns>
+    /// <exception cref="ConfigurationDeserializationException">Thrown if any deserialization failed.</exception>
+    public ConfigSnapshot Build(long version)
+    {
+        if (_failures.Count > 0)
+        {
+            throw new ConfigurationDeserializationException(_failures);
+        }
+
+        return ConfigSnapshot.Create(_instances, version);
+    }
+
+    /// <summary>
+    /// Attempts to build the snapshot without throwing.
+    /// Use this at runtime for resilient behavior that preserves last-good state.
+    /// </summary>
+    /// <param name="version">The version number for this snapshot.</param>
+    /// <returns>
+    /// A tuple containing the snapshot (or null if failures occurred) and the list of failures.
+    /// </returns>
+    public (ConfigSnapshot? Snapshot, IReadOnlyList<DeserializationFailure> Failures) TryBuild(long version)
+    {
+        if (_failures.Count > 0)
+        {
+            return (null, _failures);
+        }
+
+        return (ConfigSnapshot.Create(_instances, version), _failures);
+    }
+
+    private static string? CreateJsonPreview(JsonElement element)
+    {
+        try
+        {
+            var json = element.ToString();
+            if (json == null) return null;
+            return json.Length > 500 ? json[..500] + "..." : json;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Cocoar.Configuration/Core/ConfigurationAccessor.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationAccessor.cs
@@ -1,132 +1,251 @@
 using System.Text.Json;
-using Cocoar.Configuration.Infrastructure;
 using Cocoar.Capabilities;
+using Cocoar.Configuration.Infrastructure;
 using Cocoar.Configuration.Utilities;
 using Cocoar.Json.Mutable;
 using Microsoft.Extensions.Logging;
 
 namespace Cocoar.Configuration.Core;
 
+internal static partial class ConfigurationAccessorLog
+{
+    [LoggerMessage(EventId = 3000, Level = LogLevel.Debug,
+        Message = "Fallback deserialization for {TypeName} during recompute phase")]
+    public static partial void FallbackDeserialization(this ILogger logger, string typeName);
+
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Warning,
+        Message = "Fallback deserialization failed for {TypeName}: {Message}")]
+    public static partial void FallbackDeserializationFailed(this ILogger logger, string typeName, string message);
+}
+
 internal partial class ConfigurationAccessor : IConfigurationAccessor
 {
     private readonly ConfigurationState _state;
     private readonly ExposureRegistry _bindingRegistry;
-    private readonly ConfigManagerCapabilityScope _capabilityScope;
     private readonly ILogger _logger;
+    private ConfigManagerCapabilityScope? _capabilityScope;
 
     public ConfigurationAccessor(
         ConfigurationState state,
         ExposureRegistry bindingRegistry,
-        ConfigManagerCapabilityScope capabilityScope,
         ILogger logger)
     {
         _state = state;
         _bindingRegistry = bindingRegistry;
-        _capabilityScope = capabilityScope;
         _logger = logger;
     }
-    public T? GetConfig<T>() => (T?)ResolveConfig(typeof(T));
 
-    public bool TryGetConfig<T>(out T? value)
+    internal void SetCapabilityScope(ConfigManagerCapabilityScope capabilityScope)
     {
-        value = GetConfig<T>();
-        return value is not null;
+        _capabilityScope = capabilityScope;
     }
 
-    public T GetRequiredConfig<T>()
+    /// <summary>
+    /// Gets a configuration instance from the cached snapshot.
+    /// During recompute, falls back to on-demand deserialization.
+    /// </summary>
+    /// <remarks>
+    /// <b>DO NOT mutate the returned instance.</b> It is shared across all consumers.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No configuration rule is registered for type T.</exception>
+    public T GetConfig<T>()
     {
-        var result = GetConfig<T>();
-        if (result is null)
+        // First try the backplane (has cached instances after initialization)
+        try
+        {
+            var result = _state.Backplane.GetConfig(typeof(T));
+            if (result is T typed)
+            {
+                return typed;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Backplane not initialized yet - fall through to lazy deserialization
+        }
+
+        // Fallback: during recompute phase, deserialize on-demand from pending configurations
+        return FallbackDeserialize<T>();
+    }
+
+    private T FallbackDeserialize<T>()
+    {
+        var type = typeof(T);
+
+        // Try to resolve interface to concrete type
+        var targetType = type;
+        if (type.IsInterface && _bindingRegistry.TryGetConcreteType(type, out var concreteType))
+        {
+            targetType = concreteType;
+        }
+
+        if (!_state.TryGetConfiguration(targetType, out var json) || json == null)
         {
             throw new InvalidOperationException(
-                $"Configuration for {typeof(T).Name} hasn't been loaded yet. " +
-                $"If you're calling this from a rule factory, ensure a rule for {typeof(T).Name} appears earlier in your rule list.");
-        }
-        return result;
-    }
-
-    public object? GetConfig(Type type) => ResolveConfig(type);
-
-    public bool TryGetConfig(Type type, out object? value)
-    {
-        value = GetConfig(type);
-        return value is not null;
-    }
-
-    public object GetRequiredConfig(Type type)
-    {
-        var value = GetConfig(type);
-        if (value == null)
-        {
-            throw new InvalidOperationException(
-                $"Configuration for {type.Name} hasn't been loaded yet. " +
-                $"If you're calling this from a rule factory, ensure a rule for {type.Name} appears earlier in your rule list.");
-        }
-        return value;
-    }
-
-    public JsonElement? GetConfigAsJson(Type type) => _state.GetConfigurationAsJson(type);
-
-    private object? ResolveConfig(Type requestedType)
-    {
-        if (TryResolveConfiguration(requestedType, out var value))
-        {
-            return value;
+                $"No configuration rule is registered for type '{type.Name}'. " +
+                $"Add a rule using: rules.For<{type.Name}>().From...");
         }
 
-        if (_bindingRegistry.TryGetConcreteType(requestedType, out var concreteType) &&
-            TryResolveConfiguration(concreteType, out var concreteValue))
-        {
-            return concreteValue;
-        }
-
-        return null;
-    }
-
-    private bool TryResolveConfiguration(Type type, out object? value)
-    {
-        value = null;
-
-        if (!_state.TryGetConfiguration(type, out var mutableJsonObject) || mutableJsonObject == null)
-        {
-            return false;
-        }
-
-        var registration = _state.FindRegistration(type);
-        if (registration == null)
-        {
-            return false;
-        }
-
-        byte[] bytes;
-        lock (mutableJsonObject)
-        {
-            bytes = MutableJsonDocument.ToUtf8Bytes(mutableJsonObject);
-        }
-
-        using var doc = JsonDocument.Parse(bytes);
-        var jsonElement = doc.RootElement.Clone();
+        _logger.FallbackDeserialization(type.Name);
 
         try
         {
-            value = ConfigurationDeserializer.Deserialize(
-                jsonElement, registration, _bindingRegistry.DeserializationMap, _capabilityScope);
-            return value != null;
-        }
-        catch (Exception ex) when (ex is JsonException or FormatException or InvalidCastException)
-        {
-            var jsonPreview = jsonElement.ToString();
-            if (jsonPreview.Length > 500)
+            byte[] bytes;
+            lock (json)
             {
-                jsonPreview = jsonPreview[..500] + "...";
+                bytes = MutableJsonDocument.ToUtf8Bytes(json);
             }
-            DeserializationFailed(_logger, ex, type.Name, jsonPreview);
+
+            using var doc = JsonDocument.Parse(bytes);
+            var result = ConfigurationDeserializer.Deserialize(
+                doc.RootElement,
+                targetType,
+                _bindingRegistry.DeserializationMap,
+                _capabilityScope);
+
+            if (result is T typed)
+            {
+                return typed;
+            }
+
+            throw new InvalidOperationException(
+                $"Deserialization returned unexpected type for '{type.Name}'.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw; // Re-throw our own exceptions
+        }
+        catch (Exception ex)
+        {
+            _logger.FallbackDeserializationFailed(type.Name, ex.Message);
+            throw new InvalidOperationException(
+                $"Failed to deserialize configuration for '{type.Name}': {ex.Message}", ex);
+        }
+    }
+
+    public bool TryGetConfig<T>(out T? value)
+    {
+        try
+        {
+            value = GetConfig<T>();
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            value = default;
             return false;
         }
     }
 
-    [LoggerMessage(EventId = 5100, Level = LogLevel.Error,
-        Message = "Failed to deserialize configuration for {TypeName}. " +
-                  "This may be caused by missing 'required' properties or type mismatches. JSON: {JsonContent}")]
-    private static partial void DeserializationFailed(ILogger logger, Exception ex, string typeName, string jsonContent);
+    /// <summary>
+    /// Gets configuration, throwing if not found.
+    /// </summary>
+    /// <remarks>
+    /// This method is deprecated. GetConfig now has the same behavior - it throws if no rule is registered.
+    /// </remarks>
+    [Obsolete("Use GetConfig<T>() instead - it now throws if no rule is registered. " +
+              "This method will be removed in a future version.")]
+    public T GetRequiredConfig<T>() => GetConfig<T>();
+
+    /// <summary>
+    /// Gets a configuration instance from the cached snapshot.
+    /// During recompute, falls back to on-demand deserialization.
+    /// </summary>
+    /// <remarks>
+    /// <b>DO NOT mutate the returned instance.</b> It is shared across all consumers.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No configuration rule is registered for the type.</exception>
+    public object GetConfig(Type type)
+    {
+        // First try the backplane
+        try
+        {
+            var result = _state.Backplane.GetConfig(type);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Backplane not initialized yet - fall through to lazy deserialization
+        }
+
+        // Fallback: during recompute phase, deserialize on-demand
+        return FallbackDeserialize(type);
+    }
+
+    private object FallbackDeserialize(Type type)
+    {
+        // Try to resolve interface to concrete type
+        var targetType = type;
+        if (type.IsInterface && _bindingRegistry.TryGetConcreteType(type, out var concreteType))
+        {
+            targetType = concreteType;
+        }
+
+        if (!_state.TryGetConfiguration(targetType, out var json) || json == null)
+        {
+            throw new InvalidOperationException(
+                $"No configuration rule is registered for type '{type.Name}'. " +
+                $"Add a rule using: rules.For<{type.Name}>().From...");
+        }
+
+        _logger.FallbackDeserialization(type.Name);
+
+        try
+        {
+            byte[] bytes;
+            lock (json)
+            {
+                bytes = MutableJsonDocument.ToUtf8Bytes(json);
+            }
+
+            using var doc = JsonDocument.Parse(bytes);
+            var result = ConfigurationDeserializer.Deserialize(
+                doc.RootElement,
+                targetType,
+                _bindingRegistry.DeserializationMap,
+                _capabilityScope);
+
+            return result ?? throw new InvalidOperationException(
+                $"Deserialization returned null for '{type.Name}'.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw; // Re-throw our own exceptions
+        }
+        catch (Exception ex)
+        {
+            _logger.FallbackDeserializationFailed(type.Name, ex.Message);
+            throw new InvalidOperationException(
+                $"Failed to deserialize configuration for '{type.Name}': {ex.Message}", ex);
+        }
+    }
+
+    public bool TryGetConfig(Type type, out object? value)
+    {
+        try
+        {
+            value = GetConfig(type);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets configuration, throwing if not found.
+    /// </summary>
+    /// <remarks>
+    /// This method is deprecated. GetConfig now has the same behavior - it throws if no rule is registered.
+    /// </remarks>
+    [Obsolete("Use GetConfig(Type) instead - it now throws if no rule is registered. " +
+              "This method will be removed in a future version.")]
+    public object GetRequiredConfig(Type type) => GetConfig(type);
+
+    public JsonElement? GetConfigAsJson(Type type) => _state.GetConfigurationAsJson(type);
 }

--- a/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using Cocoar.Capabilities;
 using Cocoar.Configuration.Infrastructure;
 using Cocoar.Configuration.Rules;
 using Cocoar.Configuration.Reactive;
@@ -27,6 +28,9 @@ internal static partial class ConfigurationEngineLog
 
     [LoggerMessage(EventId = 2005, Level = LogLevel.Error, Message = "Recompute failed from change trigger")]
     public static partial void RecomputeFailedFromChange(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 2006, Level = LogLevel.Information, Message = "Startup phase complete - switching to resilient mode")]
+    public static partial void StartupComplete(this ILogger logger);
 }
 
 /// <summary>
@@ -45,6 +49,10 @@ internal class ConfigurationEngine : IDisposable
     private bool _disposed;
     private readonly List<IDisposable> _changeSubscriptions = new();
 
+    // Context for deserialization
+    private ExposureRegistry? _bindingRegistry;
+    private ConfigManagerCapabilityScope? _capabilityScope;
+
     public ConfigurationEngine(ConfigurationState state, ILogger logger)
     {
         _state = state;
@@ -55,24 +63,39 @@ internal class ConfigurationEngine : IDisposable
 
     /// <summary>
     /// Initializes the configuration system: analyzes rules, creates managers, performs initial computation, and sets up subscriptions.
+    /// Throws ConfigurationDeserializationException if any deserialization fails during startup (fail-fast behavior).
     /// </summary>
     public void InitializeAndCompute(
         List<ConfigRule> rules,
         List<RuleManager> ruleManagers,
         ProviderRegistry providerRegistry,
         IConfigurationAccessor configAccessor,
+        ExposureRegistry bindingRegistry,
+        ConfigManagerCapabilityScope capabilityScope,
         Action<int> scheduleRecomputeCallback,
         int debounceMilliseconds)
     {
+        // Store context for runtime recomputes
+        _bindingRegistry = bindingRegistry;
+        _capabilityScope = capabilityScope;
+
+        // Initialize the backplane
+        _state.InitializeBackplane(bindingRegistry);
+
         ruleManagers.Clear();
         ruleManagers.AddRange(rules.Select(rule => new RuleManager(rule, _logger, providerRegistry)));
 
         try
         {
+            // During startup, deserialization failures throw
             RecomputeAllConfigurationsSafe(ruleManagers, configAccessor);
             CreateChangeSubscriptions(ruleManagers, scheduleRecomputeCallback, debounceMilliseconds);
 
             _state.ReportSuccessfulRecompute(0);
+
+            // Mark startup complete - future failures will preserve last good config
+            _state.MarkStartupComplete();
+            _logger.StartupComplete();
         }
         catch (Exception ex)
         {
@@ -89,7 +112,6 @@ internal class ConfigurationEngine : IDisposable
     public void ScheduleRecompute(
         List<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
-        ReactiveConfigManager reactiveConfigManager,
         int startIndex)
     {
         lock (_recomputeGate)
@@ -102,7 +124,12 @@ internal class ConfigurationEngine : IDisposable
                 {
                     RecomputeAllConfigurationsSafe(ruleManagers, configAccessor, startIndex, cts.Token);
                     _state.ReportSuccessfulRecompute(startIndex);
-                    reactiveConfigManager.NotifyConfigurationObservers(configAccessor.GetConfig);
+
+                    // Report any deserialization failures to health service
+                    if (_state.LastDeserializationFailures.Count > 0)
+                    {
+                        _state.ReportDeserializationFailures(_state.LastDeserializationFailures);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -193,6 +220,7 @@ internal class ConfigurationEngine : IDisposable
             _recomputeSemaphore.Release();
         }
     }
+
     private void RecomputeAllConfigurations(
         IEnumerable<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
@@ -209,7 +237,17 @@ internal class ConfigurationEngine : IDisposable
         RecomputeSuffix(orderedManagers, startIndex, configAccessor, mergedConfigs, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
-        _state.CommitUpdate(mergedConfigs);
+
+        // Use new method with eager deserialization
+        if (_bindingRegistry != null && _capabilityScope != null)
+        {
+            _state.CommitUpdateWithDeserialization(mergedConfigs, _bindingRegistry, _capabilityScope);
+        }
+        else
+        {
+            // Fallback for tests or edge cases
+            _state.CommitUpdate(mergedConfigs);
+        }
     }
 
     private async Task RecomputeAllConfigurationsAsync(
@@ -228,7 +266,17 @@ internal class ConfigurationEngine : IDisposable
         await RecomputeSuffixAsync(orderedManagers, startIndex, configAccessor, mergedConfigs, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        _state.CommitUpdate(mergedConfigs);
+
+        // Use new method with eager deserialization
+        if (_bindingRegistry != null && _capabilityScope != null)
+        {
+            _state.CommitUpdateWithDeserialization(mergedConfigs, _bindingRegistry, _capabilityScope);
+        }
+        else
+        {
+            // Fallback for tests or edge cases
+            _state.CommitUpdate(mergedConfigs);
+        }
     }
 
     private void RestorePrefixContributions(

--- a/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Cocoar.Capabilities;
 using Cocoar.Configuration.Infrastructure;
 using Cocoar.Configuration.Rules;
-using Cocoar.Configuration.Reactive;
 using Cocoar.Configuration.Utilities;
 using Cocoar.Json.Mutable;
 
@@ -35,19 +34,18 @@ internal static partial class ConfigurationEngineLog
 
 /// <summary>
 /// Central engine for configuration computation and change management.
-/// Handles initialization, recomputation, task scheduling, and change subscriptions.
+/// Handles initialization, recomputation, and change subscriptions.
+/// Delegates scheduling/cancellation to RecomputeScheduler.
 /// </summary>
 internal class ConfigurationEngine : IDisposable
 {
     private readonly ConfigurationState _state;
     private readonly ILogger _logger;
     private readonly SemaphoreSlim _recomputeSemaphore = new(1, 1);
-    private readonly Lock _recomputeGate = new();
+    private readonly RecomputeScheduler _scheduler = new();
 
-    private CancellationTokenSource? _recomputeCts;
-    private Task? _currentRecomputeTask;
     private bool _disposed;
-    private readonly List<IDisposable> _changeSubscriptions = new();
+    private readonly List<IDisposable> _changeSubscriptions = [];
 
     // Context for deserialization
     private ExposureRegistry? _bindingRegistry;
@@ -59,7 +57,7 @@ internal class ConfigurationEngine : IDisposable
         _logger = logger;
     }
 
-    public Task? CurrentRecomputeTask => _currentRecomputeTask;
+    public Task? CurrentRecomputeTask => _scheduler.CurrentRecomputeTask;
 
     /// <summary>
     /// Initializes the configuration system: analyzes rules, creates managers, performs initial computation, and sets up subscriptions.
@@ -114,33 +112,29 @@ internal class ConfigurationEngine : IDisposable
         IConfigurationAccessor configAccessor,
         int startIndex)
     {
-        lock (_recomputeGate)
+        _scheduler.Schedule(ct =>
         {
-            var cts = RenewCancellationSource();
-
-            _currentRecomputeTask = Task.Run(() =>
+            try
             {
-                try
-                {
-                    RecomputeAllConfigurationsSafe(ruleManagers, configAccessor, startIndex, cts.Token);
-                    _state.ReportSuccessfulRecompute(startIndex);
+                RecomputeAllConfigurationsSafe(ruleManagers, configAccessor, startIndex, ct);
+                _state.ReportSuccessfulRecompute(startIndex);
 
-                    // Report any deserialization failures to health service
-                    if (_state.LastDeserializationFailures.Count > 0)
-                    {
-                        _state.ReportDeserializationFailures(_state.LastDeserializationFailures);
-                    }
-                }
-                catch (OperationCanceledException)
+                // Report any deserialization failures to health service
+                if (_state.LastDeserializationFailures.Count > 0)
                 {
+                    _state.ReportDeserializationFailures(_state.LastDeserializationFailures);
                 }
-                catch (Exception ex)
-                {
-                    _logger.RuntimeRecomputeFailed(ex);
-                    _state.ReportFailedRecompute(startIndex, ex);
-                }
-            }, cts.Token);
-        }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancelled, don't report as failure
+            }
+            catch (Exception ex)
+            {
+                _logger.RuntimeRecomputeFailed(ex);
+                _state.ReportFailedRecompute(startIndex, ex);
+            }
+        });
     }
 
     /// <summary>
@@ -440,28 +434,14 @@ internal class ConfigurationEngine : IDisposable
         _changeSubscriptions.Clear();
     }
 
-    private CancellationTokenSource RenewCancellationSource()
-    {
-        var newCts = new CancellationTokenSource();
-        var previous = Interlocked.Exchange(ref _recomputeCts, newCts);
-        Safety.CancelAndDisposeQuietly(previous);
-        return newCts;
-    }
-
-    private void DisposeCancellationSource()
-    {
-        var cts = Interlocked.Exchange(ref _recomputeCts, null);
-        Safety.CancelAndDisposeQuietly(cts);
-    }
-
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
 
-        DisposeCancellationSource();
+        _scheduler.Dispose();
         DisposeAllSubscriptions();
-        _recomputeSemaphore?.Dispose();
+        _recomputeSemaphore.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Cocoar.Configuration/Core/ConfigurationHealthReporter.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationHealthReporter.cs
@@ -1,0 +1,210 @@
+using Cocoar.Configuration.Health;
+using Cocoar.Configuration.Rules;
+
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Manages health reporting for configuration rules.
+/// Tracks rule execution outcomes and publishes health snapshots.
+/// </summary>
+internal sealed class ConfigurationHealthReporter : IDisposable
+{
+    private readonly List<RuleManager> _ruleManagers;
+    private readonly ConfigurationHealthService _healthService;
+    private long _healthSequence;
+
+    public ConfigurationHealthReporter(
+        List<RuleManager> ruleManagers,
+        List<ConfigRule> rules)
+    {
+        _ruleManagers = ruleManagers;
+
+        var initialEntries = rules.Select((r, i) => new RuleHealthEntry(
+            index: i,
+            name: r.Options?.Name,
+            required: r.Options?.Required == true,
+            status: RuleResultStatus.Unknown,
+            lastSuccessUtc: null,
+            lastFailureUtc: null,
+            failureCount: 0,
+            errorCode: null,
+            errorMessage: null,
+            providerType: r.ProviderType.Name,
+            configType: r.ConcreteType.Name,
+            deserializationStatus: null)).ToList();
+
+        var initialSnapshot = new ConfigHealthSnapshot(
+            id: ++_healthSequence,
+            timestampUtc: DateTime.UtcNow,
+            configVersion: 0,
+            rules: initialEntries);
+
+        _healthService = new(initialSnapshot);
+    }
+
+    /// <summary>
+    /// Gets the health service for external consumption.
+    /// </summary>
+    public IConfigurationHealthService HealthService => _healthService;
+
+    /// <summary>
+    /// Reports a successful recompute cycle to the health service.
+    /// </summary>
+    /// <param name="startIndex">The starting rule index (unused but kept for API compatibility).</param>
+    /// <param name="configVersion">The current configuration version.</param>
+    public void ReportSuccessfulRecompute(int startIndex, long configVersion)
+    {
+        var list = BuildEntriesFromOutcomes();
+        PublishHealthSnapshot(list, configVersion);
+    }
+
+    /// <summary>
+    /// Reports a failed recompute cycle to the health service.
+    /// </summary>
+    /// <param name="startIndex">The starting rule index (unused but kept for API compatibility).</param>
+    /// <param name="exception">The exception that caused the failure (unused but kept for API compatibility).</param>
+    /// <param name="configVersion">The current configuration version.</param>
+    public void ReportFailedRecompute(int startIndex, Exception exception, long configVersion)
+    {
+        var list = BuildEntriesFromOutcomes(forceTrailingUnknown: true);
+        PublishHealthSnapshot(list, configVersion);
+    }
+
+    /// <summary>
+    /// Reports deserialization failures to the health service.
+    /// Call this after a runtime deserialization failure to update health status.
+    /// </summary>
+    /// <param name="failures">The list of deserialization failures.</param>
+    /// <param name="configVersion">The current configuration version.</param>
+    public void ReportDeserializationFailures(IReadOnlyList<DeserializationFailure> failures, long configVersion)
+    {
+        if (failures.Count == 0) return;
+
+        var list = BuildEntriesFromOutcomes();
+
+        // Add deserialization status to affected rules
+        var failuresByType = failures.ToDictionary(f => f.ConfigType.Name, f => f);
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            var entry = list[i];
+            if (entry.ConfigType != null && failuresByType.TryGetValue(entry.ConfigType, out var failure))
+            {
+                list[i] = entry.WithDeserializationFailure(failure.Message);
+            }
+        }
+
+        PublishHealthSnapshot(list, configVersion);
+    }
+
+    private void PublishHealthSnapshot(List<RuleHealthEntry> entries, long configVersion)
+    {
+        var snapshot = new ConfigHealthSnapshot(++_healthSequence, DateTime.UtcNow, configVersion, entries);
+        _healthService.Publish(snapshot);
+    }
+
+    private List<RuleHealthEntry> BuildEntriesFromOutcomes(bool forceTrailingUnknown = false)
+    {
+        var now = DateTime.UtcNow;
+        var current = _healthService.Snapshot.Rules.ToDictionary(r => r.Index, r => r);
+        var list = new List<RuleHealthEntry>(_ruleManagers.Count);
+
+        for (var seed = 0; seed < _ruleManagers.Count; seed++)
+        {
+            if (current.TryGetValue(seed, out var existing))
+            {
+                list.Add(existing);
+            }
+            else
+            {
+                list.Add(new(seed, null, _ruleManagers[seed].Required, RuleResultStatus.Unknown, null, null, 0, null, null, null, null, null));
+            }
+        }
+
+        var encounteredRequiredFailure = false;
+        for (var i = 0; i < _ruleManagers.Count; i++)
+        {
+            var rm = _ruleManagers[i];
+            var prev = list[i];
+            RuleHealthEntry updated = prev;
+
+            switch (rm.LastOutcome)
+            {
+                case RuleManager.RuleExecutionOutcome.Unknown:
+                    updated = prev;
+                    break;
+                case RuleManager.RuleExecutionOutcome.Up:
+                    updated = prev.Status != RuleResultStatus.Up ? prev.WithStatus(RuleResultStatus.Up, now) : prev;
+                    break;
+                case RuleManager.RuleExecutionOutcome.Skipped:
+                    if (prev.Status != RuleResultStatus.Skipped)
+                    {
+                        updated = prev.WithStatus(RuleResultStatus.Skipped, now);
+                    }
+                    break;
+                case RuleManager.RuleExecutionOutcome.Failed:
+                    var ex = rm.LastFailureException ?? new InvalidOperationException("Rule failed without exception details");
+                    updated = prev.WithStatus(RuleResultStatus.Down, now, MapException(ex), ShortMessage(ex));
+                    if (rm.Required)
+                    {
+                        encounteredRequiredFailure = true;
+                    }
+                    break;
+            }
+
+            list[i] = updated;
+            if (forceTrailingUnknown && encounteredRequiredFailure && i < _ruleManagers.Count - 1)
+            {
+                for (var j = i + 1; j < _ruleManagers.Count; j++)
+                {
+                    var existing = list[j];
+                    if (existing.Status is RuleResultStatus.Up or RuleResultStatus.Skipped)
+                    {
+                        list[j] = new(existing.Index, existing.Name, existing.Required, RuleResultStatus.Unknown, existing.LastSuccessUtc, existing.LastFailureUtc, existing.FailureCount, existing.ErrorCode, existing.ErrorMessage, existing.ProviderType, existing.ConfigType, existing.DeserializationStatus);
+                    }
+                }
+                break;
+            }
+        }
+        return list;
+    }
+
+    private static string? MapException(Exception ex)
+    {
+        static bool TryGetCodeFromData(Exception e, out string? code)
+        {
+            code = null;
+            if (e.Data is { Count: > 0 })
+            {
+                if (e.Data.Contains("HealthErrorCode") && e.Data["HealthErrorCode"] is string c1 && !string.IsNullOrWhiteSpace(c1))
+                {
+                    code = c1; return true;
+                }
+                if (e.Data.Contains("ErrorCode") && e.Data["ErrorCode"] is string c2 && !string.IsNullOrWhiteSpace(c2))
+                {
+                    code = c2; return true;
+                }
+            }
+            return false;
+        }
+
+        if (TryGetCodeFromData(ex, out var codeFromEx))
+        {
+            return codeFromEx;
+        }
+
+        if (ex is AggregateException { InnerException: { } inner } && TryGetCodeFromData(inner, out var codeFromInner))
+        {
+            return codeFromInner;
+        }
+
+        return null;
+    }
+
+    private static string ShortMessage(Exception ex) => ex.Message.Length > 200 ? ex.Message.Substring(0, 200) : ex.Message;
+
+    public void Dispose()
+    {
+        _healthService.Dispose();
+    }
+}

--- a/src/Cocoar.Configuration/Core/ConfigurationState.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationState.cs
@@ -158,6 +158,10 @@ internal class ConfigurationState : IDisposable
             var snapshot = builder.Build(++_configVersion);
             _backplane?.Publish(snapshot);
             _logger.SnapshotPublished(snapshot.Version, snapshot.Count);
+
+            // Store the raw JSON for backward compatibility with GetConfigurationAsJson
+            _configs = finalConfigurations;
+            _pendingConfigurations = null;
         }
         else
         {
@@ -169,6 +173,11 @@ internal class ConfigurationState : IDisposable
                 _lastDeserializationFailures = [];
                 _backplane?.Publish(snapshot);
                 _logger.SnapshotPublished(snapshot.Version, snapshot.Count);
+
+                // Only update JSON when deserialization succeeds - keeps consistency
+                // between GetConfig<T>() (cached instances) and GetConfigAsJson() (raw JSON)
+                _configs = finalConfigurations;
+                _pendingConfigurations = null;
             }
             else
             {
@@ -180,14 +189,12 @@ internal class ConfigurationState : IDisposable
                     _logger.DeserializationFailed(failure.Exception, failure.ConfigType.Name, failure.Message);
                 }
 
+                // Rollback: keep old JSON AND old cached instances
+                // Don't update _configs - keep the last good JSON
                 // Don't decrement version - we want to track that an attempt was made
-                // The backplane keeps the old snapshot
+                _pendingConfigurations = null;
             }
         }
-
-        // Also store the raw JSON for backward compatibility with GetConfigurationAsJson
-        _configs = finalConfigurations;
-        _pendingConfigurations = null;
     }
 
     /// <summary>

--- a/src/Cocoar.Configuration/Core/ConfigurationState.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationState.cs
@@ -32,10 +32,8 @@ internal class ConfigurationState : IDisposable
 {
     private volatile Dictionary<Type, MutableJsonObject> _configs = new();
     private volatile Dictionary<Type, MutableJsonObject>? _pendingConfigurations;
-    private readonly List<RuleManager> _ruleManagers;
-    private readonly ConfigurationHealthService _healthService;
+    private readonly ConfigurationHealthReporter _healthReporter;
     private readonly ILogger _logger;
-    private long _healthSequence;
     private long _configVersion;
 
     // Master Backplane fields
@@ -45,29 +43,8 @@ internal class ConfigurationState : IDisposable
 
     public ConfigurationState(List<RuleManager> ruleManagers, List<ConfigRule> rules, ILogger logger)
     {
-        _ruleManagers = ruleManagers;
         _logger = logger;
-        var initialEntries = rules.Select((r, i) => new RuleHealthEntry(
-            index: i,
-            name: r.Options?.Name,
-            required: r.Options?.Required == true,
-            status: RuleResultStatus.Unknown,
-            lastSuccessUtc: null,
-            lastFailureUtc: null,
-            failureCount: 0,
-            errorCode: null,
-            errorMessage: null,
-            providerType: r.ProviderType.Name,
-            configType: r.ConcreteType.Name,
-            deserializationStatus: null)).ToList();
-
-        var initialSnapshot = new ConfigHealthSnapshot(
-            id: ++_healthSequence,
-            timestampUtc: DateTime.UtcNow,
-            configVersion: _configVersion,
-            rules: initialEntries);
-
-        _healthService = new(initialSnapshot);
+        _healthReporter = new ConfigurationHealthReporter(ruleManagers, rules);
     }
 
     /// <summary>
@@ -262,160 +239,24 @@ internal class ConfigurationState : IDisposable
         return null;
     }
 
-    public IConfigurationHealthService GetHealthService() => _healthService;
+    public IConfigurationHealthService GetHealthService() => _healthReporter.HealthService;
 
     public void ReportSuccessfulRecompute(int startIndex)
-    {
-        var list = BuildEntriesFromOutcomes();
-        // Don't increment version here - it's already incremented in CommitUpdateWithDeserialization
-        PublishHealthSnapshot(list, incrementVersion: false);
-    }
+        => _healthReporter.ReportSuccessfulRecompute(startIndex, _configVersion);
 
     public void ReportFailedRecompute(int startIndex, Exception exception)
-    {
-        var list = BuildEntriesFromOutcomes(forceTrailingUnknown: true);
-        PublishHealthSnapshot(list, incrementVersion: false);
-    }
+        => _healthReporter.ReportFailedRecompute(startIndex, exception, _configVersion);
 
     /// <summary>
     /// Reports deserialization failures to the health service.
     /// Call this after a runtime deserialization failure to update health status.
     /// </summary>
     public void ReportDeserializationFailures(IReadOnlyList<DeserializationFailure> failures)
-    {
-        if (failures.Count == 0) return;
-
-        var list = BuildEntriesFromOutcomes();
-
-        // Add deserialization status to affected rules
-        var failuresByType = failures.ToDictionary(f => f.ConfigType.Name, f => f);
-
-        for (var i = 0; i < list.Count; i++)
-        {
-            var entry = list[i];
-            if (entry.ConfigType != null && failuresByType.TryGetValue(entry.ConfigType, out var failure))
-            {
-                list[i] = entry.WithDeserializationFailure(failure.Message);
-            }
-        }
-
-        PublishHealthSnapshot(list, incrementVersion: false);
-    }
-
-    private void PublishHealthSnapshot(List<RuleHealthEntry> entries, bool incrementVersion)
-    {
-        if (incrementVersion)
-        {
-            _configVersion++;
-        }
-
-        var snapshot = new ConfigHealthSnapshot(++_healthSequence, DateTime.UtcNow, _configVersion, entries);
-        _healthService.Publish(snapshot);
-    }
-
-    private List<RuleHealthEntry> BuildEntriesFromOutcomes(bool forceTrailingUnknown = false)
-    {
-        var now = DateTime.UtcNow;
-        var current = _healthService.Snapshot.Rules.ToDictionary(r => r.Index, r => r);
-        var list = new List<RuleHealthEntry>(_ruleManagers.Count);
-
-        for (var seed = 0; seed < _ruleManagers.Count; seed++)
-        {
-            if (current.TryGetValue(seed, out var existing))
-            {
-                list.Add(existing);
-            }
-            else
-            {
-                list.Add(new(seed, null, _ruleManagers[seed].Required, RuleResultStatus.Unknown, null, null, 0, null, null, null, null, null));
-            }
-        }
-
-        var encounteredRequiredFailure = false;
-        for (var i = 0; i < _ruleManagers.Count; i++)
-        {
-            var rm = _ruleManagers[i];
-            var prev = list[i];
-            RuleHealthEntry updated = prev;
-
-            switch (rm.LastOutcome)
-            {
-                case RuleManager.RuleExecutionOutcome.Unknown:
-                    updated = prev;
-                    break;
-                case RuleManager.RuleExecutionOutcome.Up:
-                    updated = prev.Status != RuleResultStatus.Up ? prev.WithStatus(RuleResultStatus.Up, now) : prev;
-                    break;
-                case RuleManager.RuleExecutionOutcome.Skipped:
-                    if (prev.Status != RuleResultStatus.Skipped)
-                    {
-                        updated = prev.WithStatus(RuleResultStatus.Skipped, now);
-                    }
-                    break;
-                case RuleManager.RuleExecutionOutcome.Failed:
-                    var ex = rm.LastFailureException ?? new InvalidOperationException("Rule failed without exception details");
-                    updated = prev.WithStatus(RuleResultStatus.Down, now, MapException(ex), ShortMessage(ex));
-                    if (rm.Required)
-                    {
-                        encounteredRequiredFailure = true;
-                    }
-                    break;
-            }
-
-            list[i] = updated;
-            if (forceTrailingUnknown && encounteredRequiredFailure && i < _ruleManagers.Count - 1)
-            {
-                for (var j = i + 1; j < _ruleManagers.Count; j++)
-                {
-                    var existing = list[j];
-                    if (existing.Status is RuleResultStatus.Up or RuleResultStatus.Skipped)
-                    {
-                        list[j] = new(existing.Index, existing.Name, existing.Required, RuleResultStatus.Unknown, existing.LastSuccessUtc, existing.LastFailureUtc, existing.FailureCount, existing.ErrorCode, existing.ErrorMessage, existing.ProviderType, existing.ConfigType, existing.DeserializationStatus);
-                    }
-                }
-                break;
-            }
-        }
-        return list;
-    }
-
-    private static string? MapException(Exception ex)
-    {
-        static bool TryGetCodeFromData(Exception e, out string? code)
-        {
-            code = null;
-            if (e.Data is { Count: > 0 })
-            {
-                if (e.Data.Contains("HealthErrorCode") && e.Data["HealthErrorCode"] is string c1 && !string.IsNullOrWhiteSpace(c1))
-                {
-                    code = c1; return true;
-                }
-                if (e.Data.Contains("ErrorCode") && e.Data["ErrorCode"] is string c2 && !string.IsNullOrWhiteSpace(c2))
-                {
-                    code = c2; return true;
-                }
-            }
-            return false;
-        }
-
-        if (TryGetCodeFromData(ex, out var codeFromEx))
-        {
-            return codeFromEx;
-        }
-
-        if (ex is AggregateException { InnerException: { } inner } && TryGetCodeFromData(inner, out var codeFromInner))
-        {
-            return codeFromInner;
-        }
-
-        return null;
-    }
-
-    private static string ShortMessage(Exception ex) => ex.Message.Length > 200 ? ex.Message.Substring(0, 200) : ex.Message;
+        => _healthReporter.ReportDeserializationFailures(failures, _configVersion);
 
     public void Dispose()
     {
-        _healthService.Dispose();
+        _healthReporter.Dispose();
         _backplane?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/src/Cocoar.Configuration/Core/ConfigurationState.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationState.cs
@@ -1,13 +1,32 @@
 using System.Text.Json;
+using Cocoar.Capabilities;
 using Cocoar.Configuration.Health;
+using Cocoar.Configuration.Infrastructure;
 using Cocoar.Configuration.Rules;
 using Cocoar.Json.Mutable;
+using Microsoft.Extensions.Logging;
 
 namespace Cocoar.Configuration.Core;
+
+internal static partial class ConfigurationStateLog
+{
+    [LoggerMessage(EventId = 4000, Level = LogLevel.Error,
+        Message = "Deserialization failed for {TypeName}: {Message}")]
+    public static partial void DeserializationFailed(this ILogger logger, Exception? ex, string typeName, string message);
+
+    [LoggerMessage(EventId = 4001, Level = LogLevel.Warning,
+        Message = "Runtime deserialization failed for {FailureCount} types, keeping last good configuration")]
+    public static partial void RuntimeDeserializationFailed(this ILogger logger, int failureCount);
+
+    [LoggerMessage(EventId = 4002, Level = LogLevel.Information,
+        Message = "Configuration snapshot published: version={Version}, types={TypeCount}")]
+    public static partial void SnapshotPublished(this ILogger logger, long version, int typeCount);
+}
 
 /// <summary>
 /// Central state management for configurations and health monitoring.
 /// Combines configuration storage (repository) with health tracking.
+/// Uses MasterBackplane for atomic, eager-deserialized configuration updates.
 /// </summary>
 internal class ConfigurationState : IDisposable
 {
@@ -15,12 +34,19 @@ internal class ConfigurationState : IDisposable
     private volatile Dictionary<Type, MutableJsonObject>? _pendingConfigurations;
     private readonly List<RuleManager> _ruleManagers;
     private readonly ConfigurationHealthService _healthService;
+    private readonly ILogger _logger;
     private long _healthSequence;
     private long _configVersion;
 
-    public ConfigurationState(List<RuleManager> ruleManagers, List<ConfigRule> rules)
+    // Master Backplane fields
+    private MasterBackplane? _backplane;
+    private bool _isStartupPhase = true;
+    private IReadOnlyList<DeserializationFailure> _lastDeserializationFailures = [];
+
+    public ConfigurationState(List<RuleManager> ruleManagers, List<ConfigRule> rules, ILogger logger)
     {
         _ruleManagers = ruleManagers;
+        _logger = logger;
         var initialEntries = rules.Select((r, i) => new RuleHealthEntry(
             index: i,
             name: r.Options?.Name,
@@ -32,7 +58,8 @@ internal class ConfigurationState : IDisposable
             errorCode: null,
             errorMessage: null,
             providerType: r.ProviderType.Name,
-            configType: r.ConcreteType.Name)).ToList();
+            configType: r.ConcreteType.Name,
+            deserializationStatus: null)).ToList();
 
         var initialSnapshot = new ConfigHealthSnapshot(
             id: ++_healthSequence,
@@ -42,6 +69,42 @@ internal class ConfigurationState : IDisposable
 
         _healthService = new(initialSnapshot);
     }
+
+    /// <summary>
+    /// Gets the MasterBackplane for accessing cached configuration instances.
+    /// </summary>
+    public MasterBackplane Backplane => _backplane ?? throw new InvalidOperationException("Backplane not initialized. Call InitializeBackplane first.");
+
+    /// <summary>
+    /// Indicates whether the system is still in the startup phase.
+    /// During startup, deserialization failures throw exceptions.
+    /// After startup, failures preserve the last good configuration.
+    /// </summary>
+    public bool IsStartupPhase => _isStartupPhase;
+
+    /// <summary>
+    /// Gets the last deserialization failures that occurred during runtime (non-startup) updates.
+    /// </summary>
+    public IReadOnlyList<DeserializationFailure> LastDeserializationFailures => _lastDeserializationFailures;
+
+    /// <summary>
+    /// Initializes the MasterBackplane with the binding registry.
+    /// Must be called before CommitUpdateWithDeserialization.
+    /// </summary>
+    internal void InitializeBackplane(ExposureRegistry bindingRegistry)
+    {
+        _backplane = new MasterBackplane(bindingRegistry);
+    }
+
+    /// <summary>
+    /// Marks the startup phase as complete.
+    /// After this, deserialization failures will preserve last good configuration instead of throwing.
+    /// </summary>
+    public void MarkStartupComplete()
+    {
+        _isStartupPhase = false;
+    }
+
     /// <summary>
     /// Gets the current configuration dictionary (or pending if available).
     /// Thread-safe access to avoid race conditions.
@@ -71,6 +134,66 @@ internal class ConfigurationState : IDisposable
         _pendingConfigurations[type] = value;
     }
 
+    /// <summary>
+    /// Commits the update with eager deserialization to the MasterBackplane.
+    /// During startup, throws on any deserialization failure.
+    /// At runtime, keeps last good configuration on failure.
+    /// </summary>
+    public void CommitUpdateWithDeserialization(
+        Dictionary<Type, MutableJsonObject> finalConfigurations,
+        ExposureRegistry bindingRegistry,
+        ConfigManagerCapabilityScope capabilityScope)
+    {
+        // Build the snapshot with eager deserialization
+        var builder = new ConfigSnapshotBuilder(bindingRegistry, capabilityScope);
+
+        foreach (var (type, json) in finalConfigurations)
+        {
+            builder.DeserializeType(type, json);
+        }
+
+        if (_isStartupPhase)
+        {
+            // Startup: fail fast with all errors
+            var snapshot = builder.Build(++_configVersion);
+            _backplane?.Publish(snapshot);
+            _logger.SnapshotPublished(snapshot.Version, snapshot.Count);
+        }
+        else
+        {
+            // Runtime: keep last good on failure
+            var (snapshot, failures) = builder.TryBuild(++_configVersion);
+
+            if (snapshot != null)
+            {
+                _lastDeserializationFailures = [];
+                _backplane?.Publish(snapshot);
+                _logger.SnapshotPublished(snapshot.Version, snapshot.Count);
+            }
+            else
+            {
+                _lastDeserializationFailures = failures;
+                _logger.RuntimeDeserializationFailed(failures.Count);
+
+                foreach (var failure in failures)
+                {
+                    _logger.DeserializationFailed(failure.Exception, failure.ConfigType.Name, failure.Message);
+                }
+
+                // Don't decrement version - we want to track that an attempt was made
+                // The backplane keeps the old snapshot
+            }
+        }
+
+        // Also store the raw JSON for backward compatibility with GetConfigurationAsJson
+        _configs = finalConfigurations;
+        _pendingConfigurations = null;
+    }
+
+    /// <summary>
+    /// Legacy commit that only stores JSON without deserialization.
+    /// Used during the transition period.
+    /// </summary>
     public void CommitUpdate(Dictionary<Type, MutableJsonObject> finalConfigurations)
     {
         _configs = finalConfigurations;
@@ -131,21 +254,48 @@ internal class ConfigurationState : IDisposable
         }
         return null;
     }
+
     public IConfigurationHealthService GetHealthService() => _healthService;
 
     public void ReportSuccessfulRecompute(int startIndex)
     {
         var list = BuildEntriesFromOutcomes();
-        PublishSnapshot(list, incrementVersion: true);
+        // Don't increment version here - it's already incremented in CommitUpdateWithDeserialization
+        PublishHealthSnapshot(list, incrementVersion: false);
     }
 
     public void ReportFailedRecompute(int startIndex, Exception exception)
     {
         var list = BuildEntriesFromOutcomes(forceTrailingUnknown: true);
-        PublishSnapshot(list, incrementVersion: false);
+        PublishHealthSnapshot(list, incrementVersion: false);
     }
 
-    private void PublishSnapshot(List<RuleHealthEntry> entries, bool incrementVersion)
+    /// <summary>
+    /// Reports deserialization failures to the health service.
+    /// Call this after a runtime deserialization failure to update health status.
+    /// </summary>
+    public void ReportDeserializationFailures(IReadOnlyList<DeserializationFailure> failures)
+    {
+        if (failures.Count == 0) return;
+
+        var list = BuildEntriesFromOutcomes();
+
+        // Add deserialization status to affected rules
+        var failuresByType = failures.ToDictionary(f => f.ConfigType.Name, f => f);
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            var entry = list[i];
+            if (entry.ConfigType != null && failuresByType.TryGetValue(entry.ConfigType, out var failure))
+            {
+                list[i] = entry.WithDeserializationFailure(failure.Message);
+            }
+        }
+
+        PublishHealthSnapshot(list, incrementVersion: false);
+    }
+
+    private void PublishHealthSnapshot(List<RuleHealthEntry> entries, bool incrementVersion)
     {
         if (incrementVersion)
         {
@@ -170,7 +320,7 @@ internal class ConfigurationState : IDisposable
             }
             else
             {
-                list.Add(new(seed, null, _ruleManagers[seed].Required, RuleResultStatus.Unknown, null, null, 0, null, null, null, null));
+                list.Add(new(seed, null, _ruleManagers[seed].Required, RuleResultStatus.Unknown, null, null, 0, null, null, null, null, null));
             }
         }
 
@@ -213,7 +363,7 @@ internal class ConfigurationState : IDisposable
                     var existing = list[j];
                     if (existing.Status is RuleResultStatus.Up or RuleResultStatus.Skipped)
                     {
-                        list[j] = new(existing.Index, existing.Name, existing.Required, RuleResultStatus.Unknown, existing.LastSuccessUtc, existing.LastFailureUtc, existing.FailureCount, existing.ErrorCode, existing.ErrorMessage, existing.ProviderType, existing.ConfigType);
+                        list[j] = new(existing.Index, existing.Name, existing.Required, RuleResultStatus.Unknown, existing.LastSuccessUtc, existing.LastFailureUtc, existing.FailureCount, existing.ErrorCode, existing.ErrorMessage, existing.ProviderType, existing.ConfigType, existing.DeserializationStatus);
                     }
                 }
                 break;
@@ -259,6 +409,7 @@ internal class ConfigurationState : IDisposable
     public void Dispose()
     {
         _healthService.Dispose();
+        _backplane?.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Cocoar.Configuration/Core/ConfigurationState.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationState.cs
@@ -25,13 +25,12 @@ internal static partial class ConfigurationStateLog
 
 /// <summary>
 /// Central state management for configurations and health monitoring.
-/// Combines configuration storage (repository) with health tracking.
+/// Coordinates JSON storage, backplane publication, and health tracking.
 /// Uses MasterBackplane for atomic, eager-deserialized configuration updates.
 /// </summary>
 internal class ConfigurationState : IDisposable
 {
-    private volatile Dictionary<Type, MutableJsonObject> _configs = new();
-    private volatile Dictionary<Type, MutableJsonObject>? _pendingConfigurations;
+    private readonly ConfigJsonRepository _jsonRepository = new();
     private readonly ConfigurationHealthReporter _healthReporter;
     private readonly ILogger _logger;
     private long _configVersion;
@@ -65,6 +64,12 @@ internal class ConfigurationState : IDisposable
     public IReadOnlyList<DeserializationFailure> LastDeserializationFailures => _lastDeserializationFailures;
 
     /// <summary>
+    /// Gets the current configuration dictionary (or pending if available).
+    /// Thread-safe access to avoid race conditions.
+    /// </summary>
+    public Dictionary<Type, MutableJsonObject> CurrentConfigurations => _jsonRepository.CurrentConfigurations;
+
+    /// <summary>
     /// Initializes the MasterBackplane with the binding registry.
     /// Must be called before CommitUpdateWithDeserialization.
     /// </summary>
@@ -82,34 +87,9 @@ internal class ConfigurationState : IDisposable
         _isStartupPhase = false;
     }
 
-    /// <summary>
-    /// Gets the current configuration dictionary (or pending if available).
-    /// Thread-safe access to avoid race conditions.
-    /// </summary>
-    public Dictionary<Type, MutableJsonObject> CurrentConfigurations
-    {
-        get
-        {
-            // Capture volatile field once to avoid torn reads
-            var pending = _pendingConfigurations;
-            return pending ?? _configs;
-        }
-    }
+    public void BeginUpdate() => _jsonRepository.BeginUpdate();
 
-    public void BeginUpdate()
-    {
-        _pendingConfigurations = new();
-    }
-
-    public void UpdateConfiguration(Type type, MutableJsonObject value)
-    {
-        if (_pendingConfigurations == null)
-        {
-            throw new InvalidOperationException("Must call BeginUpdate() before updating configurations");
-        }
-
-        _pendingConfigurations[type] = value;
-    }
+    public void UpdateConfiguration(Type type, MutableJsonObject value) => _jsonRepository.UpdateConfiguration(type, value);
 
     /// <summary>
     /// Commits the update with eager deserialization to the MasterBackplane.
@@ -137,8 +117,7 @@ internal class ConfigurationState : IDisposable
             _logger.SnapshotPublished(snapshot.Version, snapshot.Count);
 
             // Store the raw JSON for backward compatibility with GetConfigurationAsJson
-            _configs = finalConfigurations;
-            _pendingConfigurations = null;
+            _jsonRepository.CommitUpdate(finalConfigurations);
         }
         else
         {
@@ -153,8 +132,7 @@ internal class ConfigurationState : IDisposable
 
                 // Only update JSON when deserialization succeeds - keeps consistency
                 // between GetConfig<T>() (cached instances) and GetConfigAsJson() (raw JSON)
-                _configs = finalConfigurations;
-                _pendingConfigurations = null;
+                _jsonRepository.CommitUpdate(finalConfigurations);
             }
             else
             {
@@ -169,7 +147,7 @@ internal class ConfigurationState : IDisposable
                 // Rollback: keep old JSON AND old cached instances
                 // Don't update _configs - keep the last good JSON
                 // Don't decrement version - we want to track that an attempt was made
-                _pendingConfigurations = null;
+                _jsonRepository.RollbackUpdate();
             }
         }
     }
@@ -179,65 +157,19 @@ internal class ConfigurationState : IDisposable
     /// Used during the transition period.
     /// </summary>
     public void CommitUpdate(Dictionary<Type, MutableJsonObject> finalConfigurations)
-    {
-        _configs = finalConfigurations;
-        _pendingConfigurations = null;
-    }
+        => _jsonRepository.CommitUpdate(finalConfigurations);
 
-    public void RollbackUpdate()
-    {
-        _pendingConfigurations = null;
-    }
+    public void RollbackUpdate() => _jsonRepository.RollbackUpdate();
 
-    public Type? FindRegistration<T>() => FindRegistration(typeof(T));
+    public Type? FindRegistration<T>() => _jsonRepository.FindRegistration<T>();
 
-    /// <summary>
-    /// Finds a configuration registration by concrete type.
-    /// Thread-safe to avoid race conditions.
-    /// </summary>
-    public Type? FindRegistration(Type type)
-    {
-        var currentConfigs = CurrentConfigurations;
-        return currentConfigs.ContainsKey(type) ? type : null;
-    }
+    public Type? FindRegistration(Type type) => _jsonRepository.FindRegistration(type);
 
-    public bool TryGetConfiguration<T>(out MutableJsonObject? value) => TryGetConfiguration(typeof(T), out value);
+    public bool TryGetConfiguration<T>(out MutableJsonObject? value) => _jsonRepository.TryGetConfiguration<T>(out value);
 
-    /// <summary>
-    /// Tries to get a configuration value by type.
-    /// Thread-safe to avoid race conditions with volatile fields.
-    /// </summary>
-    public bool TryGetConfiguration(Type type, out MutableJsonObject? value)
-    {
-        var foundType = FindRegistration(type);
-        if (foundType != null)
-        {
-            var currentConfigs = CurrentConfigurations;
-            if (currentConfigs.TryGetValue(foundType, out value))
-            {
-                return true;
-            }
-        }
+    public bool TryGetConfiguration(Type type, out MutableJsonObject? value) => _jsonRepository.TryGetConfiguration(type, out value);
 
-        value = default;
-        return false;
-    }
-
-    public JsonElement? GetConfigurationAsJson(Type type)
-    {
-        var currentConfigs = CurrentConfigurations;
-        if (currentConfigs.TryGetValue(type, out var value))
-        {
-            byte[] bytes;
-            lock (value)
-            {
-                bytes = MutableJsonDocument.ToUtf8Bytes(value);
-            }
-            using var doc = JsonDocument.Parse(bytes);
-            return doc.RootElement.Clone();
-        }
-        return null;
-    }
+    public JsonElement? GetConfigurationAsJson(Type type) => _jsonRepository.GetConfigurationAsJson(type);
 
     public IConfigurationHealthService GetHealthService() => _healthReporter.HealthService;
 

--- a/src/Cocoar.Configuration/Core/MasterBackplane.cs
+++ b/src/Cocoar.Configuration/Core/MasterBackplane.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Cocoar.Configuration.Infrastructure;
+
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Single source of truth for all configuration instances.
+/// Provides atomic updates across all types and type-specific projections for reactive consumers.
+/// </summary>
+internal sealed class MasterBackplane : IDisposable
+{
+    private readonly BehaviorSubject<ConfigSnapshot> _snapshotSubject;
+    private readonly ExposureRegistry _bindingRegistry;
+    private readonly ConcurrentDictionary<Type, object> _typeProjectionCache = new();
+    private readonly Lock _publishLock = new();
+    private bool _disposed;
+
+    public MasterBackplane(ExposureRegistry bindingRegistry)
+    {
+        _bindingRegistry = bindingRegistry;
+        _snapshotSubject = new BehaviorSubject<ConfigSnapshot>(ConfigSnapshot.Empty);
+    }
+
+    /// <summary>
+    /// Gets the current configuration snapshot.
+    /// </summary>
+    public ConfigSnapshot CurrentSnapshot => _snapshotSubject.Value;
+
+    /// <summary>
+    /// Observable stream of configuration snapshots.
+    /// Emits whenever a new snapshot is published.
+    /// </summary>
+    public IObservable<ConfigSnapshot> SnapshotStream => _snapshotSubject.AsObservable();
+
+    /// <summary>
+    /// Publishes a new configuration snapshot atomically.
+    /// All type projections will be updated in a single operation.
+    /// </summary>
+    /// <param name="snapshot">The new snapshot to publish.</param>
+    public void Publish(ConfigSnapshot snapshot)
+    {
+        lock (_publishLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _snapshotSubject.OnNext(snapshot);
+        }
+    }
+
+    /// <summary>
+    /// Gets an observable projection for a specific configuration type.
+    /// Uses ReferenceEquals for efficient change detection.
+    /// </summary>
+    /// <typeparam name="T">The configuration type to project.</typeparam>
+    /// <returns>An observable that emits when the configuration instance reference changes.</returns>
+    public IObservable<T> GetTypeProjection<T>() where T : class
+    {
+        var type = typeof(T);
+        return (IObservable<T>)_typeProjectionCache.GetOrAdd(type, _ => CreateTypeProjection<T>());
+    }
+
+    /// <summary>
+    /// Gets a configuration instance from the current snapshot.
+    /// Supports interface-to-concrete type mapping.
+    /// </summary>
+    /// <typeparam name="T">The configuration type to retrieve.</typeparam>
+    /// <returns>The configuration instance, or null if not found.</returns>
+    public T? GetConfig<T>() where T : class
+    {
+        var snapshot = CurrentSnapshot;
+
+        // Try direct type lookup first
+        var result = snapshot.GetConfig<T>();
+        if (result != null)
+        {
+            return result;
+        }
+
+        // Try interface-to-concrete mapping
+        if (_bindingRegistry.TryGetConcreteType(typeof(T), out var concreteType))
+        {
+            var concrete = snapshot.GetConfig(concreteType);
+            if (concrete is T typed)
+            {
+                return typed;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets a configuration instance from the current snapshot.
+    /// Supports interface-to-concrete type mapping.
+    /// </summary>
+    /// <param name="type">The configuration type to retrieve.</param>
+    /// <returns>The configuration instance, or null if not found.</returns>
+    public object? GetConfig(Type type)
+    {
+        var snapshot = CurrentSnapshot;
+
+        // Try direct type lookup first
+        var result = snapshot.GetConfig(type);
+        if (result != null)
+        {
+            return result;
+        }
+
+        // Try interface-to-concrete mapping
+        if (_bindingRegistry.TryGetConcreteType(type, out var concreteType))
+        {
+            return snapshot.GetConfig(concreteType);
+        }
+
+        return null;
+    }
+
+    private IObservable<T> CreateTypeProjection<T>() where T : class
+    {
+        // Project the snapshot stream to the specific type
+        // Use DistinctUntilChanged with ReferenceEquals for efficient change detection
+        return _snapshotSubject
+            .Select(snapshot =>
+            {
+                // First try direct lookup
+                var config = snapshot.GetConfig<T>();
+                if (config != null) return config;
+
+                // Then try interface mapping
+                if (_bindingRegistry.TryGetConcreteType(typeof(T), out var concreteType))
+                {
+                    var concrete = snapshot.GetConfig(concreteType);
+                    if (concrete is T typed) return typed;
+                }
+
+                return null!;
+            })
+            .Where(config => config != null)
+            .DistinctUntilChanged(ReferenceEqualityComparer<T>.Instance);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _snapshotSubject.OnCompleted();
+        _snapshotSubject.Dispose();
+        _typeProjectionCache.Clear();
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Comparer that uses ReferenceEquals for efficient change detection.
+    /// </summary>
+    private sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
+    {
+        public static readonly ReferenceEqualityComparer<T> Instance = new();
+
+        public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+        public int GetHashCode(T obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/src/Cocoar.Configuration/Core/RecomputeScheduler.cs
+++ b/src/Cocoar.Configuration/Core/RecomputeScheduler.cs
@@ -1,0 +1,77 @@
+using Cocoar.Configuration.Utilities;
+
+namespace Cocoar.Configuration.Core;
+
+/// <summary>
+/// Manages scheduling and cancellation of configuration recompute operations.
+/// Handles concurrency boundaries: cancels in-flight recomputes when new ones are triggered.
+/// </summary>
+internal sealed class RecomputeScheduler : IDisposable
+{
+    private readonly Lock _recomputeGate = new();
+    private CancellationTokenSource? _recomputeCts;
+    private Task? _currentRecomputeTask;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the currently running recompute task, if any.
+    /// </summary>
+    public Task? CurrentRecomputeTask => _currentRecomputeTask;
+
+    /// <summary>
+    /// Schedules a recompute operation. Cancels any in-flight recompute before starting a new one.
+    /// </summary>
+    /// <param name="recomputeAction">The action to execute for recomputation. Receives a CancellationToken.</param>
+    public void Schedule(Action<CancellationToken> recomputeAction)
+    {
+        lock (_recomputeGate)
+        {
+            var cts = RenewCancellationSource();
+
+            _currentRecomputeTask = Task.Run(() =>
+            {
+                recomputeAction(cts.Token);
+            }, cts.Token);
+        }
+    }
+
+    /// <summary>
+    /// Schedules an async recompute operation. Cancels any in-flight recompute before starting a new one.
+    /// </summary>
+    /// <param name="recomputeAction">The async action to execute for recomputation. Receives a CancellationToken.</param>
+    public void ScheduleAsync(Func<CancellationToken, Task> recomputeAction)
+    {
+        lock (_recomputeGate)
+        {
+            var cts = RenewCancellationSource();
+
+            _currentRecomputeTask = Task.Run(async () =>
+            {
+                await recomputeAction(cts.Token).ConfigureAwait(false);
+            }, cts.Token);
+        }
+    }
+
+    private CancellationTokenSource RenewCancellationSource()
+    {
+        var newCts = new CancellationTokenSource();
+        var previous = Interlocked.Exchange(ref _recomputeCts, newCts);
+        Safety.CancelAndDisposeQuietly(previous);
+        return newCts;
+    }
+
+    private void DisposeCancellationSource()
+    {
+        var cts = Interlocked.Exchange(ref _recomputeCts, null);
+        Safety.CancelAndDisposeQuietly(cts);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        DisposeCancellationSource();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Cocoar.Configuration/Health/ConfigurationHealthModels.cs
+++ b/src/Cocoar.Configuration/Health/ConfigurationHealthModels.cs
@@ -19,6 +19,72 @@ public enum RuleResultStatus
     Skipped = 3
 }
 
+/// <summary>
+/// Tracks the deserialization status for a configuration type.
+/// </summary>
+public sealed class DeserializationStatus
+{
+    /// <summary>
+    /// Indicates whether deserialization was successful.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Error message if deserialization failed.
+    /// </summary>
+    public string? ErrorMessage { get; }
+
+    /// <summary>
+    /// UTC timestamp of the last successful deserialization.
+    /// </summary>
+    public DateTime? LastSuccessUtc { get; }
+
+    /// <summary>
+    /// UTC timestamp of the last failed deserialization.
+    /// </summary>
+    public DateTime? LastFailureUtc { get; }
+
+    /// <summary>
+    /// Number of consecutive deserialization failures.
+    /// </summary>
+    public int FailureCount { get; }
+
+    private DeserializationStatus(bool success, string? errorMessage, DateTime? lastSuccessUtc, DateTime? lastFailureUtc, int failureCount)
+    {
+        Success = success;
+        ErrorMessage = errorMessage;
+        LastSuccessUtc = lastSuccessUtc;
+        LastFailureUtc = lastFailureUtc;
+        FailureCount = failureCount;
+    }
+
+    /// <summary>
+    /// Creates a successful deserialization status.
+    /// </summary>
+    public static DeserializationStatus CreateSuccess(DateTime utcNow, DeserializationStatus? previous = null)
+    {
+        return new DeserializationStatus(
+            success: true,
+            errorMessage: null,
+            lastSuccessUtc: utcNow,
+            lastFailureUtc: previous?.LastFailureUtc,
+            failureCount: 0);
+    }
+
+    /// <summary>
+    /// Creates a failed deserialization status.
+    /// </summary>
+    public static DeserializationStatus CreateFailure(string errorMessage, DateTime utcNow, DeserializationStatus? previous = null)
+    {
+        return new DeserializationStatus(
+            success: false,
+            errorMessage: errorMessage,
+            lastSuccessUtc: previous?.LastSuccessUtc,
+            lastFailureUtc: utcNow,
+            failureCount: (previous?.FailureCount ?? 0) + 1);
+    }
+}
+
 public sealed class RuleHealthEntry(
     int index,
     string? name,
@@ -30,7 +96,8 @@ public sealed class RuleHealthEntry(
     string? errorCode,
     string? errorMessage,
     string? providerType = null,
-    string? configType = null)
+    string? configType = null,
+    DeserializationStatus? deserializationStatus = null)
 {
     public int Index { get; } = index;
     public string? Name { get; } = name;
@@ -44,12 +111,42 @@ public sealed class RuleHealthEntry(
     public string? ProviderType { get; } = providerType;
     public string? ConfigType { get; } = configType;
 
+    /// <summary>
+    /// Tracks the deserialization status for this configuration type.
+    /// Null if never attempted or if this is an older health entry.
+    /// </summary>
+    public DeserializationStatus? DeserializationStatus { get; } = deserializationStatus;
+
     public RuleHealthEntry WithStatus(RuleResultStatus status, DateTime utcNow, string? errorCode = null, string? errorMessage = null)
     {
         var lastSuccess = status == RuleResultStatus.Up ? utcNow : LastSuccessUtc;
         var lastFailure = status == RuleResultStatus.Down ? utcNow : LastFailureUtc;
         var failureCount = status == RuleResultStatus.Down ? FailureCount + 1 : FailureCount;
-        return new(Index, Name, Required, status, lastSuccess, lastFailure, failureCount, errorCode, errorMessage, ProviderType, ConfigType);
+
+        // Update deserialization status on success
+        var deserializationStatus = status == RuleResultStatus.Up
+            ? Health.DeserializationStatus.CreateSuccess(utcNow, DeserializationStatus)
+            : DeserializationStatus;
+
+        return new(Index, Name, Required, status, lastSuccess, lastFailure, failureCount, errorCode, errorMessage, ProviderType, ConfigType, deserializationStatus);
+    }
+
+    /// <summary>
+    /// Creates a new entry with a deserialization failure recorded.
+    /// </summary>
+    public RuleHealthEntry WithDeserializationFailure(string errorMessage)
+    {
+        var newStatus = Health.DeserializationStatus.CreateFailure(errorMessage, DateTime.UtcNow, DeserializationStatus);
+        return new(Index, Name, Required, Status, LastSuccessUtc, LastFailureUtc, FailureCount, ErrorCode, ErrorMessage, ProviderType, ConfigType, newStatus);
+    }
+
+    /// <summary>
+    /// Creates a new entry with a successful deserialization recorded.
+    /// </summary>
+    public RuleHealthEntry WithDeserializationSuccess()
+    {
+        var newStatus = Health.DeserializationStatus.CreateSuccess(DateTime.UtcNow, DeserializationStatus);
+        return new(Index, Name, Required, Status, LastSuccessUtc, LastFailureUtc, FailureCount, ErrorCode, ErrorMessage, ProviderType, ConfigType, newStatus);
     }
 }
 
@@ -66,12 +163,17 @@ public sealed class ConfigHealthSnapshot(
     public IReadOnlyList<RuleHealthEntry> Rules { get; } = rules;
     public SummaryInfo Summary { get; } = BuildSummary(rules);
 
-    public sealed class SummaryInfo(int total, int requiredFailed, int optionalFailed, int skipped)
+    public sealed class SummaryInfo(int total, int requiredFailed, int optionalFailed, int skipped, int deserializationFailures)
     {
         public int Total { get; } = total;
         public int RequiredFailed { get; } = requiredFailed;
         public int OptionalFailed { get; } = optionalFailed;
         public int Skipped { get; } = skipped;
+
+        /// <summary>
+        /// Number of rules with deserialization failures.
+        /// </summary>
+        public int DeserializationFailures { get; } = deserializationFailures;
     }
 
     private static SummaryInfo BuildSummary(IReadOnlyList<RuleHealthEntry> rules)
@@ -80,7 +182,8 @@ public sealed class ConfigHealthSnapshot(
         var requiredFailed = rules.Count(r => r is { Required: true, Status: RuleResultStatus.Down });
         var optionalFailed = rules.Count(r => r is { Required: false, Status: RuleResultStatus.Down });
         var skipped = rules.Count(r => r.Status == RuleResultStatus.Skipped);
-        return new(total, requiredFailed, optionalFailed, skipped);
+        var deserializationFailures = rules.Count(r => r.DeserializationStatus is { Success: false });
+        return new(total, requiredFailed, optionalFailed, skipped, deserializationFailures);
     }
 
     private static HealthStatus DeriveStatus(IReadOnlyList<RuleHealthEntry> rules)
@@ -93,8 +196,16 @@ public sealed class ConfigHealthSnapshot(
         var anyRequiredDown = false;
         var anyOptionalDown = false;
         var anyUnknown = false;
+        var anyDeserializationFailure = false;
+
         foreach (var r in rules)
         {
+            // Check deserialization failures
+            if (r.DeserializationStatus is { Success: false })
+            {
+                anyDeserializationFailure = true;
+            }
+
             switch (r.Status)
             {
                 case RuleResultStatus.Down:
@@ -122,7 +233,8 @@ public sealed class ConfigHealthSnapshot(
             return HealthStatus.Unhealthy;
         }
 
-        if (anyOptionalDown)
+        // Deserialization failures cause Degraded status
+        if (anyDeserializationFailure || anyOptionalDown)
         {
             return HealthStatus.Degraded;
         }
@@ -160,7 +272,7 @@ internal sealed class ConfigurationHealthService(ConfigHealthSnapshot initial)
     public void Publish(ConfigHealthSnapshot snapshot)
     {
         var current = _subject.Value;
-        
+
         if (current.OverallStatus == snapshot.OverallStatus && current.ConfigVersion == snapshot.ConfigVersion)
         {
             var same = current.Rules.Count == snapshot.Rules.Count;
@@ -170,7 +282,8 @@ internal sealed class ConfigurationHealthService(ConfigHealthSnapshot initial)
                 {
                     var a = current.Rules[i];
                     var b = snapshot.Rules[i];
-                    if (a.Status != b.Status || a.FailureCount != b.FailureCount)
+                    if (a.Status != b.Status || a.FailureCount != b.FailureCount ||
+                        a.DeserializationStatus?.Success != b.DeserializationStatus?.Success)
                     { same = false; break; }
                 }
             }
@@ -194,4 +307,3 @@ internal sealed class ConfigurationHealthService(ConfigHealthSnapshot initial)
         _statusSubject.Dispose();
     }
 }
-

--- a/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
@@ -90,13 +90,10 @@ internal sealed class ReactiveConfigManager : IDisposable
     {
         private readonly MasterBackplane _backplane;
         private readonly IObservable<T> _observable;
-        private readonly ILogger _logger;
-        private bool _disposed;
 
         public BackplaneReactiveConfig(MasterBackplane backplane, ILogger logger)
         {
             _backplane = backplane;
-            _logger = logger;
             _observable = backplane.GetTypeProjection<T>();
         }
 
@@ -106,7 +103,7 @@ internal sealed class ReactiveConfigManager : IDisposable
 
         public void Dispose()
         {
-            _disposed = true;
+            // No resources to dispose - backplane and observable are shared
         }
     }
 }

--- a/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
@@ -1,19 +1,11 @@
-using System;
-using System.Buffers;
 using System.Collections.Concurrent;
-using System.Linq;
-using System.Reactive.Subjects;
-using System.Linq.Expressions;
 using System.Reactive.Linq;
-using System.Security.Cryptography;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.Reactive.Subjects;
+using Cocoar.Configuration.Core;
 using Cocoar.Configuration.Infrastructure;
 using Microsoft.Extensions.Logging;
-using Cocoar.Configuration.Utilities;
 
 namespace Cocoar.Configuration.Reactive;
-
 
 internal static partial class ReactiveConfigManagerLog
 {
@@ -23,318 +15,98 @@ internal static partial class ReactiveConfigManagerLog
     [LoggerMessage(EventId = 6001, Level = LogLevel.Warning, Message = "Failed to get initial config for type {Type}, using default value")]
     public static partial void GetInitialConfigFailed(this ILogger logger, Exception exception, Type Type);
 
-    [LoggerMessage(EventId = 6002, Level = LogLevel.Warning, Message = "Failed to get current config for type {Type} during notification, skipping update")]
-    public static partial void GetCurrentConfigFailed(this ILogger logger, Exception exception, Type Type);
-
-    [LoggerMessage(EventId = 6003, Level = LogLevel.Warning, Message = "Failed change emission for type {Type}")]
-    public static partial void ChangeEmissionFailed(this ILogger logger, Exception exception, Type Type);
-
-    [LoggerMessage(EventId = 6004, Level = LogLevel.Warning, Message = "Failed per-pass emission for type {Type}")]
-    public static partial void PerPassEmissionFailed(this ILogger logger, Exception exception, Type Type);
-
-    [LoggerMessage(EventId = 6005, Level = LogLevel.Warning, Message = "Failed to dispose configuration observable")]
-    public static partial void DisposeObservableFailed(this ILogger logger, Exception exception);
+    [LoggerMessage(EventId = 6006, Level = LogLevel.Debug, Message = "Created reactive config wrapper for type {Type}")]
+    public static partial void CreatedReactiveConfig(this ILogger logger, Type type);
 }
 
-internal sealed class ReactiveConfigManager(ILogger logger, ExposureRegistry bindingRegistry) : IDisposable
+/// <summary>
+/// Manages reactive configuration access using the MasterBackplane.
+/// Provides type-safe projections of the configuration snapshot stream.
+/// </summary>
+internal sealed class ReactiveConfigManager : IDisposable
 {
-    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly ExposureRegistry _bindingRegistry = bindingRegistry ?? throw new ArgumentNullException(nameof(bindingRegistry));
-    private readonly ConcurrentDictionary<Type, object> _configObservables = new();
-    private readonly ConcurrentDictionary<Type, string> _previousConfigHashes = new();
-    private readonly ConcurrentDictionary<Type, object> _perPassSubjects = new();
-    private long _passId;
+    private readonly ILogger _logger;
+    private readonly ExposureRegistry _bindingRegistry;
+    private readonly ConcurrentDictionary<Type, object> _reactiveConfigs = new();
+    private MasterBackplane? _backplane;
+    private bool _disposed;
 
-    private static readonly ConcurrentDictionary<Type, Action<object, object?>> s_onNextCache = new();
-    private static readonly ConcurrentDictionary<Type, Func<object?, bool, long, object>> s_passEventFactoryCache = new();
-
-
-    private static readonly JsonSerializerOptions _optimizedJsonOptions = new()
+    public ReactiveConfigManager(ILogger logger, ExposureRegistry bindingRegistry)
     {
-        WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        PropertyNamingPolicy = null,
-        IncludeFields = false
-    };
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _bindingRegistry = bindingRegistry ?? throw new ArgumentNullException(nameof(bindingRegistry));
+    }
 
-
-    public IReactiveConfig<T> GetReactiveConfig<T>(Func<T> configAccessor)
+    /// <summary>
+    /// Sets the MasterBackplane for this manager.
+    /// Must be called before GetReactiveConfig.
+    /// </summary>
+    internal void SetBackplane(MasterBackplane backplane)
     {
+        _backplane = backplane ?? throw new ArgumentNullException(nameof(backplane));
+    }
+
+    /// <summary>
+    /// Gets a reactive configuration wrapper for the specified type.
+    /// Uses the MasterBackplane's type projection for efficient change detection.
+    /// </summary>
+    public IReactiveConfig<T> GetReactiveConfig<T>(Func<T> fallbackAccessor) where T : class
+    {
+        if (_backplane == null)
+        {
+            throw new InvalidOperationException("MasterBackplane not initialized. Ensure InitializeBackplane is called first.");
+        }
+
         var type = typeof(T);
-        
-        var subject = (BehaviorSubject<T>)_configObservables.AddOrUpdate(type, 
-            _ => CreateBehaviorSubject(configAccessor),
-            (_, existing) =>
-            {
-                if (existing is BehaviorSubject<T> { IsDisposed: false })
-                {
-                    return existing;
-                }
-                
-                _logger.RecreatingDeadObservable(type);
-                return CreateBehaviorSubject(configAccessor);
-            });
-
-        _perPassSubjects.GetOrAdd(type, _ => new Subject<PassEvent<T>>());
-
-        return new ReactiveConfig<T>(subject, _logger);
-    }
-
-
-    internal readonly struct PassEvent<T>(T value, bool changed, long passId)
-    {
-        public T Value { get; } = value;
-        public bool Changed { get; } = changed;
-        public long PassId { get; } = passId;
-    }
-
-
-    internal IObservable<PassEvent<T>> ObservePerPass<T>()
-    {
-        if (_perPassSubjects.TryGetValue(typeof(T), out var existing) && existing is Subject<PassEvent<T>> subject)
+        return (IReactiveConfig<T>)_reactiveConfigs.GetOrAdd(type, _ =>
         {
-            return subject.AsObservable();
-        }
-
-        var created = (Subject<PassEvent<T>>)_perPassSubjects.GetOrAdd(typeof(T), _ => new Subject<PassEvent<T>>());
-        return created.AsObservable();
-    }
-
-    private BehaviorSubject<T> CreateBehaviorSubject<T>(Func<T> configAccessor)
-    {
-        T initialValue;
-        try
-        {
-            initialValue = configAccessor() ?? default(T)!;
-        }
-        catch (Exception ex)
-        {
-            _logger.GetInitialConfigFailed(ex, typeof(T));
-            initialValue = default(T)!;
-        }
-
-        var initialHash = ComputeConfigHash(initialValue);
-        _previousConfigHashes[typeof(T)] = initialHash;
-
-        return new(initialValue);
-    }
-
-    public void NotifyConfigurationObservers(Func<Type, object?> configAccessor)
-    {
-        var passId = Interlocked.Increment(ref _passId);
-
-        var allTypes = new HashSet<Type>();
-        foreach (var type in _configObservables.Keys)
-        {
-            allTypes.Add(type);
-        }
-
-        foreach (var type in _perPassSubjects.Keys)
-        {
-            allTypes.Add(type);
-        }
-
-        foreach (var type in allTypes.ToArray())
-        {
-            var subject = _configObservables.GetValueOrDefault(type);
-            object? currentConfig;
-            var changed = false;
-            try
-            {
-                currentConfig = configAccessor(type);
-            }
-            catch (Exception ex)
-            {
-                _logger.GetCurrentConfigFailed(ex, type);
-                continue;
-            }
-
-            try
-            {
-                var currentHash = ComputeConfigHash(currentConfig);
-                var previousHash = _previousConfigHashes.GetValueOrDefault(type, string.Empty);
-                changed = currentHash != previousHash || string.IsNullOrEmpty(previousHash);
-                if (changed)
-                {
-                    _previousConfigHashes[type] = currentHash;
-
-                    if (subject is not null)
-                    {
-                        var payload = PrepareValueForSubject(type, currentConfig);
-
-                        try
-                        {
-                            PublishToSubject(subject, payload);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.ChangeEmissionFailed(ex, type);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.ChangeEmissionFailed(ex, type);
-            }
-
-            try
-            {
-                if (_perPassSubjects.TryGetValue(type, out var perPassObj))
-                {
-                    var evt = CreatePassEventInstance(type, currentConfig, changed, passId);
-                    PublishToSubject(perPassObj, evt);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.PerPassEmissionFailed(ex, type);
-            }
-        }
-    }
-
-    
-
-    private static string ComputeConfigHash(object? config)
-    {
-        if (config is null)
-        {
-            return "NULL";
-        }
-
-        try
-        {
-            // Use IncrementalHash for better performance (no stream overhead)
-            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-            var bufferWriter = new ArrayBufferWriter<byte>();
-            using var writer = new Utf8JsonWriter(bufferWriter, new()
-            { 
-                Indented = false,
-                SkipValidation = true 
-            });
-            
-            JsonSerializer.Serialize(writer, config, config.GetType(), _optimizedJsonOptions);
-            writer.Flush();
-            
-            var written = bufferWriter.WrittenSpan;
-            hash.AppendData(written);
-            
-            return Convert.ToHexString(hash.GetHashAndReset());
-        }
-        catch
-        {
-            return $"{config.GetType().FullName}#{config.GetHashCode()}";
-        }
+            _logger.CreatedReactiveConfig(type);
+            return new BackplaneReactiveConfig<T>(_backplane, _logger);
+        });
     }
 
     public void Dispose()
     {
-        foreach (var observable in _configObservables.Values.ToArray())
+        if (_disposed) return;
+        _disposed = true;
+
+        foreach (var config in _reactiveConfigs.Values)
         {
-            try
+            if (config is IDisposable disposable)
             {
-                if (observable is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.DisposeObservableFailed(ex);
+                try { disposable.Dispose(); }
+                catch { /* ignore */ }
             }
         }
 
-        _configObservables.Clear();
-        _previousConfigHashes.Clear();
-        foreach (var perPass in _perPassSubjects.Values.ToArray())
-        {
-            Safety.DisposeQuietly(perPass as IDisposable);
-        }
-        _perPassSubjects.Clear();
+        _reactiveConfigs.Clear();
+        GC.SuppressFinalize(this);
     }
 
-    private static void PublishToSubject(object subject, object? value)
+    /// <summary>
+    /// IReactiveConfig implementation that uses the MasterBackplane for values.
+    /// </summary>
+    private sealed class BackplaneReactiveConfig<T> : IReactiveConfig<T>, IDisposable where T : class
     {
-        var action = s_onNextCache.GetOrAdd(subject.GetType(), CreatePublishDelegate);
-        action(subject, value);
-    }
+        private readonly MasterBackplane _backplane;
+        private readonly IObservable<T> _observable;
+        private readonly ILogger _logger;
+        private bool _disposed;
 
-    private static Action<object, object?> CreatePublishDelegate(Type subjectType)
-    {
-        var onNext = subjectType.GetMethods()
-            .FirstOrDefault(m => string.Equals(m.Name, "OnNext", StringComparison.Ordinal) && m.GetParameters().Length == 1);
-        if (onNext == null)
+        public BackplaneReactiveConfig(MasterBackplane backplane, ILogger logger)
         {
-            return (_, _) => { };
+            _backplane = backplane;
+            _logger = logger;
+            _observable = backplane.GetTypeProjection<T>();
         }
 
-        var subjectParameter = Expression.Parameter(typeof(object), "subject");
-        var valueParameter = Expression.Parameter(typeof(object), "value");
+        public T CurrentValue => _backplane.GetConfig<T>()!;
 
-        var castSubject = Expression.Convert(subjectParameter, subjectType);
-        var parameterType = onNext.GetParameters()[0].ParameterType;
-        var castValue = Expression.Convert(valueParameter, parameterType);
+        public IDisposable Subscribe(IObserver<T> observer) => _observable.Subscribe(observer);
 
-        var body = Expression.Call(castSubject, onNext, castValue);
-        var lambda = Expression.Lambda<Action<object, object?>>(body, subjectParameter, valueParameter);
-        return lambda.Compile();
-    }
-
-    private static object CreatePassEventInstance(Type configType, object? value, bool changed, long passId)
-    {
-        var factory = s_passEventFactoryCache.GetOrAdd(configType, CreatePassEventFactory);
-        return factory(value, changed, passId);
-    }
-
-    private static Func<object?, bool, long, object> CreatePassEventFactory(Type configType)
-    {
-        var passEventType = typeof(PassEvent<>).MakeGenericType(configType);
-        var ctor = passEventType.GetConstructors()
-            .FirstOrDefault(c =>
-            {
-                var parameters = c.GetParameters();
-                return parameters.Length == 3 &&
-                       parameters[0].ParameterType == configType &&
-                       parameters[1].ParameterType == typeof(bool) &&
-                       parameters[2].ParameterType == typeof(long);
-            })
-            ?? throw new InvalidOperationException($"Unable to locate PassEvent constructor for type {configType}");
-
-        var valueParam = Expression.Parameter(typeof(object), "value");
-        var changedParam = Expression.Parameter(typeof(bool), "changed");
-        var passIdParam = Expression.Parameter(typeof(long), "passId");
-
-        Expression typedValue = configType.IsValueType
-            ? Expression.Condition(
-                Expression.Equal(valueParam, Expression.Constant(null)),
-                Expression.Default(configType),
-                Expression.Convert(valueParam, configType))
-            : Expression.Convert(valueParam, configType);
-
-        var newExpression = Expression.New(ctor, typedValue, changedParam, passIdParam);
-        var body = Expression.Convert(newExpression, typeof(object));
-
-        return Expression.Lambda<Func<object?, bool, long, object>>(body, valueParam, changedParam, passIdParam).Compile();
-    }
-
-    private object? PrepareValueForSubject(Type requestedType, object? currentValue)
-    {
-        if (currentValue is null)
+        public void Dispose()
         {
-            return null;
+            _disposed = true;
         }
-
-        if (requestedType.IsInstanceOfType(currentValue))
-        {
-            return currentValue;
-        }
-
-        if (_bindingRegistry.TryGetConcreteType(requestedType, out var concreteType) &&
-            concreteType.IsInstanceOfType(currentValue))
-        {
-            return currentValue;
-        }
-
-        return currentValue;
     }
 }

--- a/src/Cocoar.Configuration/Reactive/ReactiveConfigurationFactory.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveConfigurationFactory.cs
@@ -15,6 +15,9 @@ internal static partial class ReactiveConfigurationFactoryLog
 
     [LoggerMessage(EventId = 6402, Level = LogLevel.Warning, Message = "Failed to prime reactive configuration for tuple element {Type}")]
     public static partial void PrimeReactiveConfigFailed(this ILogger logger, Exception exception, Type Type);
+
+    [LoggerMessage(EventId = 6403, Level = LogLevel.Warning, Message = "Type {Type} is not a class, skipping reactive priming")]
+    public static partial void SkippingNonClassType(this ILogger logger, Type Type);
 }
 
 internal class ReactiveConfigurationFactory(
@@ -31,10 +34,30 @@ internal class ReactiveConfigurationFactory(
         {
             return (IReactiveConfig<T>)CreateTupleReactiveConfig(t);
         }
-        return reactiveConfigManager.GetReactiveConfig(configAccessor);
+
+        // For non-tuple types, must be a class for the backplane
+        if (!t.IsClass)
+        {
+            throw new InvalidOperationException(
+                $"GetReactiveConfig<{t.Name}> is only supported for class types or ValueTuple types. " +
+                $"Configuration types should be classes, not structs.");
+        }
+
+        // Use reflection to call the generic method with class constraint
+        var method = typeof(ReactiveConfigManager)
+            .GetMethod(nameof(ReactiveConfigManager.GetReactiveConfig))?
+            .MakeGenericMethod(t);
+
+        if (method == null)
+        {
+            throw new InvalidOperationException($"Cannot create IReactiveConfig<{t.Name}> - internal error.");
+        }
+
+        var funcType = typeof(Func<>).MakeGenericType(t);
+        return (IReactiveConfig<T>)method.Invoke(reactiveConfigManager, [configAccessor])!;
     }
 
-    private static bool IsValueTupleType(Type t) => 
+    private static bool IsValueTupleType(Type t) =>
         t is { IsValueType: true, FullName: not null } && t.FullName.StartsWith("System.ValueTuple", StringComparison.Ordinal);
 
     private object CreateTupleReactiveConfig(Type tupleType)
@@ -72,8 +95,16 @@ internal class ReactiveConfigurationFactory(
             throw new InvalidOperationException($"Cannot create IReactiveConfig<{tupleType.Name}>. The following tuple element types are not configured/exposed: {string.Join(", ", invalid)}");
         }
 
+        // Prime each distinct element type's reactive config
         foreach (var et in elementTypes.Distinct())
         {
+            // Only prime reference types (class constraint on ReactiveConfigManager)
+            if (!et.IsClass)
+            {
+                logger.SkippingNonClassType(et);
+                continue;
+            }
+
             try
             {
                 var reactiveMethod = typeof(ReactiveConfigManager)

--- a/src/Cocoar.Configuration/Reactive/ReactiveTupleConfig.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveTupleConfig.cs
@@ -1,12 +1,12 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Cocoar.Configuration.Core;
 
 namespace Cocoar.Configuration.Reactive;
-
 
 internal static partial class ReactiveTupleConfigLog
 {
@@ -16,13 +16,14 @@ internal static partial class ReactiveTupleConfigLog
     [LoggerMessage(EventId = 6101, Level = LogLevel.Warning, Message = "Failed to build CurrentValue for tuple {TupleType}")]
     public static partial void BuildCurrentValueFailed(this ILogger logger, Exception exception, string TupleType);
 
-    [LoggerMessage(EventId = 6102, Level = LogLevel.Debug, Message = "Tuple pass alignment discrepancy for {TupleType}: got {IncomingPass} expected {CurrentPass}")]
-    public static partial void TuplePassAlignmentDiscrepancy(this ILogger logger, string TupleType, long IncomingPass, long CurrentPass);
-
     [LoggerMessage(EventId = 6103, Level = LogLevel.Warning, Message = "Failed building tuple emission for {TupleType}")]
     public static partial void BuildTupleEmissionFailed(this ILogger logger, Exception exception, string TupleType);
 }
 
+/// <summary>
+/// Provides reactive tuple configuration using the MasterBackplane.
+/// Tuple updates are atomic - all elements update together when the snapshot changes.
+/// </summary>
 internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDisposable where TTuple : struct
 {
     private readonly ILogger _logger;
@@ -30,7 +31,6 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
     private readonly IObservable<TTuple> _observable;
     private readonly Func<object?[], object> _builder;
     private readonly Type[] _elementTypes;
-    private volatile object?[] _latestValues;
     private readonly ConfigManager _configManager;
 
     public ReactiveTupleConfig(
@@ -46,8 +46,8 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
             throw new InvalidOperationException($"{typeof(TTuple).Name} is not a ValueTuple with elements.");
         }
 
+        // Validate all elements are present
         var missing = new List<string>();
-        _latestValues = new object?[_elementTypes.Length];
         for (var i = 0; i < _elementTypes.Length; i++)
         {
             var val = configManager.GetConfig(_elementTypes[i]);
@@ -55,17 +55,17 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
             {
                 missing.Add(_elementTypes[i].Name);
             }
-
-            _latestValues[i] = val;
         }
+
         if (missing.Count > 0)
         {
             throw new InvalidOperationException(
                 $"Cannot create IReactiveConfig<{typeof(TTuple).Name}>. Missing configuration for: {string.Join(", ", missing)}");
         }
 
-        var merged = CreateMergedPerPassObservable(reactiveConfigManager);
-        _observable = merged
+        // Create observable from the backplane's snapshot stream
+        // This provides atomicity - all tuple elements update together
+        _observable = CreateTupleObservable(configManager)
             .Catch<TTuple, Exception>(ex =>
             {
                 _logger.TupleStreamErrorIgnored(ex, typeof(TTuple).Name);
@@ -84,15 +84,12 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
         {
             try
             {
+                var values = new object?[_elementTypes.Length];
                 for (var i = 0; i < _elementTypes.Length; i++)
                 {
-                    var value = _configManager.GetConfig(_elementTypes[i]);
-                    if (value != null)
-                    {
-                        _latestValues[i] = value;
-                    }
+                    values[i] = _configManager.GetConfig(_elementTypes[i]);
                 }
-                return (TTuple)_builder(_latestValues);
+                return (TTuple)_builder(values);
             }
             catch (Exception ex)
             {
@@ -104,98 +101,125 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
 
     public IDisposable Subscribe(IObserver<TTuple> observer) => _observable.Subscribe(observer);
 
-    private IObservable<TTuple> CreateMergedPerPassObservable(ReactiveConfigManager manager)
+    private IObservable<TTuple> CreateTupleObservable(ConfigManager configManager)
     {
-        var streams = new IObservable<object>[_elementTypes.Length];
-        for (var i = 0; i < _elementTypes.Length; i++)
-        {
-            var method = typeof(ReactiveConfigManager).GetMethod("ObservePerPass", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)!;
-            var g = method.MakeGenericMethod(_elementTypes[i]);
-            var passObservable = g.Invoke(manager, null)!;
-            var projected = (IObservable<object>)typeof(ReactiveTupleConfig<TTuple>)
-                .GetMethod(nameof(Project), BindingFlags.NonPublic | BindingFlags.Static)!
-                .MakeGenericMethod(_elementTypes[i])
-                .Invoke(null, [passObservable, i])!;
-            streams[i] = projected;
-        }
-
-        var merged = streams.Merge();
+        // Access the backplane through the state (after initialization)
+        // The backplane provides atomic updates for all types
         return Observable.Create<TTuple>(observer =>
         {
-            var gate = new object();
-            long currentPassId;
-            int received;
-            bool changedAny;
-            var slotChanged = new bool[_elementTypes.Length];
+            TTuple? previousTuple = null;
 
-            void Reset(long passId)
+            // Subscribe to the backplane's snapshot stream
+            var backplane = configManager.GetType()
+                .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)?
+                .GetValue(configManager);
+
+            if (backplane == null)
             {
-                currentPassId = passId;
-                received = 0;
-                changedAny = false;
-                Array.Clear(slotChanged, 0, slotChanged.Length);
+                observer.OnError(new InvalidOperationException("Cannot access ConfigurationState for tuple observation"));
+                return Disposable.Empty;
             }
 
-            Reset(-1);
+            var backplaneProp = backplane.GetType().GetProperty("Backplane", BindingFlags.Public | BindingFlags.Instance);
+            var masterBackplane = backplaneProp?.GetValue(backplane);
 
-            return merged.Subscribe(evtObj =>
+            if (masterBackplane == null)
             {
-                if (evtObj is not PassEnvelope env)
+                observer.OnError(new InvalidOperationException("MasterBackplane not initialized for tuple observation"));
+                return Disposable.Empty;
+            }
+
+            var snapshotStreamProp = masterBackplane.GetType().GetProperty("SnapshotStream");
+            var snapshotStream = snapshotStreamProp?.GetValue(masterBackplane) as IObservable<ConfigSnapshot>;
+
+            if (snapshotStream == null)
+            {
+                observer.OnError(new InvalidOperationException("Cannot access SnapshotStream for tuple observation"));
+                return Disposable.Empty;
+            }
+
+            return snapshotStream.Subscribe(snapshot =>
+            {
+                try
                 {
-                    return;
+                    var values = new object?[_elementTypes.Length];
+                    var allPresent = true;
+
+                    for (var i = 0; i < _elementTypes.Length; i++)
+                    {
+                        values[i] = snapshot.GetConfig(_elementTypes[i]);
+                        if (values[i] == null)
+                        {
+                            allPresent = false;
+                            break;
+                        }
+                    }
+
+                    if (!allPresent)
+                    {
+                        return; // Skip if any element is missing
+                    }
+
+                    var tuple = (TTuple)_builder(values);
+
+                    // Only emit if any element changed (using reference equality)
+                    var changed = previousTuple == null;
+                    if (!changed && previousTuple.HasValue)
+                    {
+                        var prevValues = ExtractTupleValues(previousTuple.Value);
+                        for (var i = 0; i < _elementTypes.Length; i++)
+                        {
+                            if (!ReferenceEquals(prevValues[i], values[i]))
+                            {
+                                changed = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (changed)
+                    {
+                        previousTuple = tuple;
+                        observer.OnNext(tuple);
+                    }
                 }
-
-                lock (gate)
+                catch (Exception ex)
                 {
-                    if (received == 0)
-                    {
-                        Reset(env.PassId);
-                    }
-                    else if (env.PassId != currentPassId)
-                    {
-                        _logger.TuplePassAlignmentDiscrepancy(typeof(TTuple).Name, env.PassId, currentPassId);
-                        Reset(env.PassId);
-                    }
-
-                    if (!slotChanged[env.Index])
-                    {
-                        slotChanged[env.Index] = true;
-                        received++;
-                        if (env.Changed)
-                        {
-                            changedAny = true;
-                        }
-
-                        _latestValues[env.Index] = env.Value;
-                    }
-
-                    if (received == _elementTypes.Length)
-                    {
-                        if (changedAny)
-                        {
-                            try
-                            {
-                                var tuple = (TTuple)_builder(_latestValues);
-                                observer.OnNext(tuple);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.BuildTupleEmissionFailed(ex, typeof(TTuple).Name);
-                            }
-                        }
-                        currentPassId = -1;
-                    }
+                    _logger.BuildTupleEmissionFailed(ex, typeof(TTuple).Name);
                 }
             }, observer.OnError, observer.OnCompleted);
         });
     }
 
-    private static IObservable<object> Project<T>(IObservable<ReactiveConfigManager.PassEvent<T>> source, int index)
+    private object?[] ExtractTupleValues(TTuple tuple)
     {
-        return source.Select(e => (object)new PassEnvelope(index, e.PassId, e.Changed, e.Value));
+        var values = new object?[_elementTypes.Length];
+        var fields = typeof(TTuple).GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+        var index = 0;
+        ExtractRecursive(tuple, fields, ref index, values);
+        return values;
     }
 
-    private readonly record struct PassEnvelope(int Index, long PassId, bool Changed, object? Value);
+    private static void ExtractRecursive(object tuple, FieldInfo[] fields, ref int index, object?[] values)
+    {
+        foreach (var field in fields)
+        {
+            if (field.Name == "Rest" && field.FieldType.FullName?.StartsWith("System.ValueTuple", StringComparison.Ordinal) == true)
+            {
+                var rest = field.GetValue(tuple);
+                if (rest != null)
+                {
+                    var restFields = field.FieldType.GetFields(BindingFlags.Public | BindingFlags.Instance);
+                    ExtractRecursive(rest, restFields, ref index, values);
+                }
+            }
+            else
+            {
+                values[index++] = field.GetValue(tuple);
+            }
+        }
+    }
 
     public void Dispose() => _subscription.Dispose();
 }
@@ -246,7 +270,6 @@ internal static class TupleShapeCache
 
     private static Func<object?[], object> CompileBuilder(Type[] elements)
     {
-
         var param = Expression.Parameter(typeof(object?[]), "arr");
 
         var body = Build(0);
@@ -260,7 +283,7 @@ internal static class TupleShapeCache
             {
                 var ctorTypes = elements.Skip(start).Take(remaining).ToArray();
                 var ctors = GetTupleType(remaining, ctorTypes);
-                var args = ctorTypes.Select((t,i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t));
+                var args = ctorTypes.Select((t, i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t));
                 return Expression.New(ctors.GetConstructors()[0], args);
             }
             else
@@ -268,7 +291,7 @@ internal static class TupleShapeCache
                 var headTypes = elements.Skip(start).Take(7).ToArray();
                 var restExpr = Build(start + 7);
                 var tupleTypeHead = GetTupleType(8, headTypes.Concat([restExpr.Type]).ToArray());
-                var args = headTypes.Select((t,i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t))
+                var args = headTypes.Select((t, i) => Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(start + i)), t))
                     .Concat([restExpr]);
                 return Expression.New(tupleTypeHead.GetConstructors()[0], args);
             }

--- a/src/Cocoar.Configuration/Rules/RuleManager.cs
+++ b/src/Cocoar.Configuration/Rules/RuleManager.cs
@@ -5,7 +5,6 @@ using Cocoar.Configuration.Core;
 using Cocoar.Configuration.Helper;
 using Cocoar.Configuration.Infrastructure;
 using Cocoar.Configuration.Providers.Abstractions;
-using Cocoar.Configuration.Utilities;
 using Cocoar.Json.Mutable;
 using Microsoft.Extensions.Logging;
 
@@ -25,20 +24,16 @@ internal static partial class RuleManagerLog
 
 /// <summary>
 /// Coordinates rule execution: provider lifecycle, query management, caching, and change tracking.
-/// Delegates caching to TransformCache and subscriptions to ChangeSubscription.
+/// Delegates lifecycle to RuleProviderLease, caching to TransformCache, and subscriptions to ChangeSubscription.
 /// </summary>
 internal sealed class RuleManager : IDisposable
 {
     private readonly ConfigRule _rule;
     private readonly ILogger _logger;
-    private readonly ProviderRegistry _registry;
 
+    private readonly RuleProviderLease _providerLease;
     private readonly TransformCache _cache = new();
     private readonly ChangeSubscription _changeSubscription = new();
-
-    private ProviderRegistry.ProviderHandle? _providerHandle;
-    private ConfigurationProvider? _provider;
-    private string? _providerKey;
 
     internal enum RuleExecutionOutcome
     {
@@ -66,7 +61,7 @@ internal sealed class RuleManager : IDisposable
     {
         _rule = rule;
         _logger = logger;
-        _registry = registry;
+        _providerLease = new RuleProviderLease(rule.ProviderType, registry);
     }
 
     public async Task<ReadOnlyMemory<byte>?> ComputeAsync(IConfigurationAccessor accessor, CancellationToken ct)
@@ -99,7 +94,7 @@ internal sealed class RuleManager : IDisposable
                 LastOutcome = RuleExecutionOutcome.Up;
                 return _cache.GetCachedBytes();
             }
-            var bytesMemory = await _provider!.FetchConfigurationBytesAsync(queryOptions, ct).ConfigureAwait(false);
+            var bytesMemory = await _providerLease.Provider!.FetchConfigurationBytesAsync(queryOptions, ct).ConfigureAwait(false);
 
             try
             {
@@ -152,18 +147,19 @@ internal sealed class RuleManager : IDisposable
 
     private void EnsureProvider(IProviderConfiguration providerOptions)
     {
-        var newProviderKey = providerOptions.GenerateProviderKey();
-        if (_provider != null && _providerKey == newProviderKey)
-        {
-            return;
-        }
+        _providerLease.EnsureProvider(providerOptions, OnBeforeProviderRebuild);
+    }
 
-        RebuildProvider(providerOptions, newProviderKey);
+    private void OnBeforeProviderRebuild()
+    {
+        _changeSubscription.Reset();
+        LastSelectionHash = null;
+        _cache.Invalidate();
     }
 
     private void EnsureSubscription(IProviderQuery queryOptions)
     {
-        if (_provider is null)
+        if (!_providerLease.HasProvider)
         {
             return;
         }
@@ -171,7 +167,7 @@ internal sealed class RuleManager : IDisposable
         var newQueryKey = ComputeQueryKey(queryOptions);
 
         bool subscriptionChanged = _changeSubscription.EnsureSubscription(
-            _provider,
+            _providerLease.Provider!,
             queryOptions,
             newQueryKey,
             ProcessProviderChangeBytes);
@@ -180,24 +176,6 @@ internal sealed class RuleManager : IDisposable
         {
             LastSelectionHash = null;
         }
-    }
-
-    private void RebuildProvider(IProviderConfiguration providerOptions, string? providerKey)
-    {
-        _changeSubscription.Reset();
-
-        if (_providerHandle is not null)
-        {
-            Safety.DisposeQuietly(_providerHandle);
-            _providerHandle = null;
-        }
-
-        _providerHandle = _registry.Acquire(_rule.ProviderType, providerOptions);
-        _provider = _providerHandle.Provider;
-        _providerKey = providerKey;
-
-        LastSelectionHash = null;
-        _cache.Invalidate();
     }
 
     private void ProcessProviderChangeBytes(byte[] bytesMemory)
@@ -309,13 +287,6 @@ internal sealed class RuleManager : IDisposable
     {
         _changeSubscription.Dispose();
         _cache.Dispose();
-
-        if (_providerHandle is not null)
-        {
-            Safety.DisposeQuietly(_providerHandle);
-            _providerHandle = null;
-        }
-
-        _provider = null;
+        _providerLease.Dispose();
     }
 }

--- a/src/Cocoar.Configuration/Rules/RuleProviderLease.cs
+++ b/src/Cocoar.Configuration/Rules/RuleProviderLease.cs
@@ -1,0 +1,84 @@
+using Cocoar.Configuration.Infrastructure;
+using Cocoar.Configuration.Providers.Abstractions;
+using Cocoar.Configuration.Utilities;
+
+namespace Cocoar.Configuration.Rules;
+
+/// <summary>
+/// Manages provider lifecycle for a configuration rule.
+/// Handles acquisition, key-based caching, and disposal of provider handles.
+/// </summary>
+internal sealed class RuleProviderLease : IDisposable
+{
+    private readonly Type _providerType;
+    private readonly ProviderRegistry _registry;
+
+    private ProviderRegistry.ProviderHandle? _providerHandle;
+    private ConfigurationProvider? _provider;
+    private string? _providerKey;
+
+    public RuleProviderLease(Type providerType, ProviderRegistry registry)
+    {
+        _providerType = providerType;
+        _registry = registry;
+    }
+
+    /// <summary>
+    /// Gets the current provider instance, or null if not acquired.
+    /// </summary>
+    public ConfigurationProvider? Provider => _provider;
+
+    /// <summary>
+    /// Gets the current provider key.
+    /// </summary>
+    public string? ProviderKey => _providerKey;
+
+    /// <summary>
+    /// Indicates whether a provider is currently held.
+    /// </summary>
+    public bool HasProvider => _provider != null;
+
+    /// <summary>
+    /// Ensures a provider is available for the given options.
+    /// Returns true if the provider was rebuilt (options changed).
+    /// </summary>
+    /// <param name="providerOptions">The provider configuration options.</param>
+    /// <param name="onBeforeRebuild">Callback invoked BEFORE provider rebuild (for unsubscribing/cache invalidation).</param>
+    /// <returns>True if the provider was newly acquired or rebuilt.</returns>
+    public bool EnsureProvider(IProviderConfiguration providerOptions, Action? onBeforeRebuild = null)
+    {
+        var newProviderKey = providerOptions.GenerateProviderKey();
+        if (_provider != null && _providerKey == newProviderKey)
+        {
+            return false;
+        }
+
+        onBeforeRebuild?.Invoke();
+        RebuildProvider(providerOptions, newProviderKey);
+        return true;
+    }
+
+    private void RebuildProvider(IProviderConfiguration providerOptions, string? providerKey)
+    {
+        if (_providerHandle is not null)
+        {
+            Safety.DisposeQuietly(_providerHandle);
+            _providerHandle = null;
+        }
+
+        _providerHandle = _registry.Acquire(_providerType, providerOptions);
+        _provider = _providerHandle.Provider;
+        _providerKey = providerKey;
+    }
+
+    public void Dispose()
+    {
+        if (_providerHandle is not null)
+        {
+            Safety.DisposeQuietly(_providerHandle);
+            _providerHandle = null;
+        }
+
+        _provider = null;
+    }
+}

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
@@ -51,7 +51,7 @@ public class ConfigManagerDeserializationTests : IDisposable
     [Trait("Provider", "ConfigManager")]
     [Trait("Feature", "Deserialization")]
     [Trait("Priority", "High")]
-    public void GetConfig_MissingRequiredProperty_ReturnsNullAndLogsError()
+    public void Initialize_MissingRequiredProperty_ThrowsDeserializationException()
     {
         // Arrange: JSON is missing the required "Name" property
         var json = """{"Value": 42}""";
@@ -60,17 +60,14 @@ public class ConfigManagerDeserializationTests : IDisposable
             r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
             logger: _logger);
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
-        // Act
-        var result = configManager.GetConfig<ConfigWithRequired>();
+        // Act & Assert: With Master Backplane, deserialization failures at startup throw
+        var exception = Assert.Throws<ConfigurationDeserializationException>(
+            () => configManager.Initialize());
 
-        // Assert
-        Assert.Null(result);
-        Assert.True(_logger.HasLogEntry(LogLevel.Error, "ConfigWithRequired"),
-            "Expected error log entry containing type name 'ConfigWithRequired'");
-        Assert.True(_logger.HasLogEntry(LogLevel.Error, 5100),
-            "Expected error log entry with EventId 5100");
+        Assert.Single(exception.Failures);
+        Assert.Equal(typeof(ConfigWithRequired), exception.Failures[0].ConfigType);
+        Assert.Contains("Name", exception.Failures[0].Message);
     }
 
     [Fact]
@@ -78,7 +75,7 @@ public class ConfigManagerDeserializationTests : IDisposable
     [Trait("Provider", "ConfigManager")]
     [Trait("Feature", "Deserialization")]
     [Trait("Priority", "High")]
-    public void GetRequiredConfig_MissingRequiredProperty_ThrowsInvalidOperationException()
+    public void Initialize_MissingRequiredProperty_ExceptionContainsJsonPreview()
     {
         // Arrange: JSON is missing the required "Name" property
         var json = """{"Value": 42}""";
@@ -87,14 +84,14 @@ public class ConfigManagerDeserializationTests : IDisposable
             r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
             logger: _logger);
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(
-            () => configManager.GetRequiredConfig<ConfigWithRequired>());
+        var exception = Assert.Throws<ConfigurationDeserializationException>(
+            () => configManager.Initialize());
 
-        Assert.Contains("ConfigWithRequired", exception.Message);
-        Assert.Contains("hasn't been loaded yet", exception.Message);
+        // The exception should include a JSON preview
+        Assert.NotNull(exception.Failures[0].JsonPreview);
+        Assert.Contains("42", exception.Failures[0].JsonPreview);
     }
 
     [Fact]
@@ -129,7 +126,7 @@ public class ConfigManagerDeserializationTests : IDisposable
     [Trait("Provider", "ConfigManager")]
     [Trait("Feature", "Deserialization")]
     [Trait("Priority", "Medium")]
-    public void GetConfig_TypeMismatch_ReturnsNullAndLogsError()
+    public void Initialize_TypeMismatch_ThrowsDeserializationException()
     {
         // Arrange: JSON has a string where an int is expected
         var json = """{"Count": "not-a-number"}""";
@@ -138,15 +135,13 @@ public class ConfigManagerDeserializationTests : IDisposable
             r => [r.For<ConfigWithInt>().FromStaticJson(json)],
             logger: _logger);
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
-        // Act
-        var result = configManager.GetConfig<ConfigWithInt>();
+        // Act & Assert: With Master Backplane, deserialization failures at startup throw
+        var exception = Assert.Throws<ConfigurationDeserializationException>(
+            () => configManager.Initialize());
 
-        // Assert
-        Assert.Null(result);
-        Assert.True(_logger.HasLogEntry(LogLevel.Error, "ConfigWithInt"),
-            "Expected error log entry containing type name 'ConfigWithInt'");
+        Assert.Single(exception.Failures);
+        Assert.Equal(typeof(ConfigWithInt), exception.Failures[0].ConfigType);
     }
 
     [Fact]
@@ -154,49 +149,27 @@ public class ConfigManagerDeserializationTests : IDisposable
     [Trait("Provider", "ConfigManager")]
     [Trait("Feature", "Deserialization")]
     [Trait("Priority", "Medium")]
-    public void GetConfig_DeserializationFailure_LogContainsJsonContent()
+    public void Initialize_MultipleFailures_ThrowsExceptionWithAllFailures()
     {
-        // Arrange: JSON is missing required property
-        var json = """{"Value": 123}""";
+        // Arrange: Both configs will fail
+        var json1 = """{"Value": 123}"""; // Missing Name
+        var json2 = """{"Count": "not-a-number"}"""; // Type mismatch
 
         var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
+            r => [
+                r.For<ConfigWithRequired>().FromStaticJson(json1),
+                r.For<ConfigWithInt>().FromStaticJson(json2)
+            ],
             logger: _logger);
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
-        // Act
-        var result = configManager.GetConfig<ConfigWithRequired>();
+        // Act & Assert
+        var exception = Assert.Throws<ConfigurationDeserializationException>(
+            () => configManager.Initialize());
 
-        // Assert
-        Assert.Null(result);
-        var logEntry = _logger.FindEntry(LogLevel.Error, "ConfigWithRequired");
-        Assert.NotNull(logEntry);
-        Assert.Contains("123", logEntry.Message); // JSON content should be in the log
-    }
-
-    [Fact]
-    [Trait("Type", "Unit")]
-    [Trait("Provider", "ConfigManager")]
-    [Trait("Feature", "Deserialization")]
-    [Trait("Priority", "Medium")]
-    public void TryGetConfig_MissingRequiredProperty_ReturnsFalse()
-    {
-        // Arrange: JSON is missing the required "Name" property
-        var json = """{"Value": 42}""";
-
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
-            logger: _logger);
-        TrackForDisposal(configManager);
-        configManager.Initialize();
-
-        // Act
-        var success = configManager.TryGetConfig<ConfigWithRequired>(out var result);
-
-        // Assert
-        Assert.False(success);
-        Assert.Null(result);
+        Assert.Equal(2, exception.Failures.Count);
+        Assert.Contains(exception.Failures, f => f.ConfigType == typeof(ConfigWithRequired));
+        Assert.Contains(exception.Failures, f => f.ConfigType == typeof(ConfigWithInt));
     }
 
     [Fact]
@@ -224,5 +197,31 @@ public class ConfigManagerDeserializationTests : IDisposable
         Assert.Equal(0, result.Value); // Default value
         Assert.False(_logger.HasLogEntry(LogLevel.Error, "deserialize"),
             "No error should be logged for successful deserialization");
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Provider", "ConfigManager")]
+    [Trait("Feature", "Deserialization")]
+    [Trait("Priority", "High")]
+    public void GetConfig_AfterSuccessfulInit_ReturnsCachedInstance()
+    {
+        // Arrange: Valid JSON
+        var json = """{"Name": "test", "Value": 42}""";
+
+        var configManager = new ConfigManager(
+            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
+            logger: _logger);
+        TrackForDisposal(configManager);
+        configManager.Initialize();
+
+        // Act: Get config multiple times
+        var result1 = configManager.GetConfig<ConfigWithRequired>();
+        var result2 = configManager.GetConfig<ConfigWithRequired>();
+
+        // Assert: Same instance returned (no re-deserialization)
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+        Assert.Same(result1, result2);
     }
 }

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
@@ -141,8 +141,9 @@ public class ConfigManagerIsolationTests : IDisposable
 
     [Fact]
     [Trait("Type", "Unit")]
-    public void GetConfig_WithNonExistentType_ShouldReturnDefault()
+    public void GetConfig_WithNonExistentType_ShouldThrow()
     {
+        // With Master Backplane architecture, GetConfig throws when no rule is registered
         var testConfig = new DatabaseConfig { ConnectionString = "test" };
         var rules = new List<ConfigRule>
         {
@@ -153,9 +154,11 @@ public class ConfigManagerIsolationTests : IDisposable
         TrackForDisposal(configManager);
         configManager.Initialize();
 
-        var result = configManager.GetConfig<ApiConfig>(); // Different type not configured
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            configManager.GetConfig<ApiConfig>()); // Different type not configured
 
-        Assert.Null(result);
+        Assert.Contains("ApiConfig", exception.Message);
+        Assert.Contains("No configuration rule is registered", exception.Message);
     }
 
     [Fact]
@@ -225,6 +228,7 @@ public class ConfigManagerIsolationTests : IDisposable
     [Trait("Type", "Unit")]
     public void GetRequiredConfig_WithNonExistentType_ShouldThrowInvalidOperationException()
     {
+        // GetRequiredConfig now delegates to GetConfig, which throws when no rule exists
         var testConfig = new DatabaseConfig();
         var rules = new List<ConfigRule>
         {
@@ -235,11 +239,13 @@ public class ConfigManagerIsolationTests : IDisposable
         TrackForDisposal(configManager);
         configManager.Initialize();
 
-        var exception = Assert.Throws<InvalidOperationException>(() => 
+#pragma warning disable CS0618 // Type or member is obsolete
+        var exception = Assert.Throws<InvalidOperationException>(() =>
             configManager.GetRequiredConfig<ApiConfig>());
-        
+#pragma warning restore CS0618
+
         Assert.Contains("ApiConfig", exception.Message);
-        Assert.Contains("hasn't been loaded", exception.Message);
+        Assert.Contains("No configuration rule is registered", exception.Message);
     }
 
     #endregion

--- a/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
@@ -468,9 +468,11 @@ public class StaticJsonProviderIsolationTests
         using var manager = new ConfigManager(rules => [
             rules.For<TestConfig>().FromStaticJson(json).When(useWhen)
         ]).Initialize();
-        // If TEST_ENV is not set, config should not be available
-        var config = manager.GetConfig<TestConfig>();
-        // Can't guarantee TEST_ENV value, just verify rule is created
+
+        // Use TryGetConfig since the rule may be skipped depending on TEST_ENV
+        // GetConfig would throw if the condition is false and rule is skipped
+        var hasConfig = manager.TryGetConfig<TestConfig>(out _);
+        // hasConfig will be true if TEST_ENV == "true", false otherwise
     }
 
     #endregion

--- a/src/tests/Cocoar.Configuration.Core.Tests/TestUtilities/ActiveWaitHelpers.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/TestUtilities/ActiveWaitHelpers.cs
@@ -31,14 +31,21 @@ public static class ActiveWaitHelpers
         
         while (stopwatch.Elapsed < timeout)
         {
-            if (condition())
+            try
             {
-                return;
+                if (condition())
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                // Condition threw (e.g., accessing property on incomplete state) - treat as "not yet met"
             }
 
             await Task.Delay(pollInterval);
         }
-        
+
         throw new TimeoutException($"Timeout waiting for {description} after {timeout}");
     }
 
@@ -65,14 +72,21 @@ public static class ActiveWaitHelpers
         
         while (stopwatch.Elapsed < timeout)
         {
-            if (await condition())
+            try
             {
-                return;
+                if (await condition())
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                // Condition threw (e.g., accessing property on incomplete state) - treat as "not yet met"
             }
 
             await Task.Delay(pollInterval);
         }
-        
+
         throw new TimeoutException($"Timeout waiting for {description} after {timeout}");
     }
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
@@ -139,17 +139,19 @@ public class DifferentialCorrectnessFuzzTests : IDisposable
             await Task.Delay(100);
         }
 
-        // Wait for final configuration to settle
+        // Compute expected result from current provider states
+        var naiveResult = ComputeNaiveFullMerge(providers.Select(p => p.Value).ToList());
+
+        // Wait for incremental config to catch up with all debounced changes
         await ActiveWaitHelpers.WaitUntilAsync(
             () => {
                 var config = configManager.GetConfig<FuzzConfig>();
-                return config != null;
+                return config != null && config.Data.Count == naiveResult.Count;
             },
             timeout: TimeSpan.FromSeconds(5),
-            description: "random change sequence completion");
+            description: "incremental config to match expected key count");
 
         var incrementalConfig = configManager.GetConfig<FuzzConfig>();
-        var naiveResult = ComputeNaiveFullMerge(providers.Select(p => p.Value).ToList());
 
         ValidateResultsMatch(incrementalConfig, naiveResult);
     }

--- a/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
@@ -84,36 +84,35 @@ public class AutomaticRegistrationTests
     }
 
     [Fact]
-    public void AutoRegistered_Types_Should_Have_Different_Instances_Across_Scopes()
+    public void AutoRegistered_Types_Should_Have_Same_Cached_Instance_Across_Scopes()
     {
-        // Arrange
+        // With Master Backplane architecture, configuration instances are cached globally.
+        // All scopes receive the same cached instance.
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]);
-        
+
         var sp = services.BuildServiceProvider();
-        
+
         // Act - Get instances from different scopes
         AppConfig? instance1;
         AppConfig? instance2;
-        
+
         using (var scope1 = sp.CreateScope())
         {
             instance1 = scope1.ServiceProvider.GetRequiredService<AppConfig>();
         }
-        
+
         using (var scope2 = sp.CreateScope())
         {
             instance2 = scope2.ServiceProvider.GetRequiredService<AppConfig>();
         }
-        
-        // Assert - Different instances across scopes (Scoped behavior)
-        Assert.NotSame(instance1, instance2);
-        
-        // But same values
-        Assert.Equal(instance1.Name, instance2.Name);
-        Assert.Equal(instance1.Version, instance2.Version);
+
+        // Assert - Same cached instance across scopes (Master Backplane behavior)
+        Assert.Same(instance1, instance2);
+        Assert.Equal("TestApp", instance1.Name);
+        Assert.Equal(1, instance1.Version);
     }
 
     [Fact]

--- a/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
@@ -7,14 +7,21 @@ using Xunit;
 
 namespace Cocoar.Configuration.DI.Tests;
 
+/// <summary>
+/// Tests for exposed type registration.
+///
+/// IMPORTANT: With the Master Backplane architecture (v5.0+), configuration instances
+/// are cached globally. All resolved services return the same cached instance.
+/// </summary>
 public class ExposedTypeRegistrationTests
 {
     public interface ITestConfig { string Value { get; } }
     public record TestConfig(string Value) : ITestConfig;
 
     [Fact]
-    public void ExposedType_Default_Registers_As_Scoped()
+    public void ExposedType_Default_Returns_Same_Cached_Instance()
     {
+        // With Master Backplane architecture, all scopes receive the same cached instance
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
@@ -34,7 +41,9 @@ public class ExposedTypeRegistrationTests
 
         using var scope2 = sp.CreateScope();
         var scoped2 = scope2.ServiceProvider.GetRequiredService<ITestConfig>();
-        Assert.NotSame(scoped1a, scoped2); // different across scopes
+
+        // With Master Backplane, all instances are the same cached object
+        Assert.Same(scoped1a, scoped2);
         Assert.Equal("Hello", scoped1a.Value);
         Assert.Equal("Hello", scoped2.Value);
     }
@@ -42,6 +51,8 @@ public class ExposedTypeRegistrationTests
     [Fact]
     public void ExposedType_Can_Override_Lifetime_And_Add_Keyed_Registrations()
     {
+        // With Master Backplane architecture, all instances are the same cached object
+        // regardless of DI lifetime settings
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
@@ -59,14 +70,11 @@ public class ExposedTypeRegistrationTests
         Assert.Same(def1, def2);
         Assert.Equal("Hello", def1.Value);
 
-        // Keyed should be transient (new instance each resolve)
+        // Keyed transient - but with Master Backplane, still returns same cached instance
         var k1a = sp.GetRequiredKeyedService<ITestConfig>("my-key");
         var k1b = sp.GetRequiredKeyedService<ITestConfig>("my-key");
-        Assert.NotSame(k1a, k1b);
+        Assert.Same(k1a, k1b); // Same cached instance
         Assert.Equal("Hello", k1a.Value);
         Assert.Equal("Hello", k1b.Value);
     }
 }
-
-
-

--- a/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
@@ -8,6 +8,18 @@ using Xunit;
 
 namespace Cocoar.Configuration.DI.Tests;
 
+/// <summary>
+/// Tests for service lifetime capabilities.
+///
+/// IMPORTANT: With the Master Backplane architecture (v5.0+), configuration instances
+/// are cached globally. This means:
+/// - GetConfig always returns the same cached instance
+/// - DI lifetime settings (Scoped/Transient) don't create new configuration instances
+/// - The instance only changes when the configuration is recomputed (e.g., file change)
+///
+/// The DI lifetime still affects when the service is resolved within the container,
+/// but the underlying configuration instance is always the same cached object.
+/// </summary>
 public class ServiceLifetimeCapabilityTests
 {
     private record TestService(int Value);
@@ -22,11 +34,11 @@ public class ServiceLifetimeCapabilityTests
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton()
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
         var instance2 = sp.GetRequiredService<TestService>();
-        
+
         Assert.Same(instance1, instance2);
         Assert.Equal(42, instance1.Value);
     }
@@ -40,51 +52,54 @@ public class ServiceLifetimeCapabilityTests
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Singleton)
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
         var instance2 = sp.GetRequiredService<TestService>();
-        
+
         Assert.Same(instance1, instance2);
         Assert.Equal(42, instance1.Value);
     }
 
     [Fact]
-    public void AsTransient_Should_Create_Different_Instances()
+    public void AsTransient_Returns_Same_Cached_Instance()
     {
+        // With Master Backplane architecture, configuration instances are cached globally.
+        // AsTransient affects DI container behavior but doesn't create new config instances.
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsTransient()
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
         var instance2 = sp.GetRequiredService<TestService>();
-        
-        Assert.NotSame(instance1, instance2);
+
+        // Both return the same cached instance from the backplane
+        Assert.Same(instance1, instance2);
         Assert.Equal(123, instance1.Value);
-        Assert.Equal(123, instance2.Value);
     }
 
     [Fact]
-    public void RegisterAs_Transient_Should_Create_Different_Instances()
+    public void RegisterAs_Transient_Returns_Same_Cached_Instance()
     {
+        // With Master Backplane architecture, configuration instances are cached globally.
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Transient)
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
         var instance2 = sp.GetRequiredService<TestService>();
-        
-        Assert.NotSame(instance1, instance2);
+
+        // Both return the same cached instance from the backplane
+        Assert.Same(instance1, instance2);
         Assert.Equal(123, instance1.Value);
-        Assert.Equal(123, instance2.Value);
     }
 
     [Fact]
@@ -96,36 +111,37 @@ public class ServiceLifetimeCapabilityTests
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Scoped, "my-key")
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance = sp.GetRequiredKeyedService<TestService>("my-key");
-        
+
         Assert.NotNull(instance);
         Assert.Equal(999, instance.Value);
     }
 
     [Fact]
-    public void Default_Registration_Should_Be_Scoped()
+    public void Default_Registration_Returns_Same_Cached_Instance()
     {
+        // With Master Backplane architecture, configuration instances are cached globally.
+        // All scopes receive the same cached instance.
         var services = new ServiceCollection();
         services.AddCocoarConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(555))).Required()
         ], setup => [
             setup.ConcreteType<TestService>() // No explicit lifetime specified
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         using var scope1 = sp.CreateScope();
         using var scope2 = sp.CreateScope();
-        
+
         var instance1a = scope1.ServiceProvider.GetRequiredService<TestService>();
         var instance1b = scope1.ServiceProvider.GetRequiredService<TestService>();
         var instance2 = scope2.ServiceProvider.GetRequiredService<TestService>();
-        
-        // Same instance within scope
+
+        // All instances are the same cached object from the backplane
         Assert.Same(instance1a, instance1b);
-        // Different instance across scopes
-        Assert.NotSame(instance1a, instance2);
+        Assert.Same(instance1a, instance2);
     }
 
     [Fact]
@@ -137,11 +153,11 @@ public class ServiceLifetimeCapabilityTests
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton("singleton-key")
         ]);
-        
+
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredKeyedService<TestService>("singleton-key");
         var instance2 = sp.GetRequiredKeyedService<TestService>("singleton-key");
-        
+
         Assert.Same(instance1, instance2); // Should be same instance (singleton)
         Assert.Equal(777, instance1.Value);
     }
@@ -155,13 +171,10 @@ public class ServiceLifetimeCapabilityTests
         ], setup => [
             setup.ConcreteType<TestService>().DisableAutoRegistration()
         ]);
-        
+
         var sp = services.BuildServiceProvider();
-        
+
         // Service should not be registered
         Assert.Throws<InvalidOperationException>(() => sp.GetRequiredService<TestService>());
     }
 }
-
-
-

--- a/src/tests/Cocoar.Configuration.Providers.Tests/TestUtilities/ActiveWaitHelpers.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/TestUtilities/ActiveWaitHelpers.cs
@@ -15,9 +15,16 @@ public static class ActiveWaitHelpers
         
         while (stopwatch.Elapsed < timeout)
         {
-            if (condition())
+            try
             {
-                return;
+                if (condition())
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                // Condition threw (e.g., accessing property on incomplete JSON) - treat as "not yet met"
             }
 
             await Task.Delay(pollInterval);

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Cocoar.Configuration.Core;
 using Cocoar.Configuration.Fluent;
 using Cocoar.Configuration.Providers;
@@ -11,6 +12,39 @@ public record ConfigWithSecret
     public string? Name { get; init; }
     public Secret<string>? Password { get; init; }
     public Secret<int>? ApiKey { get; init; }
+}
+
+/// <summary>
+/// Configuration with nullable inner types: Secret&lt;T?&gt;
+/// </summary>
+public record ConfigWithNullableInnerSecrets
+{
+    public string? Name { get; init; }
+    public Secret<string?>? NullableStringSecret { get; init; }
+    public Secret<int?>? NullableIntSecret { get; init; }
+    public Secret<bool?>? NullableBoolSecret { get; init; }
+}
+
+/// <summary>
+/// Configuration with non-nullable Secret containing nullable inner type.
+/// The Secret itself is required, but the value inside can be null.
+/// </summary>
+public record ConfigWithRequiredNullableInnerSecrets
+{
+    public string? Name { get; init; }
+    public required Secret<string?> RequiredStringSecret { get; init; }
+    public required Secret<int?> RequiredIntSecret { get; init; }
+}
+
+/// <summary>
+/// Configuration with non-nullable Secret containing non-nullable inner type.
+/// Neither the Secret nor the value inside can be null.
+/// </summary>
+public record ConfigWithNonNullableSecrets
+{
+    public string? Name { get; init; }
+    public required Secret<string> RequiredStringSecret { get; init; }
+    public required Secret<int> RequiredIntSecret { get; init; }
 }
 
 /// <summary>
@@ -234,4 +268,362 @@ public class AllowPlaintextTests
         Assert.DoesNotContain("plaintext JSON", ex.Message);  // Not a plaintext error
         Assert.Contains("test-key", ex.Message);  // Error is about the missing certificate
     }
+
+    #region Secret<T> - Non-Nullable Inner Type Behavior with null JSON
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void JsonDeserialize_Int_FromNull_Throws()
+    {
+        // Verify baseline behavior: JsonSerializer.Deserialize<int>("null") should throw
+        var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("null"));
+        Assert.Contains("could not be converted", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NonNullableInnerSecret_ValueType_WithNullJson_DeserializationFails()
+    {
+        // Secret<int> (non-nullable value type) with null JSON:
+        // The converter throws JsonException because int cannot be null.
+        // With Master Backplane architecture, deserialization failures at startup throw.
+        var json = """{"Name":"TestApp","RequiredStringSecret":"test","RequiredIntSecret":null}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        );
+
+        // Deserialization fails at startup with Master Backplane architecture
+        var ex = Assert.Throws<ConfigurationDeserializationException>(() => manager.Initialize());
+        Assert.Contains("Secret<Int32>", ex.Failures[0].Message);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NonNullableInnerSecret_ReferenceType_WithNullJson_SecretContainsNull()
+    {
+        // LIMITATION: Secret<string> (non-nullable reference type) with null JSON:
+        // At runtime, we cannot distinguish between 'string' and 'string?' - they're the same type.
+        // C# nullable reference types are compile-time only annotations.
+        // Therefore, the converter creates a Secret containing null.
+        var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        var config = manager.GetConfig<ConfigWithNonNullableSecrets>();
+        Assert.NotNull(config);
+        Assert.NotNull(config!.RequiredStringSecret);
+
+        // The Secret exists but contains null - we can't enforce non-nullable reference types at runtime
+        using var lease = config.RequiredStringSecret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NonNullableInnerSecret_WithValidValues_Works()
+    {
+        // Arrange - Secret<int> and Secret<string> with valid values
+        var json = """{"Name":"TestApp","RequiredStringSecret":"password","RequiredIntSecret":42}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNonNullableSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        using var stringLease = config!.RequiredStringSecret.Open();
+        Assert.Equal("password", stringLease.Value);
+        using var intLease = config.RequiredIntSecret.Open();
+        Assert.Equal(42, intLease.Value);
+    }
+
+    #endregion
+
+    #region Secret<T?> - Nullable Inner Type JSON Deserialization Tests
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void RequiredNullableInnerSecret_Int_WithNullValue_SecretContainsNull()
+    {
+        // Arrange - Secret<int?> (non-nullable container) should contain null, not BE null
+        // This is the key test: when someone declares `required Secret<int?> Port`, they want
+        // a Secret that contains null inside, NOT a null Secret.
+        var json = """{"Name":"TestApp","RequiredStringSecret":"test","RequiredIntSecret":null}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithRequiredNullableInnerSecrets>();
+
+        // Assert - The Secret should exist and contain null
+        Assert.NotNull(config);
+        Assert.NotNull(config!.RequiredIntSecret);  // Secret itself is NOT null
+        using var lease = config.RequiredIntSecret.Open();
+        Assert.Null(lease.Value);  // But the value inside IS null
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void RequiredNullableInnerSecret_String_WithNullValue_SecretContainsNull()
+    {
+        // Arrange - Secret<string?> with null value
+        var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithRequiredNullableInnerSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.NotNull(config!.RequiredStringSecret);
+        using var lease = config.RequiredStringSecret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_String_WithValue_DeserializesSuccessfully()
+    {
+        // Arrange - Secret<string?> with an actual value
+        var json = """{"Name":"TestApp","NullableStringSecret":"secret-value"}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.NotNull(config!.NullableStringSecret);
+        using var lease = config.NullableStringSecret!.Open();
+        Assert.Equal("secret-value", lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_String_WithNull_CreatesSecretContainingNull()
+    {
+        // Arrange - Secret<string?>? with explicit null JSON value
+        // When the inner type accepts null (string?), the converter creates a Secret containing null
+        // rather than returning null for the Secret itself. This ensures consistent behavior
+        // regardless of whether the property is declared as Secret<T?>? or Secret<T?>.
+        var json = """{"Name":"TestApp","NullableStringSecret":null}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert - The Secret exists but contains null
+        Assert.NotNull(config);
+        Assert.NotNull(config!.NullableStringSecret);
+        using var lease = config.NullableStringSecret!.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_Int_WithValue_DeserializesSuccessfully()
+    {
+        // Arrange - Secret<int?> with an actual value
+        var json = """{"Name":"TestApp","NullableIntSecret":42}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.NotNull(config!.NullableIntSecret);
+        using var lease = config.NullableIntSecret!.Open();
+        Assert.Equal(42, lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_Int_WithNull_CreatesSecretContainingNull()
+    {
+        // Arrange - Secret<int?>? with explicit null JSON value
+        var json = """{"Name":"TestApp","NullableIntSecret":null}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert - The Secret exists but contains null
+        Assert.NotNull(config);
+        Assert.NotNull(config!.NullableIntSecret);
+        using var lease = config.NullableIntSecret!.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_Bool_WithValue_DeserializesSuccessfully()
+    {
+        // Arrange - Secret<bool?> with an actual value
+        var json = """{"Name":"TestApp","NullableBoolSecret":true}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.NotNull(config!.NullableBoolSecret);
+        using var lease = config.NullableBoolSecret!.Open();
+        Assert.True(lease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_AllTypesWithValues_DeserializesSuccessfully()
+    {
+        // Arrange - All nullable inner secrets with values
+        var json = """{"Name":"TestApp","NullableStringSecret":"password","NullableIntSecret":123,"NullableBoolSecret":false}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.Equal("TestApp", config!.Name);
+
+        Assert.NotNull(config.NullableStringSecret);
+        using var stringLease = config.NullableStringSecret!.Open();
+        Assert.Equal("password", stringLease.Value);
+
+        Assert.NotNull(config.NullableIntSecret);
+        using var intLease = config.NullableIntSecret!.Open();
+        Assert.Equal(123, intLease.Value);
+
+        Assert.NotNull(config.NullableBoolSecret);
+        using var boolLease = config.NullableBoolSecret!.Open();
+        Assert.False(boolLease.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "Secrets")]
+    public void NullableInnerSecret_MissingFromJson_RemainsNull()
+    {
+        // Arrange - Secret<T?> properties not present in JSON
+        var json = """{"Name":"TestApp"}""";
+
+        var manager = new ConfigManager(
+            rules => [
+                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+            ],
+            setup => [
+                setup.Secrets().AllowPlaintext()
+            ]
+        ).Initialize();
+
+        // Act
+        var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
+
+        // Assert - All Secret<T?> properties should be null (not set)
+        Assert.NotNull(config);
+        Assert.Equal("TestApp", config!.Name);
+        Assert.Null(config.NullableStringSecret);
+        Assert.Null(config.NullableIntSecret);
+        Assert.Null(config.NullableBoolSecret);
+    }
+
+    #endregion
 }

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/EdgeCasesTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/EdgeCasesTests.cs
@@ -170,4 +170,109 @@ public class EdgeCasesTests
         Assert.Contains("plaintext JSON instead of an encrypted envelope", ex.Message);
         Assert.Contains("Pre-encrypted envelopes are required", ex.Message);
     }
+
+    #region Secret<T?> - Nullable Inner Type Tests
+
+    [Fact]
+    public void Secret_NullableString_WithValue()
+    {
+        // Secret<string?> with an actual value
+        var secret = Secret<string?>.FromPlain("hello");
+        using var lease = secret.Open();
+        Assert.Equal("hello", lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableString_WithNull()
+    {
+        // Secret<string?> with null value
+        var secret = Secret<string?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableInt_WithValue()
+    {
+        // Secret<int?> with an actual value
+        var secret = Secret<int?>.FromPlain(42);
+        using var lease = secret.Open();
+        Assert.Equal(42, lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableInt_WithNull()
+    {
+        // Secret<int?> with null value - properly supports Nullable<T> value types
+        var secret = Secret<int?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableLong_WithValue()
+    {
+        var secret = Secret<long?>.FromPlain(9876543210L);
+        using var lease = secret.Open();
+        Assert.Equal(9876543210L, lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableLong_WithNull()
+    {
+        var secret = Secret<long?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableDouble_WithValue()
+    {
+        var secret = Secret<double?>.FromPlain(3.14159);
+        using var lease = secret.Open();
+        Assert.Equal(3.14159, lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableDouble_WithNull()
+    {
+        var secret = Secret<double?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableBool_WithValue()
+    {
+        var secret = Secret<bool?>.FromPlain(true);
+        using var lease = secret.Open();
+        Assert.True(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableBool_WithNull()
+    {
+        var secret = Secret<bool?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableGuid_WithValue()
+    {
+        var guid = Guid.NewGuid();
+        var secret = Secret<Guid?>.FromPlain(guid);
+        using var lease = secret.Open();
+        Assert.Equal(guid, lease.Value);
+    }
+
+    [Fact]
+    public void Secret_NullableGuid_WithNull()
+    {
+        var secret = Secret<Guid?>.FromPlain(null);
+        using var lease = secret.Open();
+        Assert.Null(lease.Value);
+    }
+
+    #endregion
 }

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
@@ -184,10 +184,10 @@ public class ErrorMessageTests
                 rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
             ]
             // NOTE: No setup.Secrets() - deserialization will fail
-        ).Initialize();
+        );
 
-        // Act & Assert - deserialization fails, not Open()
-        var ex = Assert.ThrowsAny<Exception>(() => manager.GetConfig<ConfigWithSecretString>());
+        // Act & Assert - With Master Backplane, deserialization fails at startup
+        var ex = Assert.Throws<ConfigurationDeserializationException>(() => manager.Initialize());
 
         // The error is about JSON deserialization, not about secrets infrastructure
         Assert.Contains("Deserialization", ex.Message);


### PR DESCRIPTION
## Summary

This PR implements a major architectural change that introduces eager deserialization and atomic configuration updates. The new "Master Backplane" architecture ensures configuration consistency across all types and provides fail-fast behavior at startup.

**Key improvements:**
- Atomic updates - all configuration types succeed or all rollback together
- Eager deserialization - deserialize once during recompute, not on every `GetConfig()` call
- Fail-fast at startup - deserialization errors throw immediately instead of silently returning null
- Cached instances - `GetConfig<T>()` returns the same cached instance (no re-deserialization)
- Cleaner API - `GetConfig<T>()` now returns `T` and throws if no rule exists

## Breaking Changes

### `GetConfig<T>()` signature and behavior changed

```csharp
// Before (v4.x)
T? GetConfig<T>();  // Returns null if no rule exists or deserialization fails

// After (v5.0)
T GetConfig<T>();   // Throws if no rule exists; never null after successful init
```

**Migration:** Use `TryGetConfig<T>(out var value)` for safe access without exceptions.

### Startup deserialization failures now throw

```csharp
// Before: Silent failure
var config = manager.GetConfig<MyConfig>(); // Returns null on error

// After: Explicit failure
var manager = new ConfigManager(...).Initialize(); // Throws ConfigurationDeserializationException
```

### `GetRequiredConfig<T>()` deprecated

Since `GetConfig<T>()` now throws when no rule exists, `GetRequiredConfig<T>()` is redundant and marked `[Obsolete]`.

## New Types

| Type | Description |
|------|-------------|
| `ConfigSnapshot` | Immutable container for all deserialized config instances at a point in time |
| `ConfigSnapshotBuilder` | Collects deserialization results with failure tracking |
| `MasterBackplane` | Single source of truth with `BehaviorSubject<ConfigSnapshot>` |
| `ConfigurationDeserializationException` | Thrown at startup when any type fails to deserialize |
| `DeserializationFailure` | Record containing failure details (type, message, exception, JSON preview) |
| `DeserializationStatus` | Health tracking for deserialization state |

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| Rule exists, deserialization succeeds | Returns `T` | Returns `T` (cached) |
| Rule exists, deserialization fails at startup | Returns `null` | Throws `ConfigurationDeserializationException` |
| Rule exists, deserialization fails at runtime | Returns `null` | Keeps last good config, Health = Degraded |
| No rule registered for type | Returns `null` | Throws `InvalidOperationException` |
| Multiple `GetConfig<T>()` calls | Re-deserializes each time | Returns same cached instance |
| Cross-type dependencies | Partial updates possible | Atomic - all succeed or all rollback |

## Architecture Overview

```
┌─────────────────────────────────────────────────────────────────┐
│                    MASTER BACKPLANE                             │
│         BehaviorSubject<ConfigSnapshot>                         │
│  { AppSettings: instance1, DbConfig: instance2, ... }           │
│         (Single source of truth - atomic updates)               │
└─────────────────────────────────────────────────────────────────┘
        │                     │                     │
        ▼                     ▼                     ▼
 IReactiveConfig<T1>   IReactiveConfig<T2>   GetConfig<T>()
   (projected)           (projected)         (cache lookup)
```

## Files Changed

### New Files
- `src/Cocoar.Configuration/Core/ConfigSnapshot.cs`
- `src/Cocoar.Configuration/Core/ConfigSnapshotBuilder.cs`
- `src/Cocoar.Configuration/Core/MasterBackplane.cs`

### Modified Core Files
- `ConfigurationState.cs` - Integrated MasterBackplane, startup phase tracking
- `ConfigurationAccessor.cs` - Simplified to use backplane, throws on missing rules
- `ConfigurationEngine.cs` - Passes registry/scope for eager deserialization
- `ConfigManager.cs` - Updated return types, wired backplane
- `ConfigurationHealthModels.cs` - Added `DeserializationStatus`
- `IConfigurationAccessor.cs` - Changed return types, added `[Obsolete]` attributes

### Modified Reactive Files
- `ReactiveConfigManager.cs` - Uses backplane projections
- `ReactiveConfigurationFactory.cs` - Removed class constraint for tuple support
- `ReactiveTupleConfig.cs` - Uses backplane's SnapshotStream

### Also Included
- `SecretJsonConverter.cs` - Improved nullability handling for `Secret<T?>`
- `Secret.cs` - Added `TypeAcceptsNull()` helper for nullable value types

## Test Plan

- [x] All 426 existing tests pass
- [x] Tests updated to expect new throwing behavior
- [x] Tests updated to expect same cached instance across scopes
- [x] IReactiveConfig tests pass
- [x] Tuple support tests pass
- [x] Interface (ExposeAs) tests pass
- [x] Secrets tests pass

## Consumer Migration Guide

### If you check for null after GetConfig:
```csharp
// Before
var config = manager.GetConfig<MyConfig>();
if (config != null) { ... }

// After - Option 1: Use TryGetConfig
if (manager.TryGetConfig<MyConfig>(out var config)) { ... }

// After - Option 2: Just use GetConfig (throws if no rule)
var config = manager.GetConfig<MyConfig>(); // Never null after init
```

### If you use GetRequiredConfig:
```csharp
// Before
var config = manager.GetRequiredConfig<MyConfig>();

// After - Just use GetConfig (same behavior now)
var config = manager.GetConfig<MyConfig>();
```

### If you catch deserialization errors:
```csharp
// Before - errors returned null silently
var config = manager.GetConfig<MyConfig>(); // null on error

// After - errors throw at startup
try {
    var manager = new ConfigManager(...).Initialize();
} catch (ConfigurationDeserializationException ex) {
    // ex.Failures contains all deserialization errors
    foreach (var failure in ex.Failures) {
        Console.WriteLine($"{failure.ConfigType.Name}: {failure.Message}");
    }
}
```

### Important: Don't mutate config instances
```csharp
var config = manager.GetConfig<MyConfig>();
// DON'T DO THIS - instance is shared across all consumers!
// config.SomeProperty = "new value";
```

