### PR TITLE
Refactor ConfigManager API to use Builder Pattern

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(find:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,6 @@ local/
 .local/
 
 nul
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@
 **NEW: ConfigManager Builder API**
 - New `ConfigManager.Create()` static factory method with fluent builder pattern for creating fully-initialized ConfigManager instances
 - Single entry point replaces split construction/initialization pattern (`new ConfigManager(...).Initialize()`)
-- Builder groups concerns logically: `.WithConfiguration()` for rules/setup, `.UseLogger()` for logging, `.UseDebounce()` for debounce timing
+- Builder groups concerns logically: `.UseConfiguration()` for rules/setup, `.UseLogger()` for logging, `.UseDebounce()` for debounce timing
 - Satellite libraries can extend the builder via extension methods (e.g., `.WithSecretsSetup()`)
+
+**NEW: `ConfigManager.CreateAsync()` factory method**
+- Async counterpart to `ConfigManager.Create()` for console apps and scenarios where blocking the calling thread during provider I/O is undesirable
+- Supports cancellation via `CancellationToken` — passes through to every provider call during startup
+- Uses a fully async initialization pipeline; no sync-over-async anywhere on the hot path
+
+**IMPROVED: Runtime recomputes are now fully async**
+- Provider-triggered recomputes (file changes, HTTP polls, observable emissions) now yield the calling threadpool thread during async I/O instead of occupying it for the full duration
+- Previously, `ScheduleRecompute` wrapped async provider calls with `.GetAwaiter().GetResult()`; it now dispatches via `ScheduleAsync` and awaits the async recompute path end-to-end
+- No API changes; behavior is transparently improved for all callers
 
 **NEW: `WithSecretsSetup()` Extension Method**
 - Dedicated builder extension for configuring secrets, replacing `setup.Secrets()` in the setup lambda
@@ -18,12 +28,12 @@
 ### Changed
 
 **BREAKING: ConfigManager constructors and `Initialize()` are now `internal`**
-- Use `ConfigManager.Create(c => c.WithConfiguration(...))` instead of `new ConfigManager(...).Initialize()`
+- Use `ConfigManager.Create(c => c.UseConfiguration(...))` instead of `new ConfigManager(...).Initialize()`
 - See [Migration Guide v4→v5](docs/migration-v4-to-v5.md) for detailed migration instructions
 
 **BREAKING: `AddCocoarConfiguration()` now uses the builder API**
 - Old: `services.AddCocoarConfiguration(rule => [...], setup => [...])`
-- New: `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...], setup => [...]))`
+- New: `services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [...], setup => [...]))`
 - Same change applies to `WebApplicationBuilder.AddCocoarConfiguration()`
 - Provides access to the full builder API in DI scenarios, including `.WithSecretsSetup()` and other satellite extensions
 
@@ -42,7 +52,7 @@ var manager = new ConfigManager(
 
 // v5.0
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json")
     ])
     .UseLogger(myLogger));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - New `ConfigManager.Create()` static factory method with fluent builder pattern for creating fully-initialized ConfigManager instances
 - Single entry point replaces split construction/initialization pattern (`new ConfigManager(...).Initialize()`)
 - Builder groups concerns logically: `.UseConfiguration()` for rules/setup, `.UseLogger()` for logging, `.UseDebounce()` for debounce timing
-- Satellite libraries can extend the builder via extension methods (e.g., `.WithSecretsSetup()`)
+- Satellite libraries can extend the builder via extension methods (e.g., `.UseSecretsSetup()`)
 
 **NEW: `ConfigManager.CreateAsync()` factory method**
 - Async counterpart to `ConfigManager.Create()` for console apps and scenarios where blocking the calling thread during provider I/O is undesirable
@@ -20,10 +20,18 @@
 - Previously, `ScheduleRecompute` wrapped async provider calls with `.GetAwaiter().GetResult()`; it now dispatches via `ScheduleAsync` and awaits the async recompute path end-to-end
 - No API changes; behavior is transparently improved for all callers
 
-**NEW: `WithSecretsSetup()` Extension Method**
+**NEW: `UseSecretsSetup()` Extension Method**
 - Dedicated builder extension for configuring secrets, replacing `setup.Secrets()` in the setup lambda
 - Leverages the Cocoar.Capabilities system for cross-assembly extensibility
 - Cleaner separation: secrets configuration is now independent of the setup pipeline
+
+**BREAKING: Testing API redesigned to be per-concern and fluent**
+- `ReplaceAllRules()` → `ReplaceConfiguration()` — returns `TestOverrideBuilder` (fluent, disposable)
+- `AppendTestRules()` → `AppendConfiguration()` — returns `TestOverrideBuilder` (fluent, disposable)
+- `WithSetup()` removed — setup-only override was broken and redundant in v5
+- New `ReplaceSecretsSetup()` extension on `TestOverrideBuilder` (from `Cocoar.Configuration.Secrets`) for independent secrets override
+- Per-concern independence: mix `ReplaceConfiguration().ReplaceSecretsSetup()` or `AppendConfiguration().ReplaceSecretsSetup()` freely
+- Fixture pattern: `new TestOverrideBuilder()` (public no-arg ctor) → call `.Build()` → pass to `CocoarTestConfiguration.Apply()`
 
 ### Changed
 
@@ -35,11 +43,11 @@
 - Old: `services.AddCocoarConfiguration(rule => [...], setup => [...])`
 - New: `services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [...], setup => [...]))`
 - Same change applies to `WebApplicationBuilder.AddCocoarConfiguration()`
-- Provides access to the full builder API in DI scenarios, including `.WithSecretsSetup()` and other satellite extensions
+- Provides access to the full builder API in DI scenarios, including `.UseSecretsSetup()` and other satellite extensions
 
 **BREAKING: Secrets setup moved from `setup` lambda to dedicated builder method**
 - Old: `setup => [setup.Secrets().UseCertificateFromFile("cert.pfx")]`
-- New: `.WithSecretsSetup(secrets => secrets.UseCertificateFromFile("cert.pfx"))`
+- New: `.UseSecretsSetup(secrets => secrets.UseCertificateFromFile("cert.pfx"))`
 
 ### Migration from v4.x
 
@@ -84,7 +92,7 @@ See [Migration Guide v4→v5](docs/migration-v4-to-v5.md) for all patterns.
 - New `AllowPlaintext()` fluent API to conditionally allow plaintext JSON values to be deserialized into `Secret<T>` properties
 - Useful for development and testing scenarios where encrypted envelopes are not available
 - **SECURITY WARNING**: Only enable in development/test environments; production should always use encrypted envelopes
-- Example: `.WithSecretsSetup(secrets => secrets.AllowPlaintext(builder.Environment.IsDevelopment()))` (v5.0+ syntax)
+- Example: `.UseSecretsSetup(secrets => secrets.AllowPlaintext(builder.Environment.IsDevelopment()))` (v5.0+ syntax)
 
 **NEW: Testing Setup Overrides**
 - Extended `CocoarTestConfiguration` to support setup overrides in addition to rule overrides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [5.0.0] - unreleased
+
+### Added
+
+**NEW: ConfigManager Builder API**
+- New `ConfigManager.Create()` static factory method with fluent builder pattern for creating fully-initialized ConfigManager instances
+- Single entry point replaces split construction/initialization pattern (`new ConfigManager(...).Initialize()`)
+- Builder groups concerns logically: `.WithConfiguration()` for rules/setup, `.UseLogger()` for logging, `.UseDebounce()` for debounce timing
+- Satellite libraries can extend the builder via extension methods (e.g., `.WithSecretsSetup()`)
+
+**NEW: `WithSecretsSetup()` Extension Method**
+- Dedicated builder extension for configuring secrets, replacing `setup.Secrets()` in the setup lambda
+- Leverages the Cocoar.Capabilities system for cross-assembly extensibility
+- Cleaner separation: secrets configuration is now independent of the setup pipeline
+
+### Changed
+
+**BREAKING: ConfigManager constructors and `Initialize()` are now `internal`**
+- Use `ConfigManager.Create(c => c.WithConfiguration(...))` instead of `new ConfigManager(...).Initialize()`
+- See [Migration Guide v4→v5](docs/migration-v4-to-v5.md) for detailed migration instructions
+
+**BREAKING: `AddCocoarConfiguration()` now uses the builder API**
+- Old: `services.AddCocoarConfiguration(rule => [...], setup => [...])`
+- New: `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...], setup => [...]))`
+- Same change applies to `WebApplicationBuilder.AddCocoarConfiguration()`
+- Provides access to the full builder API in DI scenarios, including `.WithSecretsSetup()` and other satellite extensions
+
+**BREAKING: Secrets setup moved from `setup` lambda to dedicated builder method**
+- Old: `setup => [setup.Secrets().UseCertificateFromFile("cert.pfx")]`
+- New: `.WithSecretsSetup(secrets => secrets.UseCertificateFromFile("cert.pfx"))`
+
+### Migration from v4.x
+
+```csharp
+// v4.x
+var manager = new ConfigManager(
+    rule => [rule.For<AppSettings>().FromFile("config.json")],
+    logger: myLogger
+).Initialize();
+
+// v5.0
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("config.json")
+    ])
+    .UseLogger(myLogger));
+```
+
+See [Migration Guide v4→v5](docs/migration-v4-to-v5.md) for all patterns.
+
 ## [4.2.1] - 2026-02-03
 
 ### Fixed
@@ -21,10 +71,10 @@
   - `ISecret<T>` properties in configuration classes automatically deserialize to `Secret<T>` instances
 
 **NEW: AllowPlaintext() for Secrets**
-- New `setup.Secrets().AllowPlaintext()` fluent API to conditionally allow plaintext JSON values to be deserialized into `Secret<T>` properties
+- New `AllowPlaintext()` fluent API to conditionally allow plaintext JSON values to be deserialized into `Secret<T>` properties
 - Useful for development and testing scenarios where encrypted envelopes are not available
 - **SECURITY WARNING**: Only enable in development/test environments; production should always use encrypted envelopes
-- Example: `setup => [setup.Secrets().AllowPlaintext(builder.Environment.IsDevelopment())]`
+- Example: `.WithSecretsSetup(secrets => secrets.AllowPlaintext(builder.Environment.IsDevelopment()))` (v5.0+ syntax)
 
 **NEW: Testing Setup Overrides**
 - Extended `CocoarTestConfiguration` to support setup overrides in addition to rule overrides

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ SetupDefinition.GetComposer(builder).Add(new ServiceLifetimeCapability<T>(...));
 
 **Provider Consistency** - All providers return empty `{}` on failure (not null). Optional rules degrade gracefully with C# defaults; required rules roll back the entire recompute.
 
-**Test Configuration** - `CocoarTestConfiguration` uses `AsyncLocal<T>` for test isolation. Supports `ReplaceAllRules()` (skip originals) and `AppendTestRules()` (override).
+**Test Configuration** - `CocoarTestConfiguration` uses `AsyncLocal<T>` for test isolation. Supports `ReplaceConfiguration()` (skip originals), `AppendConfiguration()` (last-write-wins), and `ReplaceSecretsSetup()` (independent secrets override). Each concern is independent — chain freely on the returned `TestOverrideBuilder`.
 
 ### Project Structure
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ### Shouldn't configuration be this easy?
 ```csharp
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
         rule.For<AppSettings>().FromEnvironment("APP_")
     ]));
@@ -79,7 +79,7 @@ public class MyService(IOptions<AppSettings> options)
 ```csharp
 // Startup configuration
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("appsettings.json").Select("App")
     ]));
 
@@ -104,7 +104,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Define your configuration rules
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
         rule.For<AppSettings>().FromEnvironment("APP_"),
         rule.For<DatabaseConfig>().FromFile("appsettings.json").Select("Database")
@@ -168,7 +168,7 @@ public class ConfigHub : Hub
 ### Layer Configuration Sources
 ```csharp
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("appsettings.json"),           // Base
         rule.For<AppSettings>().FromFile("appsettings.Production.json"), // Environment
         rule.For<AppSettings>().FromEnvironment("APP_"),                 // Overrides
@@ -216,7 +216,7 @@ invoke.exe @target=server #issue=123 %env=prod
 Map arguments to specific configuration types:
 ```csharp
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromCommandLine("app_"),
         rule.For<DatabaseConfig>().FromCommandLine("db_")
     ]));
@@ -289,7 +289,7 @@ rule.For<ApiSettings>().FromHttpPolling(accessor =>
 ### Interface Exposure
 ```csharp
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rule => [rule.For<AppSettings>().FromFile("appsettings.json")],
         setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]));
 
@@ -310,7 +310,7 @@ public class AppSettings
 }
 
 builder.Services.AddCocoarConfiguration(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rule => [rule.For<AppSettings>().FromEnvironment()],  // or FromFile, FromHttpPolling, etc.
         setup => [
             // Map interface to concrete type for deserialization
@@ -362,7 +362,7 @@ public class AppSettings
 
 // Configure secrets via the builder API
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json")
     ])
     .WithSecretsSetup(secrets => secrets

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json")
     ])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")
         .WithKeyId("dev-secrets")));
 
@@ -428,12 +428,13 @@ Cocoar.Configuration provides first-class testing support with `CocoarTestConfig
 public async Task TestWithOverriddenConfig()
 {
     // Set test configuration BEFORE creating WebApplicationFactory
-    CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => testDbConfig)
     ]);
 
     await using var factory = new WebApplicationFactory<Program>();
     // Original rules are skipped - only test rules execute
+    // Scope is automatically cleared when disposed
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@
 
 ### Shouldn't configuration be this easy?
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
-    rule.For<AppSettings>().FromEnvironment("APP_")
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
+        rule.For<AppSettings>().FromEnvironment("APP_")
+    ]));
 ```
 It is. `AppSettings` is now injectable — and automatically updates when configs change.
 
@@ -77,9 +78,10 @@ public class MyService(IOptions<AppSettings> options)
 **After (Cocoar.Configuration):**
 ```csharp
 // Startup configuration
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromFile("appsettings.json").Select("App")
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("appsettings.json").Select("App")
+    ]));
 
 // Direct injection - no wrapper
 public class MyService(AppSettings settings)
@@ -101,11 +103,12 @@ public class MyService(IReactiveConfig<AppSettings> config)
 var builder = WebApplication.CreateBuilder(args);
 
 // Define your configuration rules
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
-    rule.For<AppSettings>().FromEnvironment("APP_"),
-    rule.For<DatabaseConfig>().FromFile("appsettings.json").Select("Database")
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("appsettings.json").Select("App"),
+        rule.For<AppSettings>().FromEnvironment("APP_"),
+        rule.For<DatabaseConfig>().FromFile("appsettings.json").Select("Database")
+    ]));
 
 var app = builder.Build();
 
@@ -164,12 +167,13 @@ public class ConfigHub : Hub
 
 ### Layer Configuration Sources
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromFile("appsettings.json"),           // Base
-    rule.For<AppSettings>().FromFile("appsettings.Production.json"), // Environment
-    rule.For<AppSettings>().FromEnvironment("APP_"),                 // Overrides
-    rule.For<AppSettings>().FromCommandLine()                        // Final overrides (highest priority)
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("appsettings.json"),           // Base
+        rule.For<AppSettings>().FromFile("appsettings.Production.json"), // Environment
+        rule.For<AppSettings>().FromEnvironment("APP_"),                 // Overrides
+        rule.For<AppSettings>().FromCommandLine()                        // Final overrides (highest priority)
+    ]));
 // Rules execute in order - last write wins
 ```
 
@@ -211,10 +215,11 @@ invoke.exe @target=server #issue=123 %env=prod
 **Prefix filtering for command-line arguments:**
 Map arguments to specific configuration types:
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppConfig>().FromCommandLine("app_"),
-    rule.For<DatabaseConfig>().FromCommandLine("db_")
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromCommandLine("app_"),
+        rule.For<DatabaseConfig>().FromCommandLine("db_")
+    ]));
 ```
 ```bash
 dotnet run --app_host=localhost --db_connectionstring="Server=localhost"
@@ -283,11 +288,10 @@ rule.For<ApiSettings>().FromHttpPolling(accessor =>
 
 ### Interface Exposure
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromFile("appsettings.json")
-], setup => [
-    setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(
+        rule => [rule.For<AppSettings>().FromFile("appsettings.json")],
+        setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]));
 
 // Both AppSettings and IAppSettings are injectable
 public class MyService(IAppSettings settings) { }
@@ -305,12 +309,13 @@ public class AppSettings
     public ILoggingConfig Logging { get; set; }  // Interface property!
 }
 
-builder.Services.AddCocoarConfiguration(rule => [
-    rule.For<AppSettings>().FromEnvironment()  // or FromFile, FromHttpPolling, etc.
-], setup => [
-    // Map interface to concrete type for deserialization
-    setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>()
-]);
+builder.Services.AddCocoarConfiguration(c => c
+    .WithConfiguration(
+        rule => [rule.For<AppSettings>().FromEnvironment()],  // or FromFile, FromHttpPolling, etc.
+        setup => [
+            // Map interface to concrete type for deserialization
+            setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>()
+        ]));
 ```
 
 **Why is this needed?** When loading configuration from JSON sources (files, environment variables, HTTP), properties typed as interfaces cannot be deserialized directly. This mapping tells the deserializer which concrete type to instantiate.
@@ -355,7 +360,17 @@ public class AppSettings
     public Secret<DatabaseCredentials> DatabaseSecret { get; set; }
 }
 
+// Configure secrets via the builder API
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("config.json")
+    ])
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificateFromFile("secrets.pfx")
+        .WithKeyId("dev-secrets")));
+
 // Use secrets safely
+var settings = manager.GetConfig<AppSettings>();
 using var exposed = settings.DatabaseSecret.Open();
 var connectionString = BuildConnectionString(exposed.Value);
 // Secret automatically zeroized when disposed
@@ -398,6 +413,7 @@ Explore real-world scenarios in the [examples](src/Examples/) directory:
 | Testing with Configuration Overrides | [Testing Overrides](docs/testing-overrides-quickref.md) |
 | Intelligent Certificate Caching | [Certificate Caching](src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md) |
 | Provider Guidance | [Provider Guidance](docs/provider-guidance.md) |
+| Migration from v4.x | [Migration Guide v4→v5](docs/migration-v4-to-v5.md) |
 | Migration from v2.x | [Migration Guide v2→v3](docs/migration-v2-to-v3.md) |
 | Migration from v1.x | [Migration Guide v1→v2](docs/migration-v1-to-v2.md) |
 

--- a/docs/analyzers/COCFG001.md
+++ b/docs/analyzers/COCFG001.md
@@ -1,0 +1,32 @@
+# COCFG001 — Secret Path Conflict Detected
+
+## What it detects
+
+Two or more configuration rules target the same type and include overlapping secret paths,
+which can cause one rule's secrets to silently overwrite another's after decryption.
+
+## Why it matters
+
+Secret values are decrypted and stored in memory. If two rules contribute secrets to the
+same configuration type with conflicting paths, the last rule wins silently, potentially
+discarding secrets that were meant to be additive.
+
+## Example
+
+### Non-compliant
+```csharp
+rules.For<DbConfig>().FromFile("base.json"),   // contains ConnectionString secret
+rules.For<DbConfig>().FromFile("local.json")   // also contains ConnectionString secret
+```
+
+### Compliant
+```csharp
+// Use MountAt to give each rule its own namespace, or ensure only one rule owns the secret path
+rules.For<DbConfig>().FromFile("base.json").MountAt("Base"),
+rules.For<DbConfig>().FromFile("local.json").MountAt("Override")
+```
+
+## How to fix
+
+Ensure that each rule contributing secrets to a shared type mounts its values under a unique path,
+or consolidate secrets into a single authoritative rule.

--- a/docs/analyzers/COCFG002.md
+++ b/docs/analyzers/COCFG002.md
@@ -1,0 +1,32 @@
+# COCFG002 — Rule Dependency Ordering Violation
+
+## What it detects
+
+A configuration rule references a type from an earlier rule using `GetConfig<T>()` inside
+a provider or query factory, but the dependent rule appears *before* the rule it depends on
+in the rule list.
+
+## Why it matters
+
+Rules execute in order. If Rule B's factory calls `GetConfig<T>()` to read a value produced
+by Rule A, Rule A must appear before Rule B. Violating this order means Rule B reads stale
+or default values during initialization.
+
+## Example
+
+### Non-compliant
+```csharp
+// DbConfig depends on AppConfig, but appears first
+rules.For<DbConfig>().FromFile(cm => cm.GetConfig<AppConfig>()!.DbConfigPath),
+rules.For<AppConfig>().FromFile("appsettings.json")
+```
+
+### Compliant
+```csharp
+rules.For<AppConfig>().FromFile("appsettings.json"),
+rules.For<DbConfig>().FromFile(cm => cm.GetConfig<AppConfig>()!.DbConfigPath)
+```
+
+## How to fix
+
+Reorder rules so that each rule's dependencies appear before it in the rule list.

--- a/docs/analyzers/COCFG003.md
+++ b/docs/analyzers/COCFG003.md
@@ -1,0 +1,32 @@
+# COCFG003 — Required Rule Configuration Validation
+
+## What it detects
+
+A required rule (`.Required()`) is configured with a provider or path that is known to
+be missing or invalid at analysis time (e.g., a literal file path that does not exist).
+
+## Why it matters
+
+Required rules cause `ConfigManager.Create()` to throw if they fail. A misconfigured
+required rule will prevent the application from starting. This analyzer catches obvious
+configuration errors at compile time.
+
+## Example
+
+### Non-compliant
+```csharp
+// Hard-coded path that doesn't exist — fails at startup
+rules.For<AppSettings>().FromFile("C:/nonexistent/config.json").Required()
+```
+
+### Compliant
+```csharp
+rules.For<AppSettings>().FromFile("appsettings.json").Required()
+// Or use Optional() for paths that may not exist
+rules.For<AppSettings>().FromFile("appsettings.local.json").Optional()
+```
+
+## How to fix
+
+Verify the provider path is correct, or change `.Required()` to `.Optional()` for
+configuration files that are not guaranteed to exist in all environments.

--- a/docs/analyzers/COCFG004.md
+++ b/docs/analyzers/COCFG004.md
@@ -1,0 +1,29 @@
+# COCFG004 — Configuration Accessor Type Safety Violation
+
+## What it detects
+
+A call to `GetConfig<T>()` or `TryGetConfig<T>()` uses a type `T` that is a value type
+(struct), which is not supported. Configuration types must be reference types (classes).
+
+## Why it matters
+
+The configuration system stores and retrieves instances by type. Value types cannot be
+stored polymorphically and do not participate in the reactive change detection pipeline.
+Using a struct as a configuration type will result in a runtime error.
+
+## Example
+
+### Non-compliant
+```csharp
+var config = manager.GetConfig<MyStruct>(); // MyStruct is a struct
+```
+
+### Compliant
+```csharp
+var config = manager.GetConfig<MyClass>(); // MyClass is a class
+```
+
+## How to fix
+
+Change the configuration type from a struct to a class. If you need value semantics,
+use a record class (`record`) instead of a record struct.

--- a/docs/analyzers/COCFG005.md
+++ b/docs/analyzers/COCFG005.md
@@ -1,0 +1,32 @@
+# COCFG005 — Duplicate Unconditional Rules Detected
+
+## What it detects
+
+Two or more rules for the same configuration type are both unconditional (no `.When()` predicate)
+and use the same provider type, resulting in redundant configuration loading.
+
+## Why it matters
+
+Duplicate unconditional rules waste I/O and processing. The first rule's result is entirely
+overwritten by the second rule (last-write-wins). In most cases this is unintentional.
+
+## Example
+
+### Non-compliant
+```csharp
+rules.For<AppSettings>().FromFile("appsettings.json"),
+rules.For<AppSettings>().FromFile("appsettings.json") // identical — second overwrites first entirely
+```
+
+### Compliant
+```csharp
+// Use different files for layering
+rules.For<AppSettings>().FromFile("appsettings.json"),
+rules.For<AppSettings>().FromFile("appsettings.Production.json").When(cm => IsProduction())
+// Or deduplicate if the duplicate is accidental
+rules.For<AppSettings>().FromFile("appsettings.json")
+```
+
+## How to fix
+
+Remove the duplicate rule, or add a `.When()` condition to make the second rule conditional.

--- a/docs/analyzers/COCFG006.md
+++ b/docs/analyzers/COCFG006.md
@@ -1,0 +1,33 @@
+# COCFG006 — Static Provider Ordering Suggestion
+
+## What it detects
+
+A `FromStatic()` rule appears after a `FromFile()` or `FromEnvironment()` rule for the same
+type. Static providers are evaluated at configuration time and override dynamic providers.
+Placing a static provider last can mask changes from dynamic providers.
+
+## Why it matters
+
+`FromStatic()` values never change at runtime. If a static rule overwrites a file-based rule's
+output, hot-reload changes to the file will be silently ignored for the overwritten fields.
+
+## Example
+
+### Non-compliant
+```csharp
+rules.For<AppSettings>().FromFile("appsettings.json"),
+rules.For<AppSettings>().FromStatic(_ => new AppSettings { LogLevel = "Debug" })
+// The static value always wins — file changes to LogLevel are ignored
+```
+
+### Compliant
+```csharp
+// Put static overrides before dynamic sources so dynamic sources can override them
+rules.For<AppSettings>().FromStatic(_ => new AppSettings { LogLevel = "Info" }),
+rules.For<AppSettings>().FromFile("appsettings.json") // file can override the default
+```
+
+## How to fix
+
+Move `FromStatic()` rules before dynamic provider rules for the same type, so that dynamic
+sources can override the static defaults.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,152 @@
+# Getting Started with Cocoar.Configuration
+
+This guide walks through the most common usage patterns from basic setup to advanced scenarios.
+
+## 1. Basic Usage
+
+Load configuration from a static object or JSON string and read values:
+
+```csharp
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Providers;
+
+var manager = ConfigManager.Create(builder => builder
+    .UseConfiguration(rules => [
+        rules.For<AppSettings>().FromStaticJson(_ => """{"ApplicationName":"MyApp","EnableLogging":true}""")
+    ]));
+
+var settings = manager.GetConfig<AppSettings>();
+Console.WriteLine(settings?.ApplicationName); // "MyApp"
+```
+
+## 2. File Configuration with Hot-Reload
+
+Load configuration from a JSON file. Changes to the file trigger automatic recompute:
+
+```csharp
+var manager = ConfigManager.Create(builder => builder
+    .UseConfiguration(rules => [
+        rules.For<AppSettings>().FromFile("appsettings.json")
+    ]));
+
+var settings = manager.GetConfig<AppSettings>();
+```
+
+The configuration is automatically reloaded when the file changes on disk (debounced at 300ms by default).
+
+## 3. File Layering (Multiple Sources)
+
+Combine multiple files with last-write-wins merge semantics:
+
+```csharp
+var manager = ConfigManager.Create(builder => builder
+    .UseConfiguration(rules => [
+        rules.For<AppSettings>().FromFile("appsettings.json"),
+        rules.For<AppSettings>().FromFile("appsettings.local.json").Optional()
+    ]));
+```
+
+The second rule's values override the first (property-level merge). Missing files are ignored when marked `Optional()`.
+
+## 4. Reactive Configuration
+
+Subscribe to configuration changes for live updates:
+
+```csharp
+var reactive = manager.GetReactiveConfig<AppSettings>();
+
+// Current value (always available, never null after init)
+var current = reactive.CurrentValue;
+
+// Subscribe to future changes (also immediately emits the current value)
+using var subscription = reactive.Subscribe(settings =>
+{
+    Console.WriteLine($"Config updated: {settings.ApplicationName}");
+});
+```
+
+`IReactiveConfig<T>` uses BehaviorSubject semantics: subscribing immediately emits the current value, then emits on every change.
+
+## 5. Dependency Injection (ASP.NET Core)
+
+Register Cocoar.Configuration with the DI container:
+
+```csharp
+// Program.cs
+builder.AddCocoarConfiguration(config => config
+    .UseConfiguration(
+        rules => [
+            rules.For<AppSettings>().FromFile("appsettings.json")
+        ],
+        setup => [
+            setup.ConcreteType<AppSettings>()
+        ]));
+
+// Inject in services
+public class MyService(AppSettings settings) { ... }
+// Or reactive:
+public class MyService(IReactiveConfig<AppSettings> reactiveSettings) { ... }
+```
+
+Scoped services receive a stable snapshot per request. Singletons receive `IReactiveConfig<T>` for live updates.
+
+## 6. Async Initialization (`CreateAsync`)
+
+For console apps or any context where blocking the calling thread during provider I/O is undesirable, use `CreateAsync` instead of `Create`:
+
+```csharp
+// Non-blocking startup — no threadpool thread is occupied during file/HTTP I/O
+var manager = await ConfigManager.CreateAsync(builder => builder
+    .UseConfiguration(rules => [
+        rules.For<AppSettings>().FromFile("appsettings.json")
+    ]));
+
+var settings = manager.GetConfig<AppSettings>();
+```
+
+Pass a `CancellationToken` to cancel startup (e.g., on application shutdown signal):
+
+```csharp
+var manager = await ConfigManager.CreateAsync(
+    builder => builder.UseConfiguration(rules => [
+        rules.For<AppSettings>().FromFile("appsettings.json")
+    ]),
+    cancellationToken: stoppingToken);
+```
+
+> **Note:** In ASP.NET Core the DI integration (`AddCocoarConfiguration`) handles initialization inside the host startup pipeline — `CreateAsync` is most useful in console apps, `IHostedService.StartAsync`, or any context that already has a natural `await` point.
+
+## 7. Testing Overrides
+
+Override configuration rules in tests without modifying application code:
+
+```csharp
+// Replace all rules with test-specific rules (skips file I/O)
+using var _ = CocoarTestConfiguration.ReplaceAllRules(
+    rules => [
+        rules.For<AppSettings>().FromStatic(_ => new AppSettings { ApplicationName = "TestApp" })
+    ]);
+
+// Application code that calls ConfigManager.Create() will use the test rules
+var manager = ConfigManager.Create(appConfig);
+var settings = manager.GetConfig<AppSettings>();
+Assert.Equal("TestApp", settings?.ApplicationName);
+```
+
+For fixture-based patterns where the AsyncLocal context gap matters, use `TestConfigurationContext` and `CocoarTestConfiguration.Apply()`:
+
+```csharp
+public class MyFixture
+{
+    public TestConfigurationContext TestContext { get; } =
+        TestConfigurationContext.Replace(rules => [
+            rules.For<AppSettings>().FromStatic(_ => new AppSettings { ApplicationName = "TestApp" })
+        ]);
+}
+
+public class MyTests(MyFixture fixture) : IClassFixture<MyFixture>, IDisposable
+{
+    private readonly TestConfigurationScope _scope = CocoarTestConfiguration.Apply(fixture.TestContext);
+    public void Dispose() => _scope.Dispose();
+}
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ Override configuration rules in tests without modifying application code:
 
 ```csharp
 // Replace all rules with test-specific rules (skips file I/O)
-using var _ = CocoarTestConfiguration.ReplaceAllRules(
+using var _ = CocoarTestConfiguration.ReplaceConfiguration(
     rules => [
         rules.For<AppSettings>().FromStatic(_ => new AppSettings { ApplicationName = "TestApp" })
     ]);

--- a/docs/health-monitoring.md
+++ b/docs/health-monitoring.md
@@ -235,7 +235,7 @@ This approach keeps mapping responsibility with the provider (which has full con
 You can give rules explicit names using the `.Named()` method to make health snapshots more readable:
 
 ```csharp
-builder.AddCocoarConfiguration(rule => [
+builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<DatabaseConfig>()
         .FromFile("db.json")
         .Required()
@@ -248,7 +248,7 @@ builder.AddCocoarConfiguration(rule => [
     rule.For<ApiConfig>()
         .FromEnvironment("API_")
         .Named("API Settings")
-]);
+]));
 ```
 
 When you check health, rule names appear in the snapshot:
@@ -280,12 +280,12 @@ Console.WriteLine($"Optional failed: {summary.OptionalFailed}");
 Rules with `.When()` conditions that evaluate to `false` are marked as `Skipped`:
 
 ```csharp
-builder.AddCocoarConfiguration(rule => [
+builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<FeatureConfig>()
         .FromFile("features.json")
         .When(cfg => cfg.Get<AppConfig>().EnableFeatureX)
         .Named("Feature X Config")
-]);
+]));
 
 // If EnableFeatureX is false, this rule will have Status = Skipped
 var health = manager.GetHealthService().Snapshot;

--- a/docs/health-monitoring.md
+++ b/docs/health-monitoring.md
@@ -235,7 +235,7 @@ This approach keeps mapping responsibility with the provider (which has full con
 You can give rules explicit names using the `.Named()` method to make health snapshots more readable:
 
 ```csharp
-builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<DatabaseConfig>()
         .FromFile("db.json")
         .Required()
@@ -280,7 +280,7 @@ Console.WriteLine($"Optional failed: {summary.OptionalFailed}");
 Rules with `.When()` conditions that evaluate to `false` are marked as `Skipped`:
 
 ```csharp
-builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<FeatureConfig>()
         .FromFile("features.json")
         .When(cfg => cfg.Get<AppConfig>().EnableFeatureX)

--- a/docs/intelligent-certificate-caching.md
+++ b/docs/intelligent-certificate-caching.md
@@ -16,7 +16,7 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(new[] { rule })
+    .UseConfiguration(new[] { rule })
     .WithSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs",
             cacheDurationSeconds: 30)));  // 30 seconds (default)

--- a/docs/intelligent-certificate-caching.md
+++ b/docs/intelligent-certificate-caching.md
@@ -15,15 +15,11 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 ## Basic Usage
 
 ```csharp
-var manager = new ConfigManager(
-    new[] { rule },
-    setup => new[]
-    {
-        setup.Secrets()
-            .UseCertificatesFromFolder(@"C:\certs", 
-                passwordProvider: ctx => new[] { "SecurePass123" },
-                cacheDurationSeconds: 30)  // 30 seconds (default)
-    });
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(new[] { rule })
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificatesFromFolder(@"C:\certs",
+            cacheDurationSeconds: 30)));  // 30 seconds (default)
 ```
 
 **How It Works:**
@@ -49,17 +45,15 @@ var manager = new ConfigManager(
 ```csharp
 // Critical secrets - no cache, load fresh every time
 // Folder structure: C:\certs\pci\pci-data\*.pfx
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\pci", 
-        passwordProvider: ctx => new[] { "password" },
-        cacheDurationSeconds: 0);
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\pci",
+        cacheDurationSeconds: 0))
 
 // Standard secrets - balanced 30-second cache
 // Folder structure: C:\certs\api\api-keys\*.pfx
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\api", 
-        passwordProvider: ctx => new[] { "password" },
-        cacheDurationSeconds: 30);
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\api",
+        cacheDurationSeconds: 30))
 ```
 
 ---

--- a/docs/intelligent-certificate-caching.md
+++ b/docs/intelligent-certificate-caching.md
@@ -17,7 +17,7 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(new[] { rule })
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs",
             cacheDurationSeconds: 30)));  // 30 seconds (default)
 ```
@@ -45,13 +45,13 @@ var manager = ConfigManager.Create(c => c
 ```csharp
 // Critical secrets - no cache, load fresh every time
 // Folder structure: C:\certs\pci\pci-data\*.pfx
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\pci",
         cacheDurationSeconds: 0))
 
 // Standard secrets - balanced 30-second cache
 // Folder structure: C:\certs\api\api-keys\*.pfx
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\api",
         cacheDurationSeconds: 30))
 ```

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -7,19 +7,19 @@ This guide explains how to migrate from v4.x to v5.0, which introduces the **Con
 v5.0 introduces two major breaking changes:
 
 1. **`ConfigManager` constructors and `Initialize()` are now `internal`** — use `ConfigManager.Create()` instead
-2. **`AddCocoarConfiguration()` now uses the builder API** — use `AddCocoarConfiguration(c => c.WithConfiguration(...))` instead of `AddCocoarConfiguration(rule => [...])`
+2. **`AddCocoarConfiguration()` now uses the builder API** — use `AddCocoarConfiguration(c => c.UseConfiguration(...))` instead of `AddCocoarConfiguration(rule => [...])`
 
 ### Migration Table
 
 | v4.x API | v5.0 API |
 |----------|----------|
-| `new ConfigManager(rules).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules))` |
-| `new ConfigManager(rules, setup).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules, setup))` |
-| `new ConfigManager(rules, logger: l).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(l))` |
-| `new ConfigManager(rules, debounceMilliseconds: 50).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(50))` |
-| `services.AddCocoarConfiguration(rule => [...])` | `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...]))` |
-| `services.AddCocoarConfiguration(rule => [...], setup => [...])` | `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...], setup => [...]))` |
-| `builder.AddCocoarConfiguration(rule => [...])` | `builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...]))` |
+| `new ConfigManager(rules).Initialize()` | `ConfigManager.Create(c => c.UseConfiguration(rules))` |
+| `new ConfigManager(rules, setup).Initialize()` | `ConfigManager.Create(c => c.UseConfiguration(rules, setup))` |
+| `new ConfigManager(rules, logger: l).Initialize()` | `ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(l))` |
+| `new ConfigManager(rules, debounceMilliseconds: 50).Initialize()` | `ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(50))` |
+| `services.AddCocoarConfiguration(rule => [...])` | `services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [...]))` |
+| `services.AddCocoarConfiguration(rule => [...], setup => [...])` | `services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [...], setup => [...]))` |
+| `builder.AddCocoarConfiguration(rule => [...])` | `builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [...]))` |
 
 ## Why the Change?
 
@@ -30,7 +30,7 @@ The old API had two problems:
 
 The new API solves both:
 - `ConfigManager.Create()` returns a **fully-initialized** instance — no `Initialize()` needed
-- The builder groups concerns logically: `.WithConfiguration()` for rules/setup, `.UseLogger()` for logging, etc.
+- The builder groups concerns logically: `.UseConfiguration()` for rules/setup, `.UseLogger()` for logging, etc.
 - The builder provides extension points (`.AfterBuild()`) for satellite libraries
 
 ## Quick Examples
@@ -48,7 +48,7 @@ var manager = new ConfigManager(rule => [
 **After (v5.0):**
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json"),
         rule.For<DbSettings>().FromEnvironment("DB_")
     ]));
@@ -71,7 +71,7 @@ var manager = new ConfigManager(
 **After (v5.0):**
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rule => [
             rule.For<AppSettings>().FromFile("config.json")
         ],
@@ -94,7 +94,7 @@ var manager = new ConfigManager(
 **After (v5.0):**
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json")
     ])
     .UseLogger(myLogger)
@@ -113,7 +113,7 @@ var manager = new ConfigManager(rules, logger: NullLogger.Instance).Initialize()
 ```csharp
 var rules = new[] { rule1, rule2, rule3 };
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rules)
+    .UseConfiguration(rules)
     .UseLogger(NullLogger.Instance));
 ```
 
@@ -134,7 +134,7 @@ var manager = new ConfigManager(
 **After (v5.0):**
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rule => [rule.For<AppConfig>().FromFile("config.json")])
     .WithSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")
@@ -158,7 +158,7 @@ services.AddCocoarConfiguration(
 **After (v5.0):**
 ```csharp
 services.AddCocoarConfiguration(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rule => [rule.For<AppSettings>().FromFile("config.json")],
         setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]));
 ```
@@ -166,7 +166,7 @@ services.AddCocoarConfiguration(c => c
 **ASP.NET Core:**
 ```csharp
 builder.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppSettings>().FromFile("config.json")
     ]));
 ```
@@ -174,7 +174,7 @@ builder.AddCocoarConfiguration(c => c
 **With Secrets:**
 ```csharp
 services.AddCocoarConfiguration(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile("config.json")
     ])
     .WithSecretsSetup(secrets => secrets
@@ -192,7 +192,7 @@ var manager = new ConfigManager(rule => [...]).Initialize();
 services.AddCocoarConfiguration(manager);
 
 // After:
-var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [...]));
+var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [...]));
 services.AddCocoarConfiguration(manager);
 ```
 
@@ -202,12 +202,12 @@ For most cases, find/replace works:
 
 ### Pattern 1: Chained Initialize
 **Find:** `new ConfigManager(rule => [`
-**Replace with:** `ConfigManager.Create(c => c.WithConfiguration(rule => [`
+**Replace with:** `ConfigManager.Create(c => c.UseConfiguration(rule => [`
 
 Then replace the closing `).Initialize()` with `))`.
 
 ### Pattern 2: Separate Initialize
-Remove the `.Initialize()` call and wrap the constructor in `ConfigManager.Create(c => c.WithConfiguration(...))`.
+Remove the `.Initialize()` call and wrap the constructor in `ConfigManager.Create(c => c.UseConfiguration(...))`.
 
 ## What Stays the Same
 

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -1,0 +1,226 @@
+# Migration Guide: v4.x → v5.0
+
+This guide explains how to migrate from v4.x to v5.0, which introduces the **ConfigManager Builder API** — a single entry point for creating fully-initialized ConfigManager instances.
+
+## Overview
+
+v5.0 introduces two major breaking changes:
+
+1. **`ConfigManager` constructors and `Initialize()` are now `internal`** — use `ConfigManager.Create()` instead
+2. **`AddCocoarConfiguration()` now uses the builder API** — use `AddCocoarConfiguration(c => c.WithConfiguration(...))` instead of `AddCocoarConfiguration(rule => [...])`
+
+### Migration Table
+
+| v4.x API | v5.0 API |
+|----------|----------|
+| `new ConfigManager(rules).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules))` |
+| `new ConfigManager(rules, setup).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules, setup))` |
+| `new ConfigManager(rules, logger: l).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(l))` |
+| `new ConfigManager(rules, debounceMilliseconds: 50).Initialize()` | `ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(50))` |
+| `services.AddCocoarConfiguration(rule => [...])` | `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...]))` |
+| `services.AddCocoarConfiguration(rule => [...], setup => [...])` | `services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...], setup => [...]))` |
+| `builder.AddCocoarConfiguration(rule => [...])` | `builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [...]))` |
+
+## Why the Change?
+
+The old API had two problems:
+
+1. **Split construction/initialization** — `new ConfigManager(...)` created an uninitialized object, requiring a separate `.Initialize()` call. Forgetting `Initialize()` led to subtle bugs.
+2. **Mixed concerns in the constructor** — Rules, setup, logger, debounce, and provider factory were all positional/optional parameters on one constructor.
+
+The new API solves both:
+- `ConfigManager.Create()` returns a **fully-initialized** instance — no `Initialize()` needed
+- The builder groups concerns logically: `.WithConfiguration()` for rules/setup, `.UseLogger()` for logging, etc.
+- The builder provides extension points (`.AfterBuild()`) for satellite libraries
+
+## Quick Examples
+
+### Basic Rules
+
+**Before (v4.x):**
+```csharp
+var manager = new ConfigManager(rule => [
+    rule.For<AppSettings>().FromFile("config.json"),
+    rule.For<DbSettings>().FromEnvironment("DB_")
+]).Initialize();
+```
+
+**After (v5.0):**
+```csharp
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("config.json"),
+        rule.For<DbSettings>().FromEnvironment("DB_")
+    ]));
+```
+
+### Rules with Setup
+
+**Before (v4.x):**
+```csharp
+var manager = new ConfigManager(
+    rule => [
+        rule.For<AppSettings>().FromFile("config.json")
+    ],
+    setup => [
+        setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()
+    ]
+).Initialize();
+```
+
+**After (v5.0):**
+```csharp
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(
+        rule => [
+            rule.For<AppSettings>().FromFile("config.json")
+        ],
+        setup => [
+            setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()
+        ]));
+```
+
+### With Logger and Debounce
+
+**Before (v4.x):**
+```csharp
+var manager = new ConfigManager(
+    rule => [rule.For<AppSettings>().FromFile("config.json")],
+    logger: myLogger,
+    debounceMilliseconds: 50
+).Initialize();
+```
+
+**After (v5.0):**
+```csharp
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("config.json")
+    ])
+    .UseLogger(myLogger)
+    .UseDebounce(50));
+```
+
+### Pre-built Rules (IEnumerable)
+
+**Before (v4.x):**
+```csharp
+var rules = new[] { rule1, rule2, rule3 };
+var manager = new ConfigManager(rules, logger: NullLogger.Instance).Initialize();
+```
+
+**After (v5.0):**
+```csharp
+var rules = new[] { rule1, rule2, rule3 };
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rules)
+    .UseLogger(NullLogger.Instance));
+```
+
+### Secrets Configuration
+
+**Before (v4.x):**
+```csharp
+var manager = new ConfigManager(
+    rule => [rule.For<AppConfig>().FromFile("config.json")],
+    setup => [
+        setup.Secrets()
+            .UseCertificateFromFile("secrets.pfx")
+            .WithKeyId("dev-secrets")
+    ]
+).Initialize();
+```
+
+**After (v5.0):**
+```csharp
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(
+        rule => [rule.For<AppConfig>().FromFile("config.json")])
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificateFromFile("secrets.pfx")
+        .WithKeyId("dev-secrets")));
+```
+
+> **Note:** Secrets setup is now a dedicated extension method `WithSecretsSetup()` on the builder,
+> rather than part of the `setup` lambda. This provides better separation of concerns.
+
+## DI and ASP.NET Core
+
+`AddCocoarConfiguration()` now uses the same builder API as `ConfigManager.Create()`:
+
+**Before (v4.x):**
+```csharp
+services.AddCocoarConfiguration(
+    rule => [rule.For<AppSettings>().FromFile("config.json")],
+    setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]);
+```
+
+**After (v5.0):**
+```csharp
+services.AddCocoarConfiguration(c => c
+    .WithConfiguration(
+        rule => [rule.For<AppSettings>().FromFile("config.json")],
+        setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]));
+```
+
+**ASP.NET Core:**
+```csharp
+builder.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppSettings>().FromFile("config.json")
+    ]));
+```
+
+**With Secrets:**
+```csharp
+services.AddCocoarConfiguration(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile("config.json")
+    ])
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificateFromFile("secrets.pfx")
+        .WithKeyId("dev-secrets")));
+```
+
+### Pre-built ConfigManager
+
+You can still pass a pre-built `ConfigManager` instance:
+
+```csharp
+// Before:
+var manager = new ConfigManager(rule => [...]).Initialize();
+services.AddCocoarConfiguration(manager);
+
+// After:
+var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [...]));
+services.AddCocoarConfiguration(manager);
+```
+
+## Automated Migration
+
+For most cases, find/replace works:
+
+### Pattern 1: Chained Initialize
+**Find:** `new ConfigManager(rule => [`
+**Replace with:** `ConfigManager.Create(c => c.WithConfiguration(rule => [`
+
+Then replace the closing `).Initialize()` with `))`.
+
+### Pattern 2: Separate Initialize
+Remove the `.Initialize()` call and wrap the constructor in `ConfigManager.Create(c => c.WithConfiguration(...))`.
+
+## What Stays the Same
+
+- Rule building API: `rule.For<T>().FromFile(...)`, `.Select()`, `.Required()`, `.When()`, etc.
+- Setup builder API: `setup.ConcreteType<T>().ExposeAs<I>()`
+- `AddCocoarConfiguration()` extension methods (now use builder API)
+- Reactive configuration: `IReactiveConfig<T>`
+- Health monitoring
+- Testing overrides: `CocoarTestConfiguration`
+- All provider implementations
+
+## Need Help?
+
+- Check the [examples](../src/Examples/) — all updated to v5.0
+- Review the [test suite](../src/tests/) for real-world patterns
+- See the [API documentation](../README.md) for current patterns

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -136,12 +136,12 @@ var manager = new ConfigManager(
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(
         rule => [rule.For<AppConfig>().FromFile("config.json")])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")
         .WithKeyId("dev-secrets")));
 ```
 
-> **Note:** Secrets setup is now a dedicated extension method `WithSecretsSetup()` on the builder,
+> **Note:** Secrets setup is now a dedicated extension method `UseSecretsSetup()` on the builder,
 > rather than part of the `setup` lambda. This provides better separation of concerns.
 
 ## DI and ASP.NET Core
@@ -177,7 +177,7 @@ services.AddCocoarConfiguration(c => c
     .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile("config.json")
     ])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")
         .WithKeyId("dev-secrets")));
 ```
@@ -208,6 +208,7 @@ Then replace the closing `).Initialize()` with `))`.
 
 ### Pattern 2: Separate Initialize
 Remove the `.Initialize()` call and wrap the constructor in `ConfigManager.Create(c => c.UseConfiguration(...))`.
+
 
 ## What Stays the Same
 

--- a/docs/reactive-config.md
+++ b/docs/reactive-config.md
@@ -40,7 +40,7 @@ This makes `IReactiveConfig<T>` **bulletproof** under real-world conditions.
 ### Dependency Injection (ASP.NET Core)
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<AppSettings>().FromFile("appsettings.json"),
     rule.For<AppSettings>().FromEnvironment("APP_")
 ]));
@@ -75,7 +75,7 @@ Console.WriteLine($"Current value: {reactive.CurrentValue}");
 If you expose a concrete type as an interface via the setup API, you can also request `IReactiveConfig<IInterface>`:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(
     rule => [rule.For<AppSettings>().FromFile("appsettings.json")],
     setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]
 ));

--- a/docs/reactive-config.md
+++ b/docs/reactive-config.md
@@ -40,10 +40,10 @@ This makes `IReactiveConfig<T>` **bulletproof** under real-world conditions.
 ### Dependency Injection (ASP.NET Core)
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<AppSettings>().FromFile("appsettings.json"),
     rule.For<AppSettings>().FromEnvironment("APP_")
-]);
+]));
 
 // Automatically registers IReactiveConfig<AppSettings>
 ```
@@ -75,10 +75,10 @@ Console.WriteLine($"Current value: {reactive.CurrentValue}");
 If you expose a concrete type as an interface via the setup API, you can also request `IReactiveConfig<IInterface>`:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(
     rule => [rule.For<AppSettings>().FromFile("appsettings.json")],
     setup => [setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()]
-);
+));
 
 // Both work:
 var concrete = manager.GetReactiveConfig<AppSettings>();

--- a/docs/testing-overrides-quickref.md
+++ b/docs/testing-overrides-quickref.md
@@ -69,7 +69,7 @@ In addition to overriding rules, you can override **setup** options like `AllowP
 ### Setup-Only Override
 ```csharp
 using var _ = CocoarTestConfiguration.WithSetup(setup => [
-    setup.Secrets().AllowPlaintext()
+    setup.ConcreteType<DbConfig>()
 ]);
 ```
 - Keeps original rules unchanged
@@ -83,7 +83,7 @@ using var _ = CocoarTestConfiguration.ReplaceAllRules(
         rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test" })
     ],
     setup => [
-        setup.Secrets().AllowPlaintext()
+        setup.ConcreteType<DbConfig>()
     ]);
 ```
 - Replaces rules AND adds setup overrides
@@ -99,7 +99,7 @@ public class IntegrationTestFixture
                 rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
             ],
             setup => [
-                setup.Secrets().AllowPlaintext()
+                setup.ConcreteType<DbConfig>()
             ]);
 }
 ```
@@ -116,7 +116,7 @@ This ensures you can override specific setup options without breaking core funct
 
 ## Works Everywhere
 
-- Direct `new ConfigManager(...)`
+- Direct `ConfigManager.Create(...)`
 - `services.AddCocoarConfiguration(...)`
 - `builder.AddCocoarConfiguration(...)`
 - `new WebApplicationFactory<Program>()`
@@ -202,7 +202,7 @@ public class SimpleTests : IDisposable
             rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
         ]);
 
-        var manager = new ConfigManager(rule => [...]);
+        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [...]));
         // Uses test rules
     }
 
@@ -366,7 +366,7 @@ public async Task TestWithPlaintextSecrets()
             })
         ],
         setup => [
-            setup.Secrets().AllowPlaintext()
+            setup.ConcreteType<DbConfig>()
         ]);
 
     await using var factory = new WebApplicationFactory<Program>();
@@ -390,12 +390,12 @@ var context = TestConfigurationContext.Append(rule => [...]);
 // Replace mode with setup
 var context = TestConfigurationContext.Replace(
     rule => [...],
-    setup => [setup.Secrets().AllowPlaintext()]);
+    setup => [setup.ConcreteType<DbConfig>()]);
 
 // Append mode with setup
 var context = TestConfigurationContext.Append(
     rule => [...],
-    setup => [setup.Secrets().AllowPlaintext()]);
+    setup => [setup.ConcreteType<DbConfig>()]);
 ```
 
 ---

--- a/docs/testing-overrides-quickref.md
+++ b/docs/testing-overrides-quickref.md
@@ -13,7 +13,7 @@ using Cocoar.Configuration.Testing;
 public async Task MyIntegrationTest()
 {
     // Set BEFORE creating ConfigManager/WebApplicationFactory
-    using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => testDbConfig)
     ]);
 
@@ -27,7 +27,7 @@ public async Task MyIntegrationTest()
 
 ### Replace Mode (Skip Original Rules)
 ```csharp
-using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [...]);
+using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [...]);
 ```
 - Original providers never execute (no I/O, no failures)
 - Complete test isolation
@@ -35,7 +35,7 @@ using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [...]);
 
 ### Append Mode (Last-Write-Wins)
 ```csharp
-using var _ = CocoarTestConfiguration.AppendTestRules(rule => [...]);
+using var _ = CocoarTestConfiguration.AppendConfiguration(rule => [...]);
 ```
 - Original rules run first, test rules override
 - Partial overrides only
@@ -62,61 +62,54 @@ bool isActive = CocoarTestConfiguration.IsActive;
 
 ---
 
-## Setup Overrides
+## Secrets Overrides
 
-In addition to overriding rules, you can override **setup** options like `AllowPlaintext()` for secrets. This is useful when your tests need different setup behavior than production.
+Override `UseSecretsSetup()` independently of rule mode using the `ReplaceSecretsSetup()` extension from `Cocoar.Configuration.Secrets`.
 
-### Setup-Only Override
+### Secrets Only (No Rule Override)
 ```csharp
-using var _ = CocoarTestConfiguration.WithSetup(setup => [
-    setup.ConcreteType<DbConfig>()
-]);
+using var _ = CocoarTestConfiguration.ReplaceSecretsSetup(
+    secrets => secrets.AllowPlaintext());
 ```
-- Keeps original rules unchanged
-- Only adds/overrides setup options
-- Use when: You just need to enable test-specific capabilities
+- Original rules run unchanged
+- Only secrets setup is replaced
+- Requires `Cocoar.Configuration.Secrets` package
 
-### Rules with Setup Override
-```csharp
-using var _ = CocoarTestConfiguration.ReplaceAllRules(
-    rules => [
-        rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test" })
-    ],
-    setup => [
-        setup.ConcreteType<DbConfig>()
-    ]);
-```
-- Replaces rules AND adds setup overrides
-- Setup is always merged (not replaced), so configured setup still runs first
+### Mix and Match — Per-Concern Independence
+Each concern (`ReplaceConfiguration`, `AppendConfiguration`, `ReplaceSecretsSetup`) is independent:
 
-### Fixture-Based Pattern with Setup
 ```csharp
-public class IntegrationTestFixture
-{
-    public TestConfigurationContext TestContext { get; } =
-        TestConfigurationContext.Replace(
-            rule => [
-                rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
-            ],
-            setup => [
-                setup.ConcreteType<DbConfig>()
-            ]);
-}
+// Replace rules AND replace secrets setup
+using var _ = CocoarTestConfiguration
+    .ReplaceConfiguration(rule => [
+        rule.For<DbConfig>().FromStatic(_ => testConfig)
+    ])
+    .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+
+// Append rules AND replace secrets setup
+using var _ = CocoarTestConfiguration
+    .AppendConfiguration(rule => [
+        rule.For<FeatureFlags>().FromStatic(_ => new FeatureFlags { NewFeature = true })
+    ])
+    .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+
+// Only replace secrets setup, keep original rules
+using var _ = CocoarTestConfiguration
+    .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
 ```
 
-### How Setup Merging Works
+### How Secrets Override Works
 
-Setup is always **merged** (appended), never replaced:
-1. Configured setup runs first
-2. Test setup runs after (last-write-wins for capabilities)
-
-This ensures you can override specific setup options without breaking core functionality.
+`UseSecretsSetup()` checks for a test override before applying the configured lambda.
+When a `ReplaceSecretsSetup` override is active, the test's configure delegate runs instead of the app's.
+Calling `UseSecretsSetup()` once — original behavior replaced, no accumulation issues.
 
 ---
 
 ## Works Everywhere
 
 - Direct `ConfigManager.Create(...)`
+- `ConfigManager.CreateAsync(...)`
 - `services.AddCocoarConfiguration(...)`
 - `builder.AddCocoarConfiguration(...)`
 - `new WebApplicationFactory<Program>()`
@@ -135,7 +128,7 @@ public class MyFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         // This runs in async context A
-        CocoarTestConfiguration.ReplaceAllRules(rule => [...]);
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [...]);
     }
     // ...
 }
@@ -198,7 +191,7 @@ public class SimpleTests : IDisposable
     [Fact]
     public void Test()
     {
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
         ]);
 
@@ -297,7 +290,7 @@ The scope pattern provides exception-safe cleanup:
 [Fact]
 public async Task TestWithScope()
 {
-    using var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var scope = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test" })
     ]);
 
@@ -321,7 +314,7 @@ public async Task TestWithContainer()
 {
     await _postgres.StartAsync();
 
-    using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => new DbConfig
         {
             ConnectionString = _postgres.GetConnectionString()
@@ -340,7 +333,7 @@ public async Task TestWithContainer()
 [InlineData(false)]
 public async Task TestFeatureFlag(bool enabled)
 {
-    using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<FeatureFlags>().FromStatic(_ => new FeatureFlags
         {
             NewFeature = enabled
@@ -357,17 +350,15 @@ public async Task TestFeatureFlag(bool enabled)
 [Fact]
 public async Task TestWithPlaintextSecrets()
 {
-    // Enable plaintext secrets for testing without encryption
-    using var _ = CocoarTestConfiguration.ReplaceAllRules(
-        rule => [
+    // Replace rules AND allow plaintext secrets
+    using var _ = CocoarTestConfiguration
+        .ReplaceConfiguration(rule => [
             rule.For<ApiConfig>().FromStatic(_ => new ApiConfig
             {
                 ApiKey = new Secret<string>("test-api-key")
             })
-        ],
-        setup => [
-            setup.ConcreteType<DbConfig>()
-        ]);
+        ])
+        .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
 
     await using var factory = new WebApplicationFactory<Program>();
     // Tests can use plaintext secret values
@@ -398,6 +389,20 @@ var context = TestConfigurationContext.Append(
     setup => [setup.ConcreteType<DbConfig>()]);
 ```
 
+For the fixture pattern with secrets, use `TestOverrideBuilder`:
+```csharp
+public class IntegrationTestFixture
+{
+    public TestConfigurationContext TestContext { get; } =
+        new TestOverrideBuilder()
+            .ReplaceConfiguration(rule => [
+                rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext())
+            .Build();
+}
+```
+
 ---
 
 ## Example Project
@@ -412,3 +417,4 @@ var context = TestConfigurationContext.Append(
 - **Type-safe** - full IntelliSense
 - **Fast** - Replace mode skips I/O entirely
 - **Fixture-friendly** - Apply() bridges async context gap
+- **Per-concern** - mix Replace/Append for rules independently of secrets override

--- a/docs/testing-overrides-quickref.md
+++ b/docs/testing-overrides-quickref.md
@@ -202,7 +202,7 @@ public class SimpleTests : IDisposable
             rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
         ]);
 
-        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [...]));
+        var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [...]));
         // Uses test rules
     }
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -70,10 +70,10 @@ public async Task ConfigManager_Handles_Provider_Failure_Gracefully()
         TestRules.Failable<MyConfig>(shouldFail: true), // TestProvider, not real I/O
         TestRules.StaticJson<MyConfig>(fallbackJson)
     };
-    
-    var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
+
+    var manager = ConfigManager.Create(c => c.UseConfiguration(rules));
     var config = manager.GetConfig<MyConfig>(); // Should use fallback
-    
+
     Assert.NotNull(config);
     Assert.Equal(expectedFallbackValue, config.SomeProperty);
 }
@@ -110,15 +110,15 @@ public async Task FileProvider_Detects_File_Changes()
     using var tempDir = TempDirectoryHelper.Create();
     var configFile = Path.Combine(tempDir.Path, "config.json");
     File.WriteAllText(configFile, """{"value": 1}""");
-    
+
     var provider = new FileSourceProvider(new(tempDir.Path));
     var config1 = await provider.FetchConfigurationBytesAsync(new("config.json"));
-    
+
     File.WriteAllText(configFile, """{"value": 2}""");
     await Task.Delay(100); // Wait for file watcher
-    
+
     var config2 = await provider.FetchConfigurationBytesAsync(new("config.json"));
-    
+
     Assert.Equal(1, config1.ToJsonElement().GetProperty("value").GetInt32());
     Assert.Equal(2, config2.ToJsonElement().GetProperty("value").GetInt32());
 }
@@ -149,16 +149,16 @@ public async Task FileProvider_Detects_File_Changes()
 public void AsSingleton_Creates_Same_Instance()
 {
     var services = new ServiceCollection();
-    services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+    services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
         rules.For<MyConfig>().FromStaticJson(json).Required()
     ], setup => [
         setup.ConcreteType<MyConfig>().AsSingleton()
     ]));
-    
+
     var sp = services.BuildServiceProvider();
     var instance1 = sp.GetRequiredService<MyConfig>();
     var instance2 = sp.GetRequiredService<MyConfig>();
-    
+
     Assert.Same(instance1, instance2); // ← Verifies singleton behavior
 }
 ```
@@ -258,7 +258,7 @@ public void Service_Returns_Correct_Configuration()
 {
     var service = new MyService();
     var result = service.GetConfig();
-    
+
     Assert.Equal(expectedValue, result.Property);
     Assert.True(result.IsValid);
 }
@@ -281,7 +281,7 @@ public void Service_Is_Scoped()
     using var scope = provider.CreateScope();
     var instance1 = scope.ServiceProvider.GetService<MyService>();
     var instance2 = scope.ServiceProvider.GetService<MyService>();
-    
+
     Assert.Same(instance1, instance2); // Verifies same instance
 }
 ```
@@ -396,14 +396,14 @@ When reviewing tests, ask:
 ```csharp
 // Wait for condition
 await ActiveWaitHelpers.WaitUntilAsync(
-    () => condition, 
-    TimeSpan.FromSeconds(5), 
+    () => condition,
+    TimeSpan.FromSeconds(5),
     "description");
 
 // Wait for specific value
 var result = await ActiveWaitHelpers.WaitForValueAsync(
-    () => getValue(), 
-    TimeSpan.FromSeconds(5), 
+    () => getValue(),
+    TimeSpan.FromSeconds(5),
     "description");
 ```
 
@@ -411,9 +411,9 @@ var result = await ActiveWaitHelpers.WaitForValueAsync(
 ```csharp
 var emissions = new List<T>();
 await ObservableTestHelpers.WaitForValueAsync(
-    observable, 
-    emissions, 
-    TimeSpan.FromSeconds(5), 
+    observable,
+    emissions,
+    TimeSpan.FromSeconds(5),
     "description");
 ```
 
@@ -457,12 +457,12 @@ public async Task ConfigManager_Uses_Cached_Configuration()
         fetchCount++;
         return new MyConfig { Value = fetchCount };
     });
-    
+
     var rules = new List<ConfigRule> {
         TestRules.Cached(testProvider, cacheDuration: TimeSpan.FromMinutes(1))
     };
-    
-    var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
+
+    var manager = ConfigManager.Create(c => c.UseConfiguration(rules));
 
     var config1 = manager.GetConfig<MyConfig>();
     var config2 = manager.GetConfig<MyConfig>();
@@ -478,11 +478,11 @@ public async Task ConfigManager_Uses_Cached_Configuration()
 public async Task CacheProvider_Expires_After_Duration()
 {
     var provider = new CacheProvider<MyConfig>(innerProvider, TimeSpan.FromMilliseconds(100));
-    
+
     var config1 = await provider.FetchConfigurationBytesAsync(query);
     await Task.Delay(150); // Wait for cache expiration
     var config2 = await provider.FetchConfigurationBytesAsync(query);
-    
+
     Assert.NotSame(config1, config2); // Cache expired, new fetch
 }
 ```
@@ -519,5 +519,5 @@ dotnet test --filter "Type=Performance" --logger:trx
 
 ---
 
-**Version:** 1.0.0  
+**Version:** 1.0.0
 **Last Updated:** November 16, 2025

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -71,7 +71,7 @@ public async Task ConfigManager_Handles_Provider_Failure_Gracefully()
         TestRules.StaticJson<MyConfig>(fallbackJson)
     };
     
-    var manager = new ConfigManager(rules).Initialize();
+    var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
     var config = manager.GetConfig<MyConfig>(); // Should use fallback
     
     Assert.NotNull(config);
@@ -149,11 +149,11 @@ public async Task FileProvider_Detects_File_Changes()
 public void AsSingleton_Creates_Same_Instance()
 {
     var services = new ServiceCollection();
-    services.AddCocoarConfiguration(rules => [
+    services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
         rules.For<MyConfig>().FromStaticJson(json).Required()
     ], setup => [
         setup.ConcreteType<MyConfig>().AsSingleton()
-    ]);
+    ]));
     
     var sp = services.BuildServiceProvider();
     var instance1 = sp.GetRequiredService<MyConfig>();
@@ -462,11 +462,11 @@ public async Task ConfigManager_Uses_Cached_Configuration()
         TestRules.Cached(testProvider, cacheDuration: TimeSpan.FromMinutes(1))
     };
     
-    var manager = new ConfigManager(rules).Initialize();
-    
+    var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
+
     var config1 = manager.GetConfig<MyConfig>();
     var config2 = manager.GetConfig<MyConfig>();
-    
+
     Assert.Equal(1, fetchCount); // Only fetched once (cached)
     Assert.Same(config1, config2);
 }

--- a/src/Cocoar.Configuration.Abstractions/Core/IConfigurationAccessor.cs
+++ b/src/Cocoar.Configuration.Abstractions/Core/IConfigurationAccessor.cs
@@ -23,13 +23,13 @@ public interface IConfigurationAccessor
     /// <para><b>DO NOT mutate the returned instance.</b></para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">No configuration rule is registered for type T.</exception>
-    T GetConfig<T>();
+    T? GetConfig<T>() where T : class;
 
     /// <summary>
     /// Tries to get a configuration instance without throwing.
     /// </summary>
     /// <returns>True if configuration exists for the type; false otherwise.</returns>
-    bool TryGetConfig<T>(out T? value);
+    bool TryGetConfig<T>(out T? value) where T : class;
 
     /// <summary>
     /// Gets configuration, throwing if not found.

--- a/src/Cocoar.Configuration.Abstractions/Reactive/IReactiveConfig.cs
+++ b/src/Cocoar.Configuration.Abstractions/Reactive/IReactiveConfig.cs
@@ -4,10 +4,16 @@ namespace Cocoar.Configuration.Reactive;
 /// Provides reactive access to configuration snapshots.
 /// Emits new values whenever the underlying configuration changes, after debouncing and validation.
 /// </summary>
+/// <remarks>
+/// Implements BehaviorSubject / replay-1 semantics: calling <see cref="IObservable{T}.Subscribe"/>
+/// immediately emits the current configuration value to the new subscriber, so subscribers never
+/// miss the initial state regardless of when they subscribe.
+/// </remarks>
 public interface IReactiveConfig<out T> : IObservable<T>
 {
     /// <summary>
     /// Gets the most recent configuration snapshot.
+    /// Always reflects the last emitted value; never null after initialization completes.
     /// Safe to call at any time - will not throw if configuration is temporarily unavailable.
     /// </summary>
     T CurrentValue { get; }

--- a/src/Cocoar.Configuration.Analyzers/Analyzers/RuleOrderingAnalyzer.cs
+++ b/src/Cocoar.Configuration.Analyzers/Analyzers/RuleOrderingAnalyzer.cs
@@ -34,7 +34,7 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
         foreach (var lambda in lambdas)
         {
             // Only analyze lambdas whose body is a collection expression (rule => [...])
-            // Skip outer builder lambdas (c => c.WithConfiguration(...))
+            // Skip outer builder lambdas (c => c.UseConfiguration(...))
             if (lambda.ExpressionBody is not CollectionExpressionSyntax)
                 continue;
 
@@ -66,9 +66,9 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeRuleOrdering(SimpleLambdaExpressionSyntax lambda, SyntaxNodeAnalysisContext context)
     {
         var configuredTypes = new HashSet<string>();
-        
+
         var invocations = lambda.DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
-        
+
         foreach (var inv in invocations)
         {
             var ruleInfo = ExtractRuleInfo(inv, context.SemanticModel);
@@ -78,7 +78,7 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
             }
 
             var dependencies = ExtractDependencies(inv, context.SemanticModel);
-            
+
             foreach (var dependency in dependencies)
             {
                 if (!configuredTypes.Contains(dependency))
@@ -139,7 +139,7 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
             if (parent is InvocationExpressionSyntax parentInv)
             {
                 var memberAccess = parentInv.Expression as MemberAccessExpressionSyntax;
-                
+
                 if (memberAccess?.Name.Identifier.Text == "When")
                 {
                     var lambdaArg = parentInv.ArgumentList.Arguments.FirstOrDefault()?.Expression as SimpleLambdaExpressionSyntax;
@@ -169,7 +169,7 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
         var types = new List<string>();
 
         var invocations = lambda.DescendantNodes().OfType<InvocationExpressionSyntax>();
-        
+
         foreach (var inv in invocations)
         {
             var memberAccess = inv.Expression as MemberAccessExpressionSyntax;

--- a/src/Cocoar.Configuration.Analyzers/Analyzers/RuleOrderingAnalyzer.cs
+++ b/src/Cocoar.Configuration.Analyzers/Analyzers/RuleOrderingAnalyzer.cs
@@ -33,6 +33,11 @@ public class RuleOrderingAnalyzer : DiagnosticAnalyzer
         var lambdas = invocation.DescendantNodes().OfType<SimpleLambdaExpressionSyntax>();
         foreach (var lambda in lambdas)
         {
+            // Only analyze lambdas whose body is a collection expression (rule => [...])
+            // Skip outer builder lambdas (c => c.WithConfiguration(...))
+            if (lambda.ExpressionBody is not CollectionExpressionSyntax)
+                continue;
+
             AnalyzeRuleOrdering(lambda, context);
         }
     }

--- a/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
+++ b/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
@@ -1,10 +1,6 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Logging;
 using Cocoar.Configuration.Core;
 using Cocoar.Configuration.DI;
-using Cocoar.Configuration.Configure;
-using Cocoar.Configuration.Rules;
-using Cocoar.Configuration.Fluent;
 using Cocoar.Capabilities;
 
 namespace Cocoar.Configuration.AspNetCore;
@@ -15,22 +11,17 @@ public static class CocoarConfigurationAspNetCoreExtensions
     private static readonly CapabilityScope _capabilityScope = new();
 
     /// <summary>
-    /// Adds Cocoar configuration to the WebApplicationBuilder using a function-based rule API.
+    /// Adds Cocoar configuration to the WebApplicationBuilder using the builder API.
+    /// Provides access to the full ConfigManagerBuilder for configuring rules, setup, secrets, logging, etc.
     /// Test configuration overrides are automatically applied via ConfigManager when CocoarTestConfiguration is active.
     /// </summary>
     public static WebApplicationBuilder AddCocoarConfiguration(
         this WebApplicationBuilder builder,
-        Func<RulesBuilder, ConfigRule[]> rule,
-        Func<SetupBuilder, SetupDefinition[]>? configure = null,
-        ILogger? logger = null,
-        int debounceMilliseconds = 300)
+        Action<ConfigManagerBuilder> configure)
     {
-        var configManager = new ConfigManager(rule, configure, logger, debounceMilliseconds: debounceMilliseconds);
-        configManager.Initialize();
+        var configManager = ConfigManager.Create(configure);
 
         builder.Services.AddCocoarConfiguration(configManager);
-
-        // Attach ConfigManager as a capability to the WebApplicationBuilder
         _capabilityScope.Compose(builder).Add(configManager).Build();
 
         return builder;

--- a/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
+++ b/src/Cocoar.Configuration.AspNetCore/CocoarConfigurationAspNetCoreExtensions.cs
@@ -1,14 +1,13 @@
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Builder;
 using Cocoar.Configuration.Core;
 using Cocoar.Configuration.DI;
-using Cocoar.Capabilities;
 
 namespace Cocoar.Configuration.AspNetCore;
 
 public static class CocoarConfigurationAspNetCoreExtensions
 {
-    // Use Cocoar.Capabilities infrastructure instead of ConditionalWeakTable
-    private static readonly CapabilityScope _capabilityScope = new();
+    private static readonly ConditionalWeakTable<WebApplicationBuilder, ConfigManager> _registrations = new();
 
     /// <summary>
     /// Adds Cocoar configuration to the WebApplicationBuilder using the builder API.
@@ -22,7 +21,7 @@ public static class CocoarConfigurationAspNetCoreExtensions
         var configManager = ConfigManager.Create(configure);
 
         builder.Services.AddCocoarConfiguration(configManager);
-        _capabilityScope.Compose(builder).Add(configManager).Build();
+        _registrations.AddOrUpdate(builder, configManager);
 
         return builder;
     }
@@ -32,11 +31,19 @@ public static class CocoarConfigurationAspNetCoreExtensions
         ConfigManager configManager)
     {
         builder.Services.AddCocoarConfiguration(configManager);
-        _capabilityScope.Compose(builder).Add(configManager).Build();
+        _registrations.AddOrUpdate(builder, configManager);
 
         return builder;
     }
 
     public static ConfigManager GetCocoarConfigManager(this WebApplicationBuilder builder)
-        => _capabilityScope.Compositions.GetRequired(builder).GetRequiredFirst<ConfigManager>();
+    {
+        if (!_registrations.TryGetValue(builder, out var configManager))
+        {
+            throw new InvalidOperationException(
+                "No ConfigManager has been registered for this WebApplicationBuilder. " +
+                "Call AddCocoarConfiguration() before GetCocoarConfigManager().");
+        }
+        return configManager;
+    }
 }

--- a/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
+++ b/src/Cocoar.Configuration.DI/CocoarConfigurationExtensions.cs
@@ -1,10 +1,6 @@
 using Cocoar.Configuration.Core;
-using Cocoar.Configuration.Fluent;
-using Cocoar.Configuration.Configure;
 using Cocoar.Configuration.Health;
-using Cocoar.Configuration.Rules;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Cocoar.Configuration.DI;
 
@@ -29,21 +25,17 @@ public static class CocoarConfigurationExtensions
     }
 
     /// <summary>
-    /// Adds Cocoar configuration to the service collection using a function-based rule API.
+    /// Adds Cocoar configuration to the service collection using the builder API.
+    /// Provides access to the full ConfigManagerBuilder for configuring rules, setup, secrets, logging, etc.
     /// Test configuration overrides are automatically applied via ConfigManager when CocoarTestConfiguration is active.
     /// </summary>
     public static IServiceCollection AddCocoarConfiguration(
         this IServiceCollection services,
-        Func<RulesBuilder, ConfigRule[]> rule,
-        Func<SetupBuilder, SetupDefinition[]>? setup = null,
-        ILogger? logger = null,
-        int debounceMilliseconds = 300)
+        Action<ConfigManagerBuilder> configure)
     {
         services.ThrowIfAlreadyRegistered();
 
-        var configManager = new ConfigManager(rule, setup, logger, debounceMilliseconds: debounceMilliseconds);
-        configManager.Initialize();
-
+        var configManager = ConfigManager.Create(configure);
         services.AddCocoarConfiguration(configManager);
         return services;
     }

--- a/src/Cocoar.Configuration.Secrets/Core/SecretsDecryptorResolver.cs
+++ b/src/Cocoar.Configuration.Secrets/Core/SecretsDecryptorResolver.cs
@@ -35,11 +35,11 @@ internal sealed class SecretsDecryptorResolver
                 throw new InvalidOperationException(
                     $"Cannot decrypt Secret with kid '{kid}': no certificates configured.\n\n" +
                     "To fix, configure a certificate in your secrets setup:\n\n" +
-                    "  .WithSecretsSetup(secrets => secrets\n" +
+                    "  .UseSecretsSetup(secrets => secrets\n" +
                     "      .UseCertificateFromFile(\"path/to/cert.pfx\")\n" +
                     "      .WithKeyId(\"your-key-id\"))\n\n" +
                     "Or use a certificate folder:\n\n" +
-                    "  .WithSecretsSetup(secrets => secrets\n" +
+                    "  .UseSecretsSetup(secrets => secrets\n" +
                     "      .UseCertificatesFromFolder(\"path/to/certs\"))");
             }
 

--- a/src/Cocoar.Configuration.Secrets/Core/SecretsDecryptorResolver.cs
+++ b/src/Cocoar.Configuration.Secrets/Core/SecretsDecryptorResolver.cs
@@ -35,12 +35,12 @@ internal sealed class SecretsDecryptorResolver
                 throw new InvalidOperationException(
                     $"Cannot decrypt Secret with kid '{kid}': no certificates configured.\n\n" +
                     "To fix, configure a certificate in your secrets setup:\n\n" +
-                    "  setup.Secrets()\n" +
+                    "  .WithSecretsSetup(secrets => secrets\n" +
                     "      .UseCertificateFromFile(\"path/to/cert.pfx\")\n" +
-                    "      .WithKeyId(\"your-key-id\")\n\n" +
+                    "      .WithKeyId(\"your-key-id\"))\n\n" +
                     "Or use a certificate folder:\n\n" +
-                    "  setup.Secrets()\n" +
-                    "      .UseCertificatesFromFolder(\"path/to/certs\")");
+                    "  .WithSecretsSetup(secrets => secrets\n" +
+                    "      .UseCertificatesFromFolder(\"path/to/certs\"))");
             }
 
             throw SecretDecryptionException.KidNotFound(kid, "RSA-OAEP-AES256-GCM", availableKids);

--- a/src/Cocoar.Configuration.Secrets/README.md
+++ b/src/Cocoar.Configuration.Secrets/README.md
@@ -36,7 +36,7 @@ using Cocoar.Configuration;
 using Cocoar.Configuration.Secrets;
 
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile("config.json")
     ])
     .WithSecretsSetup(secrets => secrets
@@ -115,7 +115,7 @@ using (var lease = config.Database.ApiKey.Open())
     // WARNING: 'key' is now plain text - handle carefully!
     // The Secret<T> type protects values (shows as ***), but once you
     // extract .Value, you're responsible for not logging/exposing it
-    
+
     // Use the secret (API calls, database connections, etc.)
     CallApiWithKey(key);
 }

--- a/src/Cocoar.Configuration.Secrets/README.md
+++ b/src/Cocoar.Configuration.Secrets/README.md
@@ -35,13 +35,13 @@ cocoar-secrets generate-cert -o secrets.pfx
 using Cocoar.Configuration;
 using Cocoar.Configuration.Secrets;
 
-var manager = new ConfigManager(rule => [
-    rule.For<AppConfig>().FromFile("config.json")
-], setup => [
-    setup.Secrets()
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile("config.json")
+    ])
+    .WithSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")  // Password-less certificate
-        .WithKeyId("dev-secrets")               // Matches kid in envelopes
-]).Initialize();
+        .WithKeyId("dev-secrets")));            // Matches kid in envelopes
 
 var config = manager.GetConfig<AppConfig>();
 ```
@@ -156,9 +156,9 @@ cocoar-secrets encrypt -f config.json \
 ### Single Certificate (Development)
 
 ```csharp
-setup.Secrets()
+.WithSecretsSetup(secrets => secrets
     .UseCertificateFromFile("secrets.pfx")
-    .WithKeyId("dev-secrets")
+    .WithKeyId("dev-secrets"))
 ```
 
 ### Multiple Certificates (Production with Rotation)
@@ -168,9 +168,9 @@ setup.Secrets()
 // Example: C:\certs\prod\api-keys\cert-v1.pfx
 //          C:\certs\prod\api-keys\cert-v2.pfx
 
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\prod", 
-        cacheDurationSeconds: 30)  // Cache for performance
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\prod",
+        cacheDurationSeconds: 30))  // Cache for performance
 ```
 
 **Certificate discovery:**
@@ -183,29 +183,28 @@ setup.Secrets()
 
 ```csharp
 // Critical secrets - no cache (maximum security)
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\pci", 
-        cacheDurationSeconds: 0),
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\pci",
+        cacheDurationSeconds: 0))
 
 // API keys - balanced 30-second cache
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\api", 
-        cacheDurationSeconds: 30),
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\api",
+        cacheDurationSeconds: 30))
 
 // Feature flags - 1-hour cache (performance)
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\config", 
-        cacheDurationSeconds: 3600)
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\config",
+        cacheDurationSeconds: 3600))
 ```
 
 ### Legacy Certificate Support
 
 ```csharp
-setup.Secrets()
+.WithSecretsSetup(secrets => secrets
     .UseCertificateFromFile("current.pfx")
     .WithKeyId("prod-v2")
-    .WithAdditionalKeyId("prod-v1")  // Backward compatibility
-    .Build()
+    .WithAdditionalKeyId("prod-v1"))  // Backward compatibility
 ```
 
 ## Certificate Formats
@@ -240,8 +239,8 @@ Certificates can be in PEM format (`.crt` / `.cer` + `.key` files):
 cocoar-secrets convert-cert -i cert.pfx -o cert.crt --format pem
 
 # Use PEM in configuration
-setup.Secrets()
-    .UseCertificateFromFile("cert.crt", "cert.key")  // Separate cert + key files
+.WithSecretsSetup(secrets => secrets
+    .UseCertificateFromFile("cert.crt", "cert.key"))  // Separate cert + key files
 ```
 
 ## Security Features

--- a/src/Cocoar.Configuration.Secrets/README.md
+++ b/src/Cocoar.Configuration.Secrets/README.md
@@ -39,7 +39,7 @@ var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile("config.json")
     ])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")  // Password-less certificate
         .WithKeyId("dev-secrets")));            // Matches kid in envelopes
 
@@ -156,7 +156,7 @@ cocoar-secrets encrypt -f config.json \
 ### Single Certificate (Development)
 
 ```csharp
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificateFromFile("secrets.pfx")
     .WithKeyId("dev-secrets"))
 ```
@@ -168,7 +168,7 @@ cocoar-secrets encrypt -f config.json \
 // Example: C:\certs\prod\api-keys\cert-v1.pfx
 //          C:\certs\prod\api-keys\cert-v2.pfx
 
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\prod",
         cacheDurationSeconds: 30))  // Cache for performance
 ```
@@ -183,17 +183,17 @@ cocoar-secrets encrypt -f config.json \
 
 ```csharp
 // Critical secrets - no cache (maximum security)
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\pci",
         cacheDurationSeconds: 0))
 
 // API keys - balanced 30-second cache
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\api",
         cacheDurationSeconds: 30))
 
 // Feature flags - 1-hour cache (performance)
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\config",
         cacheDurationSeconds: 3600))
 ```
@@ -201,7 +201,7 @@ cocoar-secrets encrypt -f config.json \
 ### Legacy Certificate Support
 
 ```csharp
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificateFromFile("current.pfx")
     .WithKeyId("prod-v2")
     .WithAdditionalKeyId("prod-v1"))  // Backward compatibility
@@ -239,7 +239,7 @@ Certificates can be in PEM format (`.crt` / `.cer` + `.key` files):
 cocoar-secrets convert-cert -i cert.pfx -o cert.crt --format pem
 
 # Use PEM in configuration
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificateFromFile("cert.crt", "cert.key"))  // Separate cert + key files
 ```
 

--- a/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
@@ -92,15 +92,15 @@ public sealed class Secret<T> : ISecret<T>
             throw new InvalidOperationException(
                 $"Cannot decrypt Secret<{typeof(T).Name}>: secrets infrastructure not configured.\n\n" +
                 "To fix, add secrets setup when creating ConfigManager:\n\n" +
-                "  var manager = new ConfigManager(\n" +
-                "      rules => [...],\n" +
-                "      setup => [setup.Secrets()]  // <-- Add this\n" +
-                "  );\n\n" +
+                "  ConfigManager.Create(c => c\n" +
+                "      .WithConfiguration(rules => [...])\n" +
+                "      .WithSecretsSetup(secrets => secrets\n" +
+                "          .UseCertificateFromFile(\"cert.pfx\")));\n\n" +
                 "Or with DI:\n\n" +
-                "  services.AddCocoarConfiguration(\n" +
-                "      rules => [...],\n" +
-                "      setup => [setup.Secrets()]\n" +
-                "  );");
+                "  services.AddCocoarConfiguration(c => c\n" +
+                "      .WithConfiguration(rules => [...])\n" +
+                "      .WithSecretsSetup(secrets => secrets\n" +
+                "          .UseCertificateFromFile(\"cert.pfx\")));");
         }
 
         var protector = _resolver.ResolveForKid(env.Kid);

--- a/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
@@ -14,6 +14,7 @@ public sealed class Secret<T> : ISecret<T>
     private SecretsDecryptorResolver? _resolver;
     private bool _disposed;
     private readonly bool _blockPlaintextAccess;
+    private readonly Lock _lock = new();
 
     internal Secret(T plain, SecretsDecryptorResolver? resolver = null, bool allowPlaintext = false)
     {
@@ -35,42 +36,45 @@ public sealed class Secret<T> : ISecret<T>
 
     public SecretLease<T> Open()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        lock (_lock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
 
-        ValidatePlaintextAccess();
+            ValidatePlaintextAccess();
 
-        // Get decrypted bytes - decrypt at the LAST possible moment
-        byte[] bytes;
-        bool needsCleanup;
+            // Get decrypted bytes - decrypt at the LAST possible moment
+            byte[] bytes;
+            bool needsCleanup;
 
-        if (_plainBytes is { } plain)
-        {
-            bytes = plain;
-            needsCleanup = false;
-        }
-        else if (_envelope is { } env)
-        {
-            // CRITICAL: Decrypt here, right before deserialization
-            bytes = DecryptEnvelope(env);
-            needsCleanup = true;
-        }
-        else
-        {
-            throw new ObjectDisposedException(nameof(Secret<T>));
-        }
-
-        // Deserialize and create lease immediately after decryption
-        try
-        {
-            return DeserializeAndCreateLease(bytes, needsCleanup);
-        }
-        catch
-        {
-            if (needsCleanup)
+            if (_plainBytes is { } plain)
             {
-                Array.Clear(bytes, 0, bytes.Length);
+                bytes = plain;
+                needsCleanup = false;
             }
-            throw;
+            else if (_envelope is { } env)
+            {
+                // CRITICAL: Decrypt here, right before deserialization
+                bytes = DecryptEnvelope(env);
+                needsCleanup = true;
+            }
+            else
+            {
+                throw new ObjectDisposedException(nameof(Secret<T>));
+            }
+
+            // Deserialize and create lease immediately after decryption
+            try
+            {
+                return DeserializeAndCreateLease(bytes, needsCleanup);
+            }
+            catch
+            {
+                if (needsCleanup)
+                {
+                    Array.Clear(bytes, 0, bytes.Length);
+                }
+                throw;
+            }
         }
     }
 
@@ -93,12 +97,12 @@ public sealed class Secret<T> : ISecret<T>
                 $"Cannot decrypt Secret<{typeof(T).Name}>: secrets infrastructure not configured.\n\n" +
                 "To fix, add secrets setup when creating ConfigManager:\n\n" +
                 "  ConfigManager.Create(c => c\n" +
-                "      .WithConfiguration(rules => [...])\n" +
+                "      .UseConfiguration(rules => [...])\n" +
                 "      .WithSecretsSetup(secrets => secrets\n" +
                 "          .UseCertificateFromFile(\"cert.pfx\")));\n\n" +
                 "Or with DI:\n\n" +
                 "  services.AddCocoarConfiguration(c => c\n" +
-                "      .WithConfiguration(rules => [...])\n" +
+                "      .UseConfiguration(rules => [...])\n" +
                 "      .WithSecretsSetup(secrets => secrets\n" +
                 "          .UseCertificateFromFile(\"cert.pfx\")));");
         }
@@ -158,16 +162,19 @@ public sealed class Secret<T> : ISecret<T>
 
     public void Dispose()
     {
-        if (_disposed) return;
-
-        if (_plainBytes is { } bytes)
+        lock (_lock)
         {
-            Array.Clear(bytes, 0, bytes.Length);
-            _plainBytes = null;
-        }
+            if (_disposed) return;
 
-        _envelope = null;
-        _disposed = true;
+            if (_plainBytes is { } bytes)
+            {
+                Array.Clear(bytes, 0, bytes.Length);
+                _plainBytes = null;
+            }
+
+            _envelope = null;
+            _disposed = true;
+        }
     }
 
     /// <summary>

--- a/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretTypes/Secret.cs
@@ -98,12 +98,12 @@ public sealed class Secret<T> : ISecret<T>
                 "To fix, add secrets setup when creating ConfigManager:\n\n" +
                 "  ConfigManager.Create(c => c\n" +
                 "      .UseConfiguration(rules => [...])\n" +
-                "      .WithSecretsSetup(secrets => secrets\n" +
+                "      .UseSecretsSetup(secrets => secrets\n" +
                 "          .UseCertificateFromFile(\"cert.pfx\")));\n\n" +
                 "Or with DI:\n\n" +
                 "  services.AddCocoarConfiguration(c => c\n" +
                 "      .UseConfiguration(rules => [...])\n" +
-                "      .WithSecretsSetup(secrets => secrets\n" +
+                "      .UseSecretsSetup(secrets => secrets\n" +
                 "          .UseCertificateFromFile(\"cert.pfx\")));");
         }
 

--- a/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
@@ -1,0 +1,34 @@
+using Cocoar.Configuration.Configure;
+using Cocoar.Configuration.Core;
+
+namespace Cocoar.Configuration.Secrets;
+
+public static class SecretsBuilderExtensions
+{
+    /// <summary>
+    /// Configures secrets setup (encryption, certificates, plaintext policy).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// ConfigManager.Create(c => c
+    ///     .WithConfiguration(rules => [...])
+    ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext()));
+    ///
+    /// ConfigManager.Create(c => c
+    ///     .WithConfiguration(rules => [...])
+    ///     .WithSecretsSetup(secrets => secrets
+    ///         .UseCertificateFromFile("cert.pfx")
+    ///         .WithKeyId("my-key")));
+    /// </code>
+    /// </example>
+    public static ConfigManagerBuilder WithSecretsSetup(
+        this ConfigManagerBuilder builder,
+        Func<SecretsBuilder, SetupDefinition> configure)
+    {
+        var scope = ConfigManagerBuilder.GetCapabilityScope(builder);
+        var secretsBuilder = new SecretsBuilder(scope);
+        var result = configure(secretsBuilder);
+        result.Build();
+        return builder;
+    }
+}

--- a/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
@@ -11,11 +11,11 @@ public static class SecretsBuilderExtensions
     /// <example>
     /// <code>
     /// ConfigManager.Create(c => c
-    ///     .WithConfiguration(rules => [...])
+    ///     .UseConfiguration(rules => [...])
     ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext()));
     ///
     /// ConfigManager.Create(c => c
-    ///     .WithConfiguration(rules => [...])
+    ///     .UseConfiguration(rules => [...])
     ///     .WithSecretsSetup(secrets => secrets
     ///         .UseCertificateFromFile("cert.pfx")
     ///         .WithKeyId("my-key")));

--- a/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Cocoar.Configuration.Configure;
 using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Testing;
 
 namespace Cocoar.Configuration.Secrets;
 
@@ -7,28 +8,65 @@ public static class SecretsBuilderExtensions
 {
     /// <summary>
     /// Configures secrets setup (encryption, certificates, plaintext policy).
+    /// When a test context with a secrets setup override is active, the override is used instead.
     /// </summary>
     /// <example>
     /// <code>
     /// ConfigManager.Create(c => c
     ///     .UseConfiguration(rules => [...])
-    ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext()));
+    ///     .UseSecretsSetup(secrets => secrets.AllowPlaintext()));
     ///
     /// ConfigManager.Create(c => c
     ///     .UseConfiguration(rules => [...])
-    ///     .WithSecretsSetup(secrets => secrets
+    ///     .UseSecretsSetup(secrets => secrets
     ///         .UseCertificateFromFile("cert.pfx")
     ///         .WithKeyId("my-key")));
     /// </code>
     /// </example>
-    public static ConfigManagerBuilder WithSecretsSetup(
+    public static ConfigManagerBuilder UseSecretsSetup(
         this ConfigManagerBuilder builder,
         Func<SecretsBuilder, SetupDefinition> configure)
     {
         var scope = ConfigManagerBuilder.GetCapabilityScope(builder);
         var secretsBuilder = new SecretsBuilder(scope);
-        var result = configure(secretsBuilder);
+
+        var testContext = CocoarTestConfiguration.Current;
+        var effectiveConfigure = testContext?.GetSecretsSetupOverride() ?? configure;
+
+        var result = effectiveConfigure(secretsBuilder);
         result.Build();
         return builder;
     }
+
+    /// <summary>
+    /// Replaces the secrets setup used during ConfigManager initialization in tests.
+    /// Extends <see cref="TestOverrideBuilder"/> so that it can be chained fluently alongside
+    /// <c>ReplaceConfiguration</c> / <c>AppendConfiguration</c>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// using var _ = CocoarTestConfiguration
+    ///     .ReplaceConfiguration(rules => [...])
+    ///     .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+    /// </code>
+    /// </example>
+    public static TestOverrideBuilder ReplaceSecretsSetup(
+        this TestOverrideBuilder builder,
+        Func<SecretsBuilder, SetupDefinition> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        builder.SetSecretsSetupOverride(configure);
+        return builder;
+    }
+}
+
+internal static class TestConfigurationContextSecretsExtensions
+{
+    /// <summary>
+    /// Returns the secrets setup override cast to the correct strongly-typed delegate,
+    /// or null if no override has been registered.
+    /// </summary>
+    internal static Func<SecretsBuilder, SetupDefinition>? GetSecretsSetupOverride(
+        this TestConfigurationContext context)
+        => context.SecretsSetupOverride as Func<SecretsBuilder, SetupDefinition>;
 }

--- a/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
@@ -51,13 +51,12 @@ public sealed class SecretsBuilder : SetupDefinition
     /// <example>
     /// <code>
     /// // Conditional based on environment (ASP.NET Core)
-    /// builder.Services.AddCocoarConfiguration(
-    ///     rules => [...],
-    ///     setup => [setup.Secrets().AllowPlaintext(builder.Environment.IsDevelopment())]
-    /// );
+    /// ConfigManager.Create(c => c
+    ///     .WithConfiguration(rules => [...])
+    ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext(isDevelopment)));
     ///
     /// // Always enable for tests
-    /// setup => [setup.Secrets().AllowPlaintext()]  // defaults to true
+    /// .WithSecretsSetup(secrets => secrets.AllowPlaintext())  // defaults to true
     /// </code>
     /// </example>
     public SecretsBuilder AllowPlaintext(bool allow = true)
@@ -65,10 +64,4 @@ public sealed class SecretsBuilder : SetupDefinition
         _composer.Add(new SecretsPolicy { AllowPlaintextSecrets = allow });
         return this;
     }
-}
-
-public static class SecretsSetupExtensions
-{
-    public static SecretsBuilder Secrets(this SetupBuilder builder)
-        => new(SetupBuilder.GetCapabilityScopeFor(builder));
 }

--- a/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
@@ -54,10 +54,10 @@ public sealed class SecretsBuilder : SetupDefinition
     /// // Conditional based on environment (ASP.NET Core)
     /// ConfigManager.Create(c => c
     ///     .UseConfiguration(rules => [...])
-    ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext(isDevelopment)));
+    ///     .UseSecretsSetup(secrets => secrets.AllowPlaintext(isDevelopment)));
     ///
     /// // Always enable for tests
-    /// .WithSecretsSetup(secrets => secrets.AllowPlaintext())  // defaults to true
+    /// .UseSecretsSetup(secrets => secrets.AllowPlaintext())  // defaults to true
     /// </code>
     /// </example>
     public SecretsBuilder AllowPlaintext(bool allow = true)

--- a/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
+++ b/src/Cocoar.Configuration.Secrets/SecretsSetup.cs
@@ -20,9 +20,10 @@ public sealed class SecretsBuilder : SetupDefinition
         _composer = CapabilityScope.Owner.GetRequiredComposer();
 
         // Register test serialization if in test context
-        if (CocoarTestConfiguration.Current != null)
+        var testContext = CocoarTestConfiguration.Current;
+        if (testContext != null)
         {
-            CocoarTestConfiguration.TestSerializerOptions ??= TestSecretSerialization.Options;
+            testContext.SerializerOptions ??= TestSecretSerialization.Options;
         }
 
         if (!_composer.Has<ISerializerSetupCapability>())
@@ -52,7 +53,7 @@ public sealed class SecretsBuilder : SetupDefinition
     /// <code>
     /// // Conditional based on environment (ASP.NET Core)
     /// ConfigManager.Create(c => c
-    ///     .WithConfiguration(rules => [...])
+    ///     .UseConfiguration(rules => [...])
     ///     .WithSecretsSetup(secrets => secrets.AllowPlaintext(isDevelopment)));
     ///
     /// // Always enable for tests

--- a/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
+++ b/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
@@ -16,7 +16,7 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(new[] { rule })
+    .UseConfiguration(new[] { rule })
     .WithSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs",
             cacheDurationSeconds: 30)));  // 30 seconds (default)

--- a/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
+++ b/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
@@ -17,7 +17,7 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(new[] { rule })
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs",
             cacheDurationSeconds: 30)));  // 30 seconds (default)
 ```
@@ -45,13 +45,13 @@ var manager = ConfigManager.Create(c => c
 ```csharp
 // Critical secrets - no cache, load fresh every time
 // Folder structure: C:\certs\pci\pci-data\*.pfx
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\pci",
         cacheDurationSeconds: 0))
 
 // Standard secrets - balanced 30-second cache
 // Folder structure: C:\certs\api\api-keys\*.pfx
-.WithSecretsSetup(secrets => secrets
+.UseSecretsSetup(secrets => secrets
     .UseCertificatesFromFolder(@"C:\certs\api",
         cacheDurationSeconds: 30))
 ```

--- a/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
+++ b/src/Cocoar.Configuration.Secrets/intelligent-certificate-caching.md
@@ -15,14 +15,11 @@ Folder-based certificate mode (UseCertificatesFromFolder) provides intelligent c
 ## Basic Usage
 
 ```csharp
-var manager = new ConfigManager(
-    new[] { rule },
-    setup => new[]
-    {
-        setup.Secrets()
-            .UseCertificatesFromFolder(@"C:\certs", 
-                cacheDurationSeconds: 30)  // 30 seconds (default)
-    });
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(new[] { rule })
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificatesFromFolder(@"C:\certs",
+            cacheDurationSeconds: 30)));  // 30 seconds (default)
 ```
 
 **How It Works:**
@@ -48,15 +45,15 @@ var manager = new ConfigManager(
 ```csharp
 // Critical secrets - no cache, load fresh every time
 // Folder structure: C:\certs\pci\pci-data\*.pfx
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\pci", 
-        cacheDurationSeconds: 0);
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\pci",
+        cacheDurationSeconds: 0))
 
 // Standard secrets - balanced 30-second cache
 // Folder structure: C:\certs\api\api-keys\*.pfx
-setup.Secrets()
-    .UseCertificatesFromFolder(@"C:\certs\api", 
-        cacheDurationSeconds: 30);
+.WithSecretsSetup(secrets => secrets
+    .UseCertificatesFromFolder(@"C:\certs\api",
+        cacheDurationSeconds: 30))
 ```
 
 ---

--- a/src/Cocoar.Configuration.slnx
+++ b/src/Cocoar.Configuration.slnx
@@ -26,6 +26,7 @@
     <Project Path="Examples/SimplifiedCoreExample/SimplifiedCoreExample.csproj" />
     <Project Path="Examples/StaticProviderExample/StaticProviderExample.csproj" />
     <Project Path="Examples/TupleReactiveExample/TupleReactiveExample.csproj" />
+    <Project Path="Examples/ConfigurationShowcase/ConfigurationShowcase.csproj" />
   </Folder>
   <Project Path="Cocoar.Configuration.Analyzers/Cocoar.Configuration.Analyzers.csproj" />
   <Project Path="Cocoar.Configuration.AspNetCore/Cocoar.Configuration.AspNetCore.csproj" />

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -223,13 +223,22 @@ public sealed class ConfigManager : IConfigurationAccessor, IDisposable, IAsyncD
     public T GetRequiredConfig<T>() => _accessor.GetRequiredConfig<T>();
 #pragma warning restore CS0618
 
+    /// <inheritdoc cref="GetConfig{T}"/>
     public object GetConfig(Type type) => _accessor.GetConfig(type);
+
+    /// <inheritdoc cref="TryGetConfig{T}(out T?)"/>
     public bool TryGetConfig(Type type, out object? value) => _accessor.TryGetConfig(type, out value);
 
 #pragma warning disable CS0618 // Type or member is obsolete
+    /// <inheritdoc cref="GetRequiredConfig{T}"/>
     public object GetRequiredConfig(Type type) => _accessor.GetRequiredConfig(type);
 #pragma warning restore CS0618
 
+    /// <summary>
+    /// Gets the current configuration snapshot for the specified type serialized as a <see cref="JsonElement"/>.
+    /// Returns <c>null</c> if no rule is registered for the type.
+    /// </summary>
+    /// <param name="type">The configuration type to retrieve.</param>
     public JsonElement? GetConfigAsJson(Type type) => _accessor.GetConfigAsJson(type);
 
     /// <summary>

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -14,7 +14,7 @@ using Cocoar.Configuration.Utilities;
 
 namespace Cocoar.Configuration.Core;
 
-public class ConfigManager : IConfigurationAccessor, IDisposable
+public sealed class ConfigManager : IConfigurationAccessor, IDisposable, IAsyncDisposable
 {
     private List<ConfigRule> _rules = null!;
     private List<SetupDefinition> _setupDefinitions = null!;
@@ -31,8 +31,22 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     private ILogger _logger = NullLogger.Instance;
     private int _debounceMilliseconds = 300;
 
-    private volatile bool _initialized;
+    private int _initialized;
 
+    /// <summary>
+    /// Creates and initializes a new <see cref="ConfigManager"/> using the provided configuration.
+    /// </summary>
+    /// <param name="configure">An action to configure the <see cref="ConfigManagerBuilder"/>.</param>
+    /// <returns>A fully initialized <see cref="ConfigManager"/> ready for use.</returns>
+    /// <example>
+    /// <code>
+    /// var manager = ConfigManager.Create(builder => builder
+    ///     .UseConfiguration(rules => [
+    ///         rules.For&lt;AppSettings&gt;().FromFile("appsettings.json")
+    ///     ]));
+    /// var settings = manager.GetConfig&lt;AppSettings&gt;();
+    /// </code>
+    /// </example>
     public static ConfigManager Create(Action<ConfigManagerBuilder> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
@@ -103,17 +117,17 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     public IReadOnlyList<ConfigRule> Rules => _rules.AsReadOnly();
     internal IReadOnlyList<SetupDefinition> SetupDefinitions => _setupDefinitions.AsReadOnly();
 
-    public ConfigManagerCapabilityScope CapabilityScope => _capabilityScope;
-
+    internal ConfigManagerCapabilityScope CapabilityScope => _capabilityScope;
+    internal MasterBackplane Backplane => _state.Backplane;
 
     internal ConfigManager Initialize()
     {
-        if (_initialized)
+        if (_initialized != 0)
         {
             return this;
         }
 
-        if (!Interlocked.CompareExchange(ref _initialized, true, false))
+        if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 0)
         {
             _capabilityScope.Owner.TryGetComposer(out var composer);
             composer?.Build();
@@ -135,8 +149,75 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         return this;
     }
 
-    public T GetConfig<T>() => _accessor.GetConfig<T>();
-    public bool TryGetConfig<T>(out T? value) => _accessor.TryGetConfig(out value);
+    internal async Task<ConfigManager> InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (_initialized != 0)
+            return this;
+
+        if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 0)
+        {
+            _capabilityScope.Owner.TryGetComposer(out var composer);
+            composer?.Build();
+            _capabilityScope.Owner.GetComposition()?.UsingEach<IDeferredConfiguration>(c => c.Apply());
+
+            await _engine.InitializeAndComputeAsync(
+                _rules,
+                _ruleManagers,
+                _providerRegistry,
+                this,
+                _bindingRegistry,
+                _capabilityScope,
+                ScheduleRecompute,
+                _debounceMilliseconds,
+                cancellationToken).ConfigureAwait(false);
+
+            _reactiveConfigManager.SetBackplane(_state.Backplane);
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Creates and initializes a new <see cref="ConfigManager"/> asynchronously.
+    /// Prefer this over <see cref="Create"/> in console apps or any context where
+    /// blocking the calling thread during provider I/O is undesirable.
+    /// </summary>
+    /// <param name="configure">An action to configure the <see cref="ConfigManagerBuilder"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the initialization.</param>
+    public static async Task<ConfigManager> CreateAsync(
+        Action<ConfigManagerBuilder> configure,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var manager = new ConfigManager();
+        var builder = new ConfigManagerBuilder(manager);
+        configure(builder);
+        return await builder.BuildAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets a configuration instance of the specified type from the current snapshot.
+    /// </summary>
+    /// <typeparam name="T">The configuration type to retrieve. Must be a class.</typeparam>
+    /// <returns>The configuration instance, or null if not found.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Configure"/> has not been called.</exception>
+    public T? GetConfig<T>() where T : class
+    {
+        if (_initialized == 0) throw new InvalidOperationException("ConfigManager has not been initialized. Call Configure() first.");
+        return _accessor.GetConfig<T>();
+    }
+
+    /// <summary>
+    /// Attempts to get a configuration instance without throwing.
+    /// </summary>
+    /// <typeparam name="T">The configuration type to retrieve. Must be a class.</typeparam>
+    /// <param name="value">The configuration instance if found; otherwise null.</param>
+    /// <returns>True if the configuration exists; false otherwise.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Configure"/> has not been called.</exception>
+    public bool TryGetConfig<T>(out T? value) where T : class
+    {
+        if (_initialized == 0) throw new InvalidOperationException("ConfigManager has not been initialized. Call Configure() first.");
+        return _accessor.TryGetConfig(out value);
+    }
 
 #pragma warning disable CS0618 // Type or member is obsolete
     public T GetRequiredConfig<T>() => _accessor.GetRequiredConfig<T>();
@@ -151,20 +232,45 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
 
     public JsonElement? GetConfigAsJson(Type type) => _accessor.GetConfigAsJson(type);
 
-    public IReactiveConfig<T> GetReactiveConfig<T>() => _reactiveFactory.GetReactiveConfig<T>(() => GetConfig<T>());
+    /// <summary>
+    /// Gets a reactive wrapper for the specified configuration type.
+    /// The returned <see cref="IReactiveConfig{T}"/> emits the current value immediately on subscribe
+    /// and then on every subsequent configuration change (replay-1 / BehaviorSubject semantics).
+    /// </summary>
+    /// <typeparam name="T">The configuration type. Must be a class, interface (with ExposeAs), or ValueTuple.</typeparam>
+    /// <returns>A reactive configuration wrapper.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Configure"/> has not been called.</exception>
+    public IReactiveConfig<T> GetReactiveConfig<T>()
+    {
+        if (_initialized == 0) throw new InvalidOperationException("ConfigManager has not been initialized. Call Configure() first.");
+        return _reactiveFactory.GetReactiveConfig<T>(() => (T)GetConfig(typeof(T)));
+    }
 
-    public IConfigurationHealthService GetHealthService() => _state.GetHealthService();
+    /// <summary>
+    /// Gets the health service for monitoring the configuration system's status.
+    /// </summary>
+    /// <returns>An <see cref="IConfigurationHealthService"/> providing health status and observable streams.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Configure"/> has not been called.</exception>
+    public IConfigurationHealthService GetHealthService()
+    {
+        if (_initialized == 0) throw new InvalidOperationException("ConfigManager has not been initialized. Call Configure() first.");
+        return _state.GetHealthService();
+    }
 
     internal void ScheduleRecompute(int startIndex) =>
         _engine.ScheduleRecompute(_ruleManagers, this, startIndex);
 
     internal Task? CurrentRecomputeTask => _engine.CurrentRecomputeTask;
 
+    /// <summary>
+    /// Disposes the configuration manager and all associated resources.
+    /// After disposal, configuration methods will throw <see cref="InvalidOperationException"/>.
+    /// </summary>
     public void Dispose()
     {
-        _engine.Dispose();
-        _reactiveConfigManager.Dispose();
-        _state.Dispose();
+        _engine?.Dispose();
+        _reactiveConfigManager?.Dispose();
+        _state?.Dispose();
 
         foreach (var rm in _ruleManagers.ToArray())
         {
@@ -172,8 +278,27 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         }
 
         _ruleManagers.Clear();
-        _initialized = false;
-        GC.SuppressFinalize(this);
+        Interlocked.Exchange(ref _initialized, 0);
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the configuration manager, awaiting any in-flight recompute to finish.
+    /// Preferred over <see cref="Dispose"/> in ASP.NET Core and other async hosts, which call
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> on singletons at shutdown.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_engine != null) await _engine.DisposeAsync().ConfigureAwait(false);
+        _reactiveConfigManager?.Dispose();
+        _state?.Dispose();
+
+        foreach (var rm in _ruleManagers.ToArray())
+        {
+            Safety.DisposeQuietly(rm);
+        }
+
+        _ruleManagers.Clear();
+        Interlocked.Exchange(ref _initialized, 0);
     }
 
     /// <summary>

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -16,41 +16,61 @@ namespace Cocoar.Configuration.Core;
 
 public class ConfigManager : IConfigurationAccessor, IDisposable
 {
-    private readonly List<ConfigRule> _rules;
-    private readonly List<SetupDefinition> _setupDefinitions;
+    private List<ConfigRule> _rules = null!;
+    private List<SetupDefinition> _setupDefinitions = null!;
     private readonly List<RuleManager> _ruleManagers = new();
 
-    private readonly ConfigurationAccessor _accessor;
-    private readonly ReactiveConfigurationFactory _reactiveFactory;
-    private readonly ReactiveConfigManager _reactiveConfigManager;
+    private ConfigurationAccessor _accessor = null!;
+    private ReactiveConfigurationFactory _reactiveFactory = null!;
+    private ReactiveConfigManager _reactiveConfigManager = null!;
     private readonly ConfigManagerCapabilityScope _capabilityScope;
-    private readonly ConfigurationEngine _engine;
-    private readonly ConfigurationState _state;
-    private readonly ProviderRegistry _providerRegistry;
-    private readonly ExposureRegistry _bindingRegistry;
-    private readonly ILogger _logger;
-    private readonly int _debounceMilliseconds;
+    private ConfigurationEngine _engine = null!;
+    private ConfigurationState _state = null!;
+    private ProviderRegistry _providerRegistry = null!;
+    private ExposureRegistry _bindingRegistry = null!;
+    private ILogger _logger = NullLogger.Instance;
+    private int _debounceMilliseconds = 300;
 
     private volatile bool _initialized;
 
-    /// <summary>
-    /// Creates a new ConfigManager with a function-based rules builder.
-    /// Automatically detects and applies test configuration overrides when CocoarTestConfiguration is active.
-    /// </summary>
-    public ConfigManager(Func<RulesBuilder, ConfigRule[]> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
+    public static ConfigManager Create(Action<ConfigManagerBuilder> configure)
     {
-        var rulesBuilder = new RulesBuilder();
-        var configuredRules = rules(rulesBuilder);
+        ArgumentNullException.ThrowIfNull(configure);
+        var manager = new ConfigManager();
+        var builder = new ConfigManagerBuilder(manager);
+        configure(builder);
+        return builder.Build();
+    }
 
-        // Apply test configuration overrides if present
-        _rules = ApplyTestConfigurationOverrides(configuredRules).ToList();
-
+    /// <summary>
+    /// Creates a bare ConfigManager with only the CapabilityScope initialized.
+    /// Must be followed by <see cref="Configure"/> and <see cref="Initialize"/> to be fully operational.
+    /// </summary>
+    internal ConfigManager()
+    {
         _capabilityScope = new ConfigManagerCapabilityScope(this);
         _capabilityScope.Owner.Compose();
+    }
+
+    /// <summary>
+    /// Configures the ConfigManager with rules, setup, and infrastructure.
+    /// Called by <see cref="ConfigManagerBuilder.Build"/> after the user lambda
+    /// has had a chance to configure satellite capabilities on the scope.
+    /// </summary>
+    internal void Configure(
+        ConfigRule[] configuredRules,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null,
+        ILogger? logger = null,
+        Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null,
+        int debounceMilliseconds = 300)
+    {
+        // Apply test configuration overrides if present
+        _rules = ApplyTestConfigurationOverrides(configuredRules).ToList();
 
         // Apply test setup overrides if present
         var effectiveSetup = ApplyTestSetupOverrides(setup);
         _setupDefinitions = effectiveSetup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
+
         _logger = logger ?? NullLogger.Instance;
         _debounceMilliseconds = debounceMilliseconds;
 
@@ -66,36 +86,18 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
         _engine = new ConfigurationEngine(_state, _logger);
     }
 
-    /// <summary>
-    /// Creates a new ConfigManager with a pre-built list of rules.
-    /// Automatically detects and applies test configuration overrides when CocoarTestConfiguration is active.
-    /// </summary>
-    public ConfigManager(IEnumerable<ConfigRule> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
+    internal ConfigManager(Func<RulesBuilder, ConfigRule[]> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
+        : this()
     {
-        var configuredRules = rules.ToArray();
+        var rulesBuilder = new RulesBuilder();
+        var configuredRules = rules(rulesBuilder);
+        Configure(configuredRules, setup, logger, providerFactory, debounceMilliseconds);
+    }
 
-        // Apply test configuration overrides if present
-        _rules = ApplyTestConfigurationOverrides(configuredRules).ToList();
-
-        _capabilityScope = new ConfigManagerCapabilityScope(this);
-        _capabilityScope.Owner.Compose();
-
-        // Apply test setup overrides if present
-        var effectiveSetup = ApplyTestSetupOverrides(setup);
-        _setupDefinitions = effectiveSetup?.Invoke(new SetupBuilder(_capabilityScope)).Select(s => s.Build()).ToList() ?? new List<SetupDefinition>();
-        _logger = logger ?? NullLogger.Instance;
-        _debounceMilliseconds = debounceMilliseconds;
-
-        _state = new ConfigurationState(_ruleManagers, _rules, _logger);
-        _providerRegistry = new ProviderRegistry(_logger, enableDiagnostics: false, factory: providerFactory);
-        _bindingRegistry = new ExposureRegistry(_setupDefinitions, _logger, _capabilityScope);
-
-        _accessor = new(_state, _bindingRegistry, _logger);
-        _accessor.SetCapabilityScope(_capabilityScope);
-        _reactiveConfigManager = new(_logger, _bindingRegistry);
-        _reactiveFactory = new(_reactiveConfigManager, _rules, _logger, this, _bindingRegistry);
-
-        _engine = new ConfigurationEngine(_state, _logger);
+    internal ConfigManager(IEnumerable<ConfigRule> rules, Func<SetupBuilder, SetupDefinition[]>? setup = null, ILogger? logger = null, Func<Type, IProviderConfiguration, ConfigurationProvider>? providerFactory = null, int debounceMilliseconds = 300)
+        : this()
+    {
+        Configure(rules.ToArray(), setup, logger, providerFactory, debounceMilliseconds);
     }
 
     public IReadOnlyList<ConfigRule> Rules => _rules.AsReadOnly();
@@ -104,7 +106,7 @@ public class ConfigManager : IConfigurationAccessor, IDisposable
     public ConfigManagerCapabilityScope CapabilityScope => _capabilityScope;
 
 
-    public ConfigManager Initialize()
+    internal ConfigManager Initialize()
     {
         if (_initialized)
         {

--- a/src/Cocoar.Configuration/Core/ConfigManager.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManager.cs
@@ -304,19 +304,18 @@ public sealed class ConfigManager : IConfigurationAccessor, IDisposable, IAsyncD
     /// <summary>
     /// Applies test configuration overrides from AsyncLocal context if present.
     /// Supports both Replace (skip all configured rules) and Append (merge test rules at end) modes.
+    /// When <see cref="TestConfigurationContext.ConfigurationMode"/> is null no rules override is applied.
     /// </summary>
     private static ConfigRule[] ApplyTestConfigurationOverrides(ConfigRule[] configuredRules)
     {
         var testContext = CocoarTestConfiguration.Current;
-        if (testContext == null)
-        {
+        if (testContext?.Rules == null || testContext.ConfigurationMode == null)
             return configuredRules;
-        }
 
         var testRulesBuilder = new RulesBuilder();
         var testRules = testContext.Rules(testRulesBuilder);
 
-        return testContext.Mode switch
+        return testContext.ConfigurationMode switch
         {
             TestConfigurationMode.Replace => testRules,
             TestConfigurationMode.Append => configuredRules.Concat(testRules).ToArray(),

--- a/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
@@ -1,0 +1,117 @@
+using Cocoar.Configuration.Configure;
+using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.Providers.Abstractions;
+using Cocoar.Configuration.Rules;
+using Microsoft.Extensions.Logging;
+
+namespace Cocoar.Configuration.Core;
+
+public sealed class ConfigManagerBuilder
+{
+    private readonly ConfigManager _manager;
+
+    private Func<RulesBuilder, ConfigRule[]>? _rules;
+    private IEnumerable<ConfigRule>? _prebuiltRules;
+    private Func<SetupBuilder, SetupDefinition[]>? _setup;
+
+    private ILogger? _logger;
+    private int _debounceMilliseconds = 300;
+    private Func<Type, IProviderConfiguration, ConfigurationProvider>? _providerFactory;
+
+    private readonly List<Action<ConfigManager>> _afterBuildActions = new();
+
+    internal ConfigManagerBuilder(ConfigManager manager)
+    {
+        _manager = manager;
+    }
+
+    /// <summary>
+    /// Gets the CapabilityScope of the ConfigManager being built.
+    /// Used by satellite libraries to configure capabilities directly on the scope.
+    /// </summary>
+    public static ConfigManagerCapabilityScope GetCapabilityScope(ConfigManagerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder._manager.CapabilityScope;
+    }
+
+    public ConfigManagerBuilder WithConfiguration(
+        Func<RulesBuilder, ConfigRule[]> rules,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null)
+    {
+        _rules = rules;
+        _prebuiltRules = null;
+        _setup = setup;
+        return this;
+    }
+
+    public ConfigManagerBuilder WithConfiguration(
+        IEnumerable<ConfigRule> rules,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null)
+    {
+        _prebuiltRules = rules;
+        _rules = null;
+        _setup = setup;
+        return this;
+    }
+
+    public ConfigManagerBuilder UseLogger(ILogger logger)
+    {
+        _logger = logger;
+        return this;
+    }
+
+    public ConfigManagerBuilder UseDebounce(int milliseconds)
+    {
+        _debounceMilliseconds = milliseconds;
+        return this;
+    }
+
+    public ConfigManagerBuilder UseProviderFactory(
+        Func<Type, IProviderConfiguration, ConfigurationProvider> factory)
+    {
+        _providerFactory = factory;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an action that runs after ConfigManager is fully initialized.
+    /// Used by satellite libraries to perform post-init work
+    /// (e.g., constructing feature flags).
+    /// </summary>
+    internal ConfigManagerBuilder AfterBuild(Action<ConfigManager> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        _afterBuildActions.Add(action);
+        return this;
+    }
+
+    internal ConfigManager Build()
+    {
+        ConfigRule[] configuredRules;
+
+        if (_prebuiltRules is not null)
+        {
+            configuredRules = _prebuiltRules.ToArray();
+        }
+        else
+        {
+            var rulesBuilder = new RulesBuilder();
+            configuredRules = (_rules ?? (_ => []))(rulesBuilder);
+        }
+
+        _manager.Configure(
+            configuredRules,
+            _setup,
+            _logger,
+            _providerFactory,
+            _debounceMilliseconds);
+
+        _manager.Initialize();
+
+        foreach (var action in _afterBuildActions)
+            action(_manager);
+
+        return _manager;
+    }
+}

--- a/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
@@ -35,7 +35,25 @@ public sealed class ConfigManagerBuilder
         return builder._manager.CapabilityScope;
     }
 
-    public ConfigManagerBuilder WithConfiguration(
+    /// <summary>
+    /// Configures the rules that define how configuration is loaded and mapped to types.
+    /// </summary>
+    /// <param name="rules">A function that builds the configuration rules using the fluent API.</param>
+    /// <param name="setup">An optional function to configure DI bindings and type exposure.</param>
+    /// <returns>This builder for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// builder.UseConfiguration(
+    ///     rules => [
+    ///         rules.For&lt;AppSettings&gt;().FromFile("appsettings.json"),
+    ///         rules.For&lt;DbSettings&gt;().FromFile("database.json")
+    ///     ],
+    ///     setup => [
+    ///         setup.ConcreteType&lt;AppSettings&gt;()
+    ///     ]);
+    /// </code>
+    /// </example>
+    public ConfigManagerBuilder UseConfiguration(
         Func<RulesBuilder, ConfigRule[]> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
     {
@@ -45,7 +63,7 @@ public sealed class ConfigManagerBuilder
         return this;
     }
 
-    public ConfigManagerBuilder WithConfiguration(
+    public ConfigManagerBuilder UseConfiguration(
         IEnumerable<ConfigRule> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
     {
@@ -55,12 +73,24 @@ public sealed class ConfigManagerBuilder
         return this;
     }
 
+    /// <summary>
+    /// Configures the logger used by the configuration system for diagnostics and error reporting.
+    /// </summary>
+    /// <param name="logger">The logger instance to use.</param>
+    /// <returns>This builder for chaining.</returns>
     public ConfigManagerBuilder UseLogger(ILogger logger)
     {
         _logger = logger;
         return this;
     }
 
+    /// <summary>
+    /// Sets the debounce interval for coalescing rapid configuration changes.
+    /// When multiple changes occur within this window, only one recompute is triggered.
+    /// Default is 300ms.
+    /// </summary>
+    /// <param name="milliseconds">The debounce interval in milliseconds.</param>
+    /// <returns>This builder for chaining.</returns>
     public ConfigManagerBuilder UseDebounce(int milliseconds)
     {
         _debounceMilliseconds = milliseconds;
@@ -108,6 +138,35 @@ public sealed class ConfigManagerBuilder
             _debounceMilliseconds);
 
         _manager.Initialize();
+
+        foreach (var action in _afterBuildActions)
+            action(_manager);
+
+        return _manager;
+    }
+
+    internal async Task<ConfigManager> BuildAsync(CancellationToken cancellationToken = default)
+    {
+        ConfigRule[] configuredRules;
+
+        if (_prebuiltRules is not null)
+        {
+            configuredRules = _prebuiltRules.ToArray();
+        }
+        else
+        {
+            var rulesBuilder = new RulesBuilder();
+            configuredRules = (_rules ?? (_ => []))(rulesBuilder);
+        }
+
+        _manager.Configure(
+            configuredRules,
+            _setup,
+            _logger,
+            _providerFactory,
+            _debounceMilliseconds);
+
+        await _manager.InitializeAsync(cancellationToken).ConfigureAwait(false);
 
         foreach (var action in _afterBuildActions)
             action(_manager);

--- a/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
+++ b/src/Cocoar.Configuration/Core/ConfigManagerBuilder.cs
@@ -63,6 +63,13 @@ public sealed class ConfigManagerBuilder
         return this;
     }
 
+    /// <summary>
+    /// Configures the rules using a pre-built collection of <see cref="ConfigRule"/> instances.
+    /// Use this overload when rules are constructed programmatically rather than via the fluent builder.
+    /// </summary>
+    /// <param name="rules">A pre-built collection of configuration rules.</param>
+    /// <param name="setup">An optional function to configure DI bindings and type exposure.</param>
+    /// <returns>This builder for chaining.</returns>
     public ConfigManagerBuilder UseConfiguration(
         IEnumerable<ConfigRule> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
@@ -97,6 +104,12 @@ public sealed class ConfigManagerBuilder
         return this;
     }
 
+    /// <summary>
+    /// Overrides the default provider factory used to instantiate configuration providers.
+    /// Intended for testing and advanced scenarios where provider construction needs to be intercepted.
+    /// </summary>
+    /// <param name="factory">A factory function receiving the provider type and its configuration, returning the provider instance.</param>
+    /// <returns>This builder for chaining.</returns>
     public ConfigManagerBuilder UseProviderFactory(
         Func<Type, IProviderConfiguration, ConfigurationProvider> factory)
     {

--- a/src/Cocoar.Configuration/Core/ConfigSnapshot.cs
+++ b/src/Cocoar.Configuration/Core/ConfigSnapshot.cs
@@ -23,9 +23,9 @@ public sealed class ConfigSnapshot
     /// <summary>
     /// UTC timestamp when this snapshot was created.
     /// </summary>
-    public DateTime TimestampUtc { get; }
+    public DateTimeOffset TimestampUtc { get; }
 
-    private ConfigSnapshot(IReadOnlyDictionary<Type, object> instances, long version, DateTime timestampUtc)
+    private ConfigSnapshot(IReadOnlyDictionary<Type, object> instances, long version, DateTimeOffset timestampUtc)
     {
         _instances = instances;
         Version = version;
@@ -89,7 +89,7 @@ public sealed class ConfigSnapshot
     /// </summary>
     internal static ConfigSnapshot Create(IReadOnlyDictionary<Type, object> instances, long version)
     {
-        return new ConfigSnapshot(instances, version, DateTime.UtcNow);
+        return new ConfigSnapshot(instances, version, DateTimeOffset.UtcNow);
     }
 
     /// <summary>
@@ -98,5 +98,5 @@ public sealed class ConfigSnapshot
     public static ConfigSnapshot Empty { get; } = new(
         new Dictionary<Type, object>(),
         version: 0,
-        timestampUtc: DateTime.MinValue);
+        timestampUtc: DateTimeOffset.MinValue);
 }

--- a/src/Cocoar.Configuration/Core/ConfigurationAccessor.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationAccessor.cs
@@ -48,7 +48,7 @@ internal partial class ConfigurationAccessor : IConfigurationAccessor
     /// <b>DO NOT mutate the returned instance.</b> It is shared across all consumers.
     /// </remarks>
     /// <exception cref="InvalidOperationException">No configuration rule is registered for type T.</exception>
-    public T GetConfig<T>()
+    public T? GetConfig<T>() where T : class
     {
         // First try the backplane (has cached instances after initialization)
         try
@@ -123,7 +123,7 @@ internal partial class ConfigurationAccessor : IConfigurationAccessor
         }
     }
 
-    public bool TryGetConfig<T>(out T? value)
+    public bool TryGetConfig<T>(out T? value) where T : class
     {
         try
         {
@@ -145,7 +145,7 @@ internal partial class ConfigurationAccessor : IConfigurationAccessor
     /// </remarks>
     [Obsolete("Use GetConfig<T>() instead - it now throws if no rule is registered. " +
               "This method will be removed in a future version.")]
-    public T GetRequiredConfig<T>() => GetConfig<T>();
+    public T GetRequiredConfig<T>() => (T)GetConfig(typeof(T));
 
     /// <summary>
     /// Gets a configuration instance from the cached snapshot.

--- a/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationEngine.cs
@@ -37,7 +37,7 @@ internal static partial class ConfigurationEngineLog
 /// Handles initialization, recomputation, and change subscriptions.
 /// Delegates scheduling/cancellation to RecomputeScheduler.
 /// </summary>
-internal class ConfigurationEngine : IDisposable
+internal class ConfigurationEngine : IDisposable, IAsyncDisposable
 {
     private readonly ConfigurationState _state;
     private readonly ILogger _logger;
@@ -112,23 +112,17 @@ internal class ConfigurationEngine : IDisposable
         IConfigurationAccessor configAccessor,
         int startIndex)
     {
-        _scheduler.Schedule(ct =>
+        _scheduler.ScheduleAsync(async ct =>
         {
             try
             {
-                RecomputeAllConfigurationsSafe(ruleManagers, configAccessor, startIndex, ct);
+                await RecomputeAllConfigurationsSafeAsync(ruleManagers, configAccessor, startIndex, ct).ConfigureAwait(false);
                 _state.ReportSuccessfulRecompute(startIndex);
 
-                // Report any deserialization failures to health service
                 if (_state.LastDeserializationFailures.Count > 0)
-                {
                     _state.ReportDeserializationFailures(_state.LastDeserializationFailures);
-                }
             }
-            catch (OperationCanceledException)
-            {
-                // Expected when cancelled, don't report as failure
-            }
+            catch (OperationCanceledException) { }
             catch (Exception ex)
             {
                 _logger.RuntimeRecomputeFailed(ex);
@@ -138,10 +132,49 @@ internal class ConfigurationEngine : IDisposable
     }
 
     /// <summary>
+    /// Async variant of <see cref="InitializeAndCompute"/>. Used by <see cref="ConfigManager.InitializeAsync"/>.
+    /// </summary>
+    public async Task InitializeAndComputeAsync(
+        List<ConfigRule> rules,
+        List<RuleManager> ruleManagers,
+        ProviderRegistry providerRegistry,
+        IConfigurationAccessor configAccessor,
+        ExposureRegistry bindingRegistry,
+        ConfigManagerCapabilityScope capabilityScope,
+        Action<int> scheduleRecomputeCallback,
+        int debounceMilliseconds,
+        CancellationToken cancellationToken = default)
+    {
+        _bindingRegistry = bindingRegistry;
+        _capabilityScope = capabilityScope;
+
+        _state.InitializeBackplane(bindingRegistry);
+
+        ruleManagers.Clear();
+        ruleManagers.AddRange(rules.Select(rule => new RuleManager(rule, _logger, providerRegistry)));
+
+        try
+        {
+            await RecomputeAllConfigurationsSafeAsync(ruleManagers, configAccessor, 0, cancellationToken).ConfigureAwait(false);
+            CreateChangeSubscriptions(ruleManagers, scheduleRecomputeCallback, debounceMilliseconds);
+
+            _state.ReportSuccessfulRecompute(0);
+            _state.MarkStartupComplete();
+            _logger.StartupComplete();
+        }
+        catch (Exception ex)
+        {
+            _logger.InitializationFailed(ex);
+            _state.ReportFailedRecompute(0, ex);
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Recomputes all configurations starting from the given index, with semaphore protection and error handling.
     /// </summary>
     public void RecomputeAllConfigurationsSafe(
-        IEnumerable<RuleManager> ruleManagers,
+        IReadOnlyList<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
         int startIndex = 0,
         CancellationToken cancellationToken = default)
@@ -180,7 +213,7 @@ internal class ConfigurationEngine : IDisposable
     /// Async version of RecomputeAllConfigurationsSafe.
     /// </summary>
     public async Task RecomputeAllConfigurationsSafeAsync(
-        IEnumerable<RuleManager> ruleManagers,
+        IReadOnlyList<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
         int startIndex = 0,
         CancellationToken cancellationToken = default)
@@ -216,19 +249,18 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private void RecomputeAllConfigurations(
-        IEnumerable<RuleManager> ruleManagers,
+        IReadOnlyList<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
         int startIndex = 0,
         CancellationToken cancellationToken = default)
     {
         var mergedConfigs = new Dictionary<Type, MutableJsonObject>();
         _state.BeginUpdate();
-        var orderedManagers = ruleManagers.ToList();
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        RestorePrefixContributions(orderedManagers, startIndex, mergedConfigs, cancellationToken);
-        RecomputeSuffix(orderedManagers, startIndex, configAccessor, mergedConfigs, cancellationToken);
+        RestorePrefixContributions(ruleManagers, startIndex, mergedConfigs, cancellationToken);
+        RecomputeSuffix(ruleManagers, startIndex, configAccessor, mergedConfigs, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -245,19 +277,18 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private async Task RecomputeAllConfigurationsAsync(
-        IEnumerable<RuleManager> ruleManagers,
+        IReadOnlyList<RuleManager> ruleManagers,
         IConfigurationAccessor configAccessor,
         int startIndex = 0,
         CancellationToken cancellationToken = default)
     {
         var mergedConfigs = new Dictionary<Type, MutableJsonObject>();
         _state.BeginUpdate();
-        var orderedManagers = ruleManagers.ToList();
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        RestorePrefixContributions(orderedManagers, startIndex, mergedConfigs, cancellationToken);
-        await RecomputeSuffixAsync(orderedManagers, startIndex, configAccessor, mergedConfigs, cancellationToken).ConfigureAwait(false);
+        RestorePrefixContributions(ruleManagers, startIndex, mergedConfigs, cancellationToken);
+        await RecomputeSuffixAsync(ruleManagers, startIndex, configAccessor, mergedConfigs, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -274,7 +305,7 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private void RestorePrefixContributions(
-        List<RuleManager> orderedManagers,
+        IReadOnlyList<RuleManager> orderedManagers,
         int startIndex,
         Dictionary<Type, MutableJsonObject> mergedConfigs,
         CancellationToken cancellationToken)
@@ -302,7 +333,7 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private void RecomputeSuffix(
-        List<RuleManager> orderedManagers,
+        IReadOnlyList<RuleManager> orderedManagers,
         int startIndex,
         IConfigurationAccessor configAccessor,
         Dictionary<Type, MutableJsonObject> mergedConfigs,
@@ -320,7 +351,7 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private async Task RecomputeSuffixAsync(
-        List<RuleManager> orderedManagers,
+        IReadOnlyList<RuleManager> orderedManagers,
         int startIndex,
         IConfigurationAccessor configAccessor,
         Dictionary<Type, MutableJsonObject> mergedConfigs,
@@ -395,20 +426,19 @@ internal class ConfigurationEngine : IDisposable
     }
 
     private void CreateChangeSubscriptions(
-        IEnumerable<RuleManager> ruleManagers,
+        IReadOnlyList<RuleManager> ruleManagers,
         Action<int> recomputeFromIndexCallback,
         int debounceMilliseconds)
     {
         DisposeAllSubscriptions();
 
-        var list = ruleManagers.ToList();
         var coalescer = new RecomputeCoalescer(_logger, recomputeFromIndexCallback, debounceMilliseconds, 40);
         _changeSubscriptions.Add(coalescer);
 
-        for (var i = 0; i < list.Count; i++)
+        for (var i = 0; i < ruleManagers.Count; i++)
         {
             var idx = i;
-            var rm = list[i];
+            var rm = ruleManagers[i];
             var subscription = rm.Changes.Subscribe(_ =>
             {
                 try
@@ -442,6 +472,15 @@ internal class ConfigurationEngine : IDisposable
         _scheduler.Dispose();
         DisposeAllSubscriptions();
         _recomputeSemaphore.Dispose();
-        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        await _scheduler.DisposeAsync().ConfigureAwait(false);
+        DisposeAllSubscriptions();
+        _recomputeSemaphore.Dispose();
     }
 }

--- a/src/Cocoar.Configuration/Core/ConfigurationState.cs
+++ b/src/Cocoar.Configuration/Core/ConfigurationState.cs
@@ -190,6 +190,5 @@ internal class ConfigurationState : IDisposable
     {
         _healthReporter.Dispose();
         _backplane?.Dispose();
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Cocoar.Configuration/Core/MasterBackplane.cs
+++ b/src/Cocoar.Configuration/Core/MasterBackplane.cs
@@ -148,8 +148,6 @@ internal sealed class MasterBackplane : IDisposable
         _snapshotSubject.OnCompleted();
         _snapshotSubject.Dispose();
         _typeProjectionCache.Clear();
-
-        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/src/Cocoar.Configuration/Core/RecomputeScheduler.cs
+++ b/src/Cocoar.Configuration/Core/RecomputeScheduler.cs
@@ -6,7 +6,7 @@ namespace Cocoar.Configuration.Core;
 /// Manages scheduling and cancellation of configuration recompute operations.
 /// Handles concurrency boundaries: cancels in-flight recomputes when new ones are triggered.
 /// </summary>
-internal sealed class RecomputeScheduler : IDisposable
+internal sealed class RecomputeScheduler : IDisposable, IAsyncDisposable
 {
     private readonly Lock _recomputeGate = new();
     private CancellationTokenSource? _recomputeCts;
@@ -72,6 +72,15 @@ internal sealed class RecomputeScheduler : IDisposable
         _disposed = true;
 
         DisposeCancellationSource();
-        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        DisposeCancellationSource();
+        if (_currentRecomputeTask is { } task)
+            await task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
     }
 }

--- a/src/Cocoar.Configuration/Fluent/ProviderRuleBuilder.cs
+++ b/src/Cocoar.Configuration/Fluent/ProviderRuleBuilder.cs
@@ -46,6 +46,11 @@ public sealed class ProviderRuleBuilder<TProvider, TInstanceOptions, TQueryOptio
             opts);
     }
 
+    /// <remarks>
+    /// This implicit conversion triggers <see cref="Build"/> immediately.
+    /// Ensure the fluent chain is complete before the implicit conversion occurs,
+    /// as any further method calls after conversion will not be reflected in the built rule.
+    /// </remarks>
     public static implicit operator ConfigRule(ProviderRuleBuilder<TProvider, TInstanceOptions, TQueryOptions> builder)
     {
        return builder.Build();

--- a/src/Cocoar.Configuration/Fluent/RuleBuilderBase.cs
+++ b/src/Cocoar.Configuration/Fluent/RuleBuilderBase.cs
@@ -12,18 +12,36 @@ public abstract class RuleBuilderBase<TBuilder>
     protected string? SelectPath { get; set; }
     protected string? Name { get; set; }
 
+    /// <summary>
+    /// Marks the rule as required. If a required rule fails to load or deserialize,
+    /// the entire recompute is rolled back and the previous configuration snapshot is retained.
+    /// </summary>
+    /// <param name="value">True to mark the rule as required (default); false to revert to optional.</param>
+    /// <returns>This builder for chaining.</returns>
     public TBuilder Required(bool value = true)
     {
         IsRequired = value;
         return (TBuilder)this;
     }
-    
+
+    /// <summary>
+    /// Conditionally executes this rule based on a predicate evaluated against the current configuration state.
+    /// If the predicate returns false, the rule is skipped during recompute.
+    /// </summary>
+    /// <param name="predicate">A function that receives the current <see cref="IConfigurationAccessor"/> and returns true if the rule should run.</param>
+    /// <returns>This builder for chaining.</returns>
     public TBuilder When(Func<IConfigurationAccessor, bool> predicate)
     {
         UseWhen = predicate;
         return (TBuilder)this;
     }
 
+    /// <summary>
+    /// Sets the JSON mount path used when merging this rule's output into the target configuration type.
+    /// Values from this rule are nested under the given path before deserialization.
+    /// </summary>
+    /// <param name="mountPath">The dot-notation path to mount values under (e.g., "Database" or "Feature.Flags").</param>
+    /// <returns>This builder for chaining.</returns>
     public TBuilder MountAt(string mountPath)
     {
         if (string.IsNullOrWhiteSpace(mountPath))
@@ -35,6 +53,12 @@ public abstract class RuleBuilderBase<TBuilder>
         return (TBuilder)this;
     }
 
+    /// <summary>
+    /// Sets the JSON selection path used to extract a sub-document from the provider's output
+    /// before it is merged into the target configuration type.
+    /// </summary>
+    /// <param name="selectPath">The dot-notation path of the JSON property to select (e.g., "ConnectionStrings.Default").</param>
+    /// <returns>This builder for chaining.</returns>
     public TBuilder Select(string selectPath)
     {
         if (string.IsNullOrWhiteSpace(selectPath))
@@ -46,6 +70,11 @@ public abstract class RuleBuilderBase<TBuilder>
         return (TBuilder)this;
     }
 
+    /// <summary>
+    /// Assigns a display name to this rule for use in health monitoring and diagnostic output.
+    /// </summary>
+    /// <param name="name">A short, descriptive name for the rule (e.g., "BaseSettings", "ProductionOverride").</param>
+    /// <returns>This builder for chaining.</returns>
     public TBuilder Named(string name)
     {
         if (string.IsNullOrWhiteSpace(name))

--- a/src/Cocoar.Configuration/Health/ConfigurationHealth.cs
+++ b/src/Cocoar.Configuration/Health/ConfigurationHealth.cs
@@ -1,67 +1,10 @@
 namespace Cocoar.Configuration.Health;
 
 /// <summary>
-/// Represents the overall health status of the configuration system.
-/// </summary>
-public enum ConfigurationHealthStatus
-{
-    /// <summary>
-    /// All required rules are healthy and functioning correctly.
-    /// </summary>
-    Healthy = 0,
-
-    /// <summary>
-    /// Some optional rules are failing, but all required rules are healthy.
-    /// </summary>
-    Degraded,
-
-    /// <summary>
-    /// One or more required rules are failing.
-    /// </summary>
-    Unhealthy,
-
-    /// <summary>
-    /// Configuration health is not yet determined.
-    /// </summary>
-    Unknown
-}
-
-/// <summary>
-/// Represents the evaluation state of a configuration rule.
-/// </summary>
-public enum RuleEvaluationState
-{
-    /// <summary>
-    /// Rule has not been evaluated yet.
-    /// </summary>
-    NotEvaluated = 0,
-
-    /// <summary>
-    /// Rule was skipped due to When predicate evaluation.
-    /// </summary>
-    Skipped,
-
-    /// <summary>
-    /// Rule evaluation is currently in progress.
-    /// </summary>
-    Evaluating,
-
-    /// <summary>
-    /// Rule was successfully evaluated.
-    /// </summary>
-    Success,
-
-    /// <summary>
-    /// Rule evaluation failed.
-    /// </summary>
-    Failed
-}
-
-/// <summary>
 /// Simple health information for a single configuration rule.
 /// </summary>
 public readonly record struct RuleHealthInfo(
-    RuleEvaluationState State,
+    RuleResultStatus Status,
     bool IsRequired,
     bool IsSkipped
 );
@@ -77,27 +20,27 @@ public class ConfigurationHealthInfo
     /// <summary>
     /// Overall health status calculated automatically from rule states.
     /// </summary>
-    public ConfigurationHealthStatus State
+    public HealthStatus State
     {
         get
         {
             if (Rules.Count == 0)
             {
-                return ConfigurationHealthStatus.Unknown;
+                return HealthStatus.Unknown;
             }
-            if (Rules.Any(r => r is { IsRequired: true, State: RuleEvaluationState.Failed }))
+            if (Rules.Any(r => r is { IsRequired: true, Status: RuleResultStatus.Down }))
             {
-                return ConfigurationHealthStatus.Unhealthy;
+                return HealthStatus.Unhealthy;
             }
-            if (Rules.Any(r => r.State is RuleEvaluationState.Evaluating or RuleEvaluationState.NotEvaluated))
+            if (Rules.Any(r => r.Status is RuleResultStatus.Unknown))
             {
-                return ConfigurationHealthStatus.Unknown;
+                return HealthStatus.Unknown;
             }
-            if (Rules.Any(r => r is { IsRequired: false, State: RuleEvaluationState.Failed }))
+            if (Rules.Any(r => r is { IsRequired: false, Status: RuleResultStatus.Down }))
             {
-                return ConfigurationHealthStatus.Degraded;
+                return HealthStatus.Degraded;
             }
-            return ConfigurationHealthStatus.Healthy;
+            return HealthStatus.Healthy;
         }
     }
 

--- a/src/Cocoar.Configuration/Health/ConfigurationHealthModels.cs
+++ b/src/Cocoar.Configuration/Health/ConfigurationHealthModels.cs
@@ -248,12 +248,31 @@ public sealed class ConfigHealthSnapshot(
     }
 }
 
+/// <summary>
+/// Provides health status and observable streams for the configuration system.
+/// Obtain an instance via <see cref="Core.ConfigManager.GetHealthService"/>.
+/// Both <see cref="SnapshotStream"/> and <see cref="StatusStream"/> use BehaviorSubject semantics —
+/// subscribers receive the current value immediately on subscribe, then on every subsequent change.
+/// </summary>
 public interface IConfigurationHealthService
 {
+    /// <summary>Current overall health status of the configuration system.</summary>
     HealthStatus Status { get; }
+
+    /// <summary>The most recent full health snapshot including per-rule details.</summary>
     ConfigHealthSnapshot Snapshot { get; }
+
+    /// <summary>
+    /// Observable stream of health snapshots. Replays the latest snapshot on subscribe (BehaviorSubject semantics).
+    /// </summary>
     IObservable<ConfigHealthSnapshot> SnapshotStream { get; }
+
+    /// <summary>
+    /// Observable stream of overall health status changes. Replays the latest status on subscribe (BehaviorSubject semantics).
+    /// </summary>
     IObservable<HealthStatus> StatusStream { get; }
+
+    /// <summary><c>true</c> when <see cref="Status"/> is <see cref="HealthStatus.Healthy"/>.</summary>
     bool IsHealthy { get; }
 }
 

--- a/src/Cocoar.Configuration/Infrastructure/ChangeSubscriptionManager.cs
+++ b/src/Cocoar.Configuration/Infrastructure/ChangeSubscriptionManager.cs
@@ -51,6 +51,5 @@ internal class ChangeSubscriptionManager(ILogger logger) : IDisposable
     public void Dispose()
     {
         DisposeAllSubscriptions();
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Cocoar.Configuration/Infrastructure/ExposureRegistry.cs
+++ b/src/Cocoar.Configuration/Infrastructure/ExposureRegistry.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System.Collections.Frozen;
 using Cocoar.Capabilities;
 using Cocoar.Configuration.Configure;
 using Cocoar.Configuration.Core;
@@ -29,8 +30,8 @@ internal static partial class ExposureRegistryLog
 
 internal sealed class ExposureRegistry
 {
-    private readonly Dictionary<Type, Type> _interfaceToConcreteMap = new();
-    private readonly Dictionary<Type, Type> _deserializationMap = new();
+    private FrozenDictionary<Type, Type> _interfaceToConcreteMap = FrozenDictionary<Type, Type>.Empty;
+    private FrozenDictionary<Type, Type> _deserializationMap = FrozenDictionary<Type, Type>.Empty;
     private readonly ILogger _logger;
     private readonly ConfigManagerCapabilityScope _capabilityScope;
 
@@ -54,9 +55,9 @@ internal sealed class ExposureRegistry
 
     private void BuildMappingTables(IEnumerable<SetupDefinition> bindings)
     {
-        _interfaceToConcreteMap.Clear();
-        _deserializationMap.Clear();
-        
+        var interfaceToConcreteMap = new Dictionary<Type, Type>();
+        var deserializationMap = new Dictionary<Type, Type>();
+
         foreach (var configureSpec in bindings)
         {
 
@@ -64,7 +65,7 @@ internal sealed class ExposureRegistry
                 continue;
             }
 
-           
+
             if (!bag.TryGetPrimaryAs<IPrimaryTypeCapability>(out var typeCapability))
             {
                 _logger.MissingPrimaryTypeCapability();
@@ -75,44 +76,47 @@ internal sealed class ExposureRegistry
             if (primaryType.IsClass)
             {
                 var concreteType = primaryType;
-                
+
                 bag.GetAll<ExposeAsCapability<SetupDefinition>>().ForEach(exposeAs =>
                 {
                     var interfaceType = exposeAs.ContractType;
-                    
 
-                    if (_interfaceToConcreteMap.TryGetValue(interfaceType, out var existingConcrete))
+
+                    if (interfaceToConcreteMap.TryGetValue(interfaceType, out var existingConcrete))
                     {
                         _logger.ExposeOverride(interfaceType.Name, existingConcrete.Name, concreteType.Name);
                     }
-                    
-                    _interfaceToConcreteMap[interfaceType] = concreteType;
-                    
+
+                    interfaceToConcreteMap[interfaceType] = concreteType;
+
                     _logger.ExposedInterface(interfaceType.Name, concreteType.Name);
                 });
             }
             if (primaryType.IsInterface)
             {
                 var interfaceType = primaryType;
-                
+
                 var deserializeCaps = bag.GetAll<DeserializeToCapability<SetupDefinition>>();
                 var deserializeToCapability = deserializeCaps.Count != 0 ? deserializeCaps[0] : null;
                 if (deserializeToCapability != null)
                 {
                     var concreteType = deserializeToCapability.ConcreteType;
 
-                    if (_deserializationMap.TryGetValue(interfaceType, out var existingConcrete))
+                    if (deserializationMap.TryGetValue(interfaceType, out var existingConcrete))
                     {
                         _logger.DeserializeMappingOverride(interfaceType.Name, existingConcrete.Name, concreteType.Name);
                     }
-                    
-                    _deserializationMap[interfaceType] = concreteType;
-                    
+
+                    deserializationMap[interfaceType] = concreteType;
+
                     _logger.DeserializeMapping(interfaceType.Name, concreteType.Name);
                 }
             }
         }
-        
+
+        _interfaceToConcreteMap = interfaceToConcreteMap.ToFrozenDictionary();
+        _deserializationMap = deserializationMap.ToFrozenDictionary();
+
         _logger.BuiltExposureRegistry(_interfaceToConcreteMap.Count, _deserializationMap.Count);
     }
 }

--- a/src/Cocoar.Configuration/Providers/CommandLineProvider/CommandLineArgumentRulesExtensions.cs
+++ b/src/Cocoar.Configuration/Providers/CommandLineProvider/CommandLineArgumentRulesExtensions.cs
@@ -16,10 +16,10 @@ public static class CommandLineArgumentRulesExtensions
 
     public static
         ProviderRuleBuilder<CommandLineArgumentProvider, CommandLineProviderOptions,
-            CommandLineProviderQueryOptions> FromCommandLine<T>(this TypedRuleBuilder<T> builder, string[] switchPrefixes, string? prefix = null)
+            CommandLineProviderQueryOptions> FromCommandLine<T>(this TypedRuleBuilder<T> builder, string[] switchPrefixes)
         => new(
             cm => new(),
-            cm => new(null, switchPrefixes, prefix),
+            cm => new(null, switchPrefixes, null),
             typeof(T)
         );
 
@@ -29,7 +29,7 @@ public static class CommandLineArgumentRulesExtensions
             Func<IConfigurationAccessor, CommandLineRuleOptions> optionsFactory)
         => new(
             cm => new(),
-            cm => new(optionsFactory(cm).Args, optionsFactory(cm).SwitchPrefixes, optionsFactory(cm).Prefix),
+            cm => { var opts = optionsFactory(cm); return new CommandLineProviderQueryOptions(opts.Args, opts.SwitchPrefixes, opts.Prefix); },
             typeof(T)
         );
 }

--- a/src/Cocoar.Configuration/Providers/CommandLineProvider/README.md
+++ b/src/Cocoar.Configuration/Providers/CommandLineProvider/README.md
@@ -15,9 +15,9 @@ The CommandLine provider allows you to load configuration from command-line argu
 ### Simple usage (default `--` prefix)
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<AppConfig>().FromCommandLine()
-]);
+]));
 ```
 
 Command line:
@@ -96,10 +96,10 @@ public class DatabaseConfig
 You can use prefixes to map different command-line arguments to different configuration types:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<AppConfig>().FromCommandLine("app_"),
     rule.For<DatabaseConfig>().FromCommandLine("db_")
-]);
+]));
 ```
 
 Command line:
@@ -116,10 +116,10 @@ This maps:
 Mix semantic prefixes with custom switch styles:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<TargetConfig>().FromCommandLine("target_", ["@"]),
     rule.For<IssueConfig>().FromCommandLine("issue_", ["#"])
-]);
+]));
 ```
 
 Command line:
@@ -130,19 +130,19 @@ invoke.exe @target_host=10.10.10.10 #issue_id=123
 ### Dynamic Configuration with Config-Aware Rules
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<TenantSettings>().FromFile("tenant.json"),
-    
+
     rule.For<AppConfig>().FromCommandLine(accessor =>
     {
         var tenant = accessor.GetRequiredConfig<TenantSettings>();
-        return new CommandLineRuleOptions 
-        { 
+        return new CommandLineRuleOptions
+        {
             Prefix = $"{tenant.Name}_",
             SwitchPrefixes = ["--", "-"]
         };
     })
-]);
+]));
 ```
 
 ## Argument Format Support
@@ -213,11 +213,11 @@ public class AppConfig
 Command-line arguments are typically used as the highest-priority layer to override file and environment-based configuration:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<AppConfig>().FromFile("appsettings.json"),  // Base
     rule.For<AppConfig>().FromEnvironment("APP_"),       // Override
     rule.For<AppConfig>().FromCommandLine()              // Final override
-]);
+]));
 ```
 
 Command line:

--- a/src/Cocoar.Configuration/Providers/CommandLineProvider/README.md
+++ b/src/Cocoar.Configuration/Providers/CommandLineProvider/README.md
@@ -15,7 +15,7 @@ The CommandLine provider allows you to load configuration from command-line argu
 ### Simple usage (default `--` prefix)
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<AppConfig>().FromCommandLine()
 ]));
 ```
@@ -96,7 +96,7 @@ public class DatabaseConfig
 You can use prefixes to map different command-line arguments to different configuration types:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<AppConfig>().FromCommandLine("app_"),
     rule.For<DatabaseConfig>().FromCommandLine("db_")
 ]));
@@ -116,7 +116,7 @@ This maps:
 Mix semantic prefixes with custom switch styles:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<TargetConfig>().FromCommandLine("target_", ["@"]),
     rule.For<IssueConfig>().FromCommandLine("issue_", ["#"])
 ]));
@@ -130,7 +130,7 @@ invoke.exe @target_host=10.10.10.10 #issue_id=123
 ### Dynamic Configuration with Config-Aware Rules
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<TenantSettings>().FromFile("tenant.json"),
 
     rule.For<AppConfig>().FromCommandLine(accessor =>
@@ -213,7 +213,7 @@ public class AppConfig
 Command-line arguments are typically used as the highest-priority layer to override file and environment-based configuration:
 
 ```csharp
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<AppConfig>().FromFile("appsettings.json"),  // Base
     rule.For<AppConfig>().FromEnvironment("APP_"),       // Override
     rule.For<AppConfig>().FromCommandLine()              // Final override

--- a/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticRulesExtensions.cs
+++ b/src/Cocoar.Configuration/Providers/StaticJsonProvider/StaticRulesExtensions.cs
@@ -50,10 +50,6 @@ public static class StaticRulesExtensions
     private static JsonSerializerOptions? GetSerializerOptions()
     {
         // Only use custom serialization in test context with registered options
-        if (CocoarTestConfiguration.Current != null)
-        {
-            return CocoarTestConfiguration.TestSerializerOptions;
-        }
-        return null;  // Use default serialization
+        return CocoarTestConfiguration.Current?.SerializerOptions;
     }
 }

--- a/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveConfigManager.cs
@@ -61,7 +61,7 @@ internal sealed class ReactiveConfigManager : IDisposable
         return (IReactiveConfig<T>)_reactiveConfigs.GetOrAdd(type, _ =>
         {
             _logger.CreatedReactiveConfig(type);
-            return new BackplaneReactiveConfig<T>(_backplane, _logger);
+            return new BackplaneReactiveConfig<T>(_backplane);
         });
     }
 
@@ -80,7 +80,6 @@ internal sealed class ReactiveConfigManager : IDisposable
         }
 
         _reactiveConfigs.Clear();
-        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -91,13 +90,13 @@ internal sealed class ReactiveConfigManager : IDisposable
         private readonly MasterBackplane _backplane;
         private readonly IObservable<T> _observable;
 
-        public BackplaneReactiveConfig(MasterBackplane backplane, ILogger logger)
+        public BackplaneReactiveConfig(MasterBackplane backplane)
         {
             _backplane = backplane;
             _observable = backplane.GetTypeProjection<T>();
         }
 
-        public T CurrentValue => _backplane.GetConfig<T>()!;
+        public T CurrentValue => _backplane.GetConfig<T>() ?? throw new InvalidOperationException($"No configuration available for type {typeof(T).Name}.");
 
         public IDisposable Subscribe(IObserver<T> observer) => _observable.Subscribe(observer);
 

--- a/src/Cocoar.Configuration/Reactive/ReactiveConfigurationFactory.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveConfigurationFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System.Reflection;
 using Cocoar.Configuration.Rules;
 using Cocoar.Configuration.Core;
 using Cocoar.Configuration.Infrastructure;
@@ -27,6 +28,11 @@ internal class ReactiveConfigurationFactory(
     ConfigManager configManager,
     ExposureRegistry bindingRegistry)
 {
+    private static readonly MethodInfo _getReactiveConfigMethod =
+        typeof(ReactiveConfigManager).GetMethod(nameof(ReactiveConfigManager.GetReactiveConfig))!;
+    private static readonly MethodInfo _getConfigMethod =
+        typeof(ConfigManager).GetMethod(nameof(ConfigManager.GetConfig), Type.EmptyTypes)!;
+
     public IReactiveConfig<T> GetReactiveConfig<T>(Func<T> configAccessor)
     {
         var t = typeof(T);
@@ -58,14 +64,7 @@ internal class ReactiveConfigurationFactory(
         }
 
         // Use reflection to call the generic method with class constraint
-        var method = typeof(ReactiveConfigManager)
-            .GetMethod(nameof(ReactiveConfigManager.GetReactiveConfig))?
-            .MakeGenericMethod(t);
-
-        if (method == null)
-        {
-            throw new InvalidOperationException($"Cannot create IReactiveConfig<{t.Name}> - internal error.");
-        }
+        var method = _getReactiveConfigMethod.MakeGenericMethod(t);
 
         var funcType = typeof(Func<>).MakeGenericType(t);
         return (IReactiveConfig<T>)method.Invoke(reactiveConfigManager, [configAccessor])!;
@@ -78,27 +77,13 @@ internal class ReactiveConfigurationFactory(
     private IReactiveConfig<TInterface> CreateReactiveConfigForConcreteType<TInterface>(Type concreteType, Func<TInterface> configAccessor)
     {
         // Create an accessor for the concrete type that returns TInterface (which the concrete type implements)
-        var concreteAccessorMethod = typeof(ConfigManager)
-            .GetMethod(nameof(ConfigManager.GetConfig), Type.EmptyTypes)?
-            .MakeGenericMethod(concreteType);
-
-        if (concreteAccessorMethod == null)
-        {
-            throw new InvalidOperationException($"Cannot create accessor for concrete type {concreteType.Name}.");
-        }
+        var concreteAccessorMethod = _getConfigMethod.MakeGenericMethod(concreteType);
 
         var concreteFuncType = typeof(Func<>).MakeGenericType(concreteType);
         var concreteAccessor = Delegate.CreateDelegate(concreteFuncType, configManager, concreteAccessorMethod);
 
         // Get the reactive config for the concrete type
-        var reactiveMethod = typeof(ReactiveConfigManager)
-            .GetMethod(nameof(ReactiveConfigManager.GetReactiveConfig))?
-            .MakeGenericMethod(concreteType);
-
-        if (reactiveMethod == null)
-        {
-            throw new InvalidOperationException($"Cannot create IReactiveConfig for concrete type {concreteType.Name}.");
-        }
+        var reactiveMethod = _getReactiveConfigMethod.MakeGenericMethod(concreteType);
 
         var concreteReactiveConfig = reactiveMethod.Invoke(reactiveConfigManager, [concreteAccessor])!;
 
@@ -171,23 +156,8 @@ internal class ReactiveConfigurationFactory(
 
             try
             {
-                var reactiveMethod = typeof(ReactiveConfigManager)
-                    .GetMethod(nameof(ReactiveConfigManager.GetReactiveConfig))?
-                    .MakeGenericMethod(typeToPrime);
-                if (reactiveMethod == null)
-                {
-                    logger.MissingGetReactiveConfig(typeToPrime);
-                    continue;
-                }
-
-                var accessorMethod = typeof(ConfigManager)
-                    .GetMethod(nameof(ConfigManager.GetConfig), Type.EmptyTypes)?
-                    .MakeGenericMethod(typeToPrime);
-                if (accessorMethod == null)
-                {
-                    logger.MissingGetConfig(typeToPrime);
-                    continue;
-                }
+                var reactiveMethod = _getReactiveConfigMethod.MakeGenericMethod(typeToPrime);
+                var accessorMethod = _getConfigMethod.MakeGenericMethod(typeToPrime);
 
                 var funcType = typeof(Func<>).MakeGenericType(typeToPrime);
                 var accessorDelegate = Delegate.CreateDelegate(funcType, configManager, accessorMethod);

--- a/src/Cocoar.Configuration/Reactive/ReactiveTupleConfig.cs
+++ b/src/Cocoar.Configuration/Reactive/ReactiveTupleConfig.cs
@@ -113,33 +113,7 @@ internal sealed class ReactiveTupleConfig<TTuple> : IReactiveConfig<TTuple>, IDi
             TTuple? previousTuple = null;
 
             // Subscribe to the backplane's snapshot stream
-            var backplane = configManager.GetType()
-                .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance)?
-                .GetValue(configManager);
-
-            if (backplane == null)
-            {
-                observer.OnError(new InvalidOperationException("Cannot access ConfigurationState for tuple observation"));
-                return Disposable.Empty;
-            }
-
-            var backplaneProp = backplane.GetType().GetProperty("Backplane", BindingFlags.Public | BindingFlags.Instance);
-            var masterBackplane = backplaneProp?.GetValue(backplane);
-
-            if (masterBackplane == null)
-            {
-                observer.OnError(new InvalidOperationException("MasterBackplane not initialized for tuple observation"));
-                return Disposable.Empty;
-            }
-
-            var snapshotStreamProp = masterBackplane.GetType().GetProperty("SnapshotStream");
-            var snapshotStream = snapshotStreamProp?.GetValue(masterBackplane) as IObservable<ConfigSnapshot>;
-
-            if (snapshotStream == null)
-            {
-                observer.OnError(new InvalidOperationException("Cannot access SnapshotStream for tuple observation"));
-                return Disposable.Empty;
-            }
+            var snapshotStream = configManager.Backplane.SnapshotStream;
 
             return snapshotStream.Subscribe(snapshot =>
             {

--- a/src/Cocoar.Configuration/Rules/ConfigRule.cs
+++ b/src/Cocoar.Configuration/Rules/ConfigRule.cs
@@ -7,7 +7,7 @@ namespace Cocoar.Configuration.Rules;
 /// Represents a single configuration rule that fetches data from a provider and binds it to a concrete type.
 /// Rules are executed in order, with later rules overwriting earlier ones (last-write-wins).
 /// </summary>
-public class ConfigRule(
+public sealed class ConfigRule(
     Type providerType,
     Func<IConfigurationAccessor, IProviderConfiguration> providerOptionsFactory,
     Func<IConfigurationAccessor, IProviderQuery> queryOptionsFactory,

--- a/src/Cocoar.Configuration/Rules/RuleManager.cs
+++ b/src/Cocoar.Configuration/Rules/RuleManager.cs
@@ -20,6 +20,12 @@ internal static partial class RuleManagerLog
 
     [LoggerMessage(EventId = 5002, Level = LogLevel.Warning, Message = "Optional rule failed and will be skipped: {Provider}->{Config}")]
     public static partial void OptionalRuleFailed(this ILogger logger, Exception exception, string Provider, string Config);
+
+    [LoggerMessage(EventId = 5003, Level = LogLevel.Debug, Message = "Query key hash failed for {QueryType}; falling back to JSON serialization")]
+    public static partial void QueryKeyHashFallback(this ILogger logger, Exception exception, string QueryType);
+
+    [LoggerMessage(EventId = 5004, Level = LogLevel.Debug, Message = "Transform key computation failed; falling back to empty key")]
+    public static partial void TransformKeyFallback(this ILogger logger, Exception exception);
 }
 
 /// <summary>
@@ -225,7 +231,7 @@ internal sealed class RuleManager : IDisposable
         return "{}"u8.ToArray();
     }
 
-    private static string ComputeQueryKey(IProviderQuery query)
+    private string ComputeQueryKey(IProviderQuery query)
     {
         try
         {
@@ -242,13 +248,14 @@ internal sealed class RuleManager : IDisposable
 
             return Convert.ToHexString(hash.GetHashAndReset());
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
         {
+            _logger.QueryKeyHashFallback(ex, query.GetType().Name);
             return JsonSerializer.Serialize(query, query.GetType());
         }
     }
 
-    private static string ComputeTransformKey(ConfigRuleOptions? options)
+    private string ComputeTransformKey(ConfigRuleOptions? options)
     {
         try
         {
@@ -259,8 +266,9 @@ internal sealed class RuleManager : IDisposable
             var hash = SHA256.HashData(bytes);
             return Convert.ToHexString(hash);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
+            _logger.TransformKeyFallback(ex);
             return string.Empty;
         }
     }

--- a/src/Cocoar.Configuration/Rules/TransformCache.cs
+++ b/src/Cocoar.Configuration/Rules/TransformCache.cs
@@ -93,11 +93,8 @@ internal sealed class TransformCache : IDisposable
             
             var hash = ComputeSelectionHash(transformed);
             
-            // Use constant-time comparison to prevent timing attacks
-            if (_lastSelectionHash is not null && 
-                CryptographicOperations.FixedTimeEquals(
-                    System.Text.Encoding.UTF8.GetBytes(hash),
-                    System.Text.Encoding.UTF8.GetBytes(_lastSelectionHash)))
+            if (_lastSelectionHash is not null &&
+                string.Equals(hash, _lastSelectionHash, StringComparison.Ordinal))
             {
                 return false; // No change
             }

--- a/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
+++ b/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
@@ -160,12 +160,6 @@ public static class CocoarTestConfiguration
     /// </summary>
     public static bool IsActive => s_testContext.Value != null;
 
-    /// <summary>
-    /// Optional custom serializer options for test scenarios.
-    /// Set by extension packages (e.g., Cocoar.Configuration.Secrets) to handle
-    /// special types during FromStatic serialization.
-    /// </summary>
-    public static JsonSerializerOptions? TestSerializerOptions { get; set; }
 }
 
 /// <summary>
@@ -207,6 +201,11 @@ public sealed class TestConfigurationContext
     /// Gets the optional setup builder function for this test configuration.
     /// </summary>
     public Func<SetupBuilder, SetupDefinition[]>? Setup { get; }
+
+    /// <summary>
+    /// Optional custom serializer options for this test configuration context.
+    /// </summary>
+    public JsonSerializerOptions? SerializerOptions { get; set; }
 
     /// <summary>
     /// Creates a new test configuration context.

--- a/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
+++ b/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
@@ -28,84 +28,55 @@ public static class CocoarTestConfiguration
 
     /// <summary>
     /// Replaces all configured rules with test-specific rules.
-    /// Original rules are completely skipped - ideal when providers would fail in test environment.
+    /// Original rules are completely skipped — ideal when providers would fail in test environment.
+    /// Returns a <see cref="TestOverrideBuilder"/> that can be further composed (e.g. chaining
+    /// <c>.ReplaceSecretsSetup(...)</c>) and acts as a disposable scope.
     /// </summary>
     /// <param name="rules">Function to build test rules using the fluent API.</param>
     /// <param name="setup">Optional function to build test setup using the fluent API.</param>
-    /// <returns>A scope that clears the test configuration when disposed.</returns>
+    /// <returns>An auto-activating builder / disposable scope.</returns>
     /// <example>
     /// <code>
-    /// using var _ = CocoarTestConfiguration.ReplaceAllRules(
+    /// using var _ = CocoarTestConfiguration.ReplaceConfiguration(
     ///     rule => [
     ///         rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = testDb })
-    ///     ],
-    ///     setup => [
-    ///         setup.ConcreteType&lt;DbConfig&gt;()
     ///     ]);
-    /// // Test configuration automatically cleared when scope is disposed
     /// </code>
     /// </example>
-    public static TestConfigurationScope ReplaceAllRules(
+    public static TestOverrideBuilder ReplaceConfiguration(
         Func<RulesBuilder, ConfigRule[]> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
-    {
-        ArgumentNullException.ThrowIfNull(rules);
-        s_testContext.Value = new TestConfigurationContext(rules, TestConfigurationMode.Replace, setup);
-        return new TestConfigurationScope();
-    }
+        => new TestOverrideBuilder(autoActivate: true).ReplaceConfiguration(rules, setup);
 
     /// <summary>
     /// Appends test rules to the end of configured rules (last-write-wins).
     /// Original rules execute first, then test rules override specific values.
+    /// Returns a <see cref="TestOverrideBuilder"/> that can be further composed and acts as a disposable scope.
     /// </summary>
     /// <param name="rules">Function to build test rules using the fluent API.</param>
     /// <param name="setup">Optional function to build test setup using the fluent API.</param>
-    /// <returns>A scope that clears the test configuration when disposed.</returns>
+    /// <returns>An auto-activating builder / disposable scope.</returns>
     /// <example>
     /// <code>
-    /// using var _ = CocoarTestConfiguration.AppendTestRules(
+    /// using var _ = CocoarTestConfiguration.AppendConfiguration(
     ///     rule => [
     ///         rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = testDb })
-    ///     ],
-    ///     setup => [
-    ///         setup.ConcreteType&lt;DbConfig&gt;()
     ///     ]);
-    /// // Test configuration automatically cleared when scope is disposed
     /// </code>
     /// </example>
-    public static TestConfigurationScope AppendTestRules(
+    public static TestOverrideBuilder AppendConfiguration(
         Func<RulesBuilder, ConfigRule[]> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
-    {
-        ArgumentNullException.ThrowIfNull(rules);
-        s_testContext.Value = new TestConfigurationContext(rules, TestConfigurationMode.Append, setup);
-        return new TestConfigurationScope();
-    }
+        => new TestOverrideBuilder(autoActivate: true).AppendConfiguration(rules, setup);
 
     /// <summary>
-    /// Applies setup overrides only, keeping original rules unchanged.
-    /// Use this when you only need to override setup options like AllowPlaintext() without changing rules.
+    /// Replaces the secrets setup used during ConfigManager initialization.
+    /// Returns a <see cref="TestOverrideBuilder"/> that can be further composed and acts as a disposable scope.
     /// </summary>
-    /// <param name="setup">Function to build test setup using the fluent API.</param>
-    /// <returns>A scope that clears the test configuration when disposed.</returns>
-    /// <example>
-    /// <code>
-    /// using var _ = CocoarTestConfiguration.WithSetup(setup => [
-    ///     setup.ConcreteType&lt;DbConfig&gt;()
-    /// ]);
-    /// // Original rules are preserved, but setup includes test overrides
-    /// </code>
-    /// </example>
-    public static TestConfigurationScope WithSetup(Func<SetupBuilder, SetupDefinition[]> setup)
-    {
-        ArgumentNullException.ThrowIfNull(setup);
-        // Create context with empty rules in Append mode (original rules preserved)
-        s_testContext.Value = new TestConfigurationContext(
-            rules => [],
-            TestConfigurationMode.Append,
-            setup);
-        return new TestConfigurationScope();
-    }
+    /// <param name="configure">Raw delegate that receives a SecretsBuilder (typed by Secrets package extension).</param>
+    /// <returns>An auto-activating builder / disposable scope.</returns>
+    public static TestOverrideBuilder ReplaceSecretsSetup(Delegate configure)
+        => new TestOverrideBuilder(autoActivate: true).ReplaceSecretsSetupCore(configure);
 
     /// <summary>
     /// Applies an existing <see cref="TestConfigurationContext"/> to the current async context.
@@ -115,19 +86,10 @@ public static class CocoarTestConfiguration
     /// <returns>A scope that clears the test configuration when disposed.</returns>
     /// <example>
     /// <code>
-    /// public class IntegrationTestFixture
-    /// {
-    ///     public TestConfigurationContext TestContext { get; } =
-    ///         TestConfigurationContext.Replace(rule => [
-    ///             rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = "test-db" })
-    ///         ]);
-    /// }
-    ///
     /// public class MyTests : IClassFixture&lt;IntegrationTestFixture&gt;, IDisposable
     /// {
     ///     public MyTests(IntegrationTestFixture fixture)
     ///     {
-    ///         // Bridge the async context gap - one line!
     ///         CocoarTestConfiguration.Apply(fixture.TestContext);
     ///     }
     ///
@@ -160,6 +122,11 @@ public static class CocoarTestConfiguration
     /// </summary>
     public static bool IsActive => s_testContext.Value != null;
 
+    /// <summary>
+    /// Sets the active context. Called by <see cref="TestOverrideBuilder"/> after each mutation.
+    /// </summary>
+    internal static void SetContext(TestConfigurationContext context) =>
+        s_testContext.Value = context;
 }
 
 /// <summary>
@@ -184,18 +151,20 @@ public enum TestConfigurationMode
 /// <remarks>
 /// Store instances of this class in test fixtures and use <see cref="CocoarTestConfiguration.Apply"/>
 /// in test class constructors to bridge the async context gap between fixture setup and test methods.
+/// Use <see cref="TestConfigurationContext.Replace"/> or <see cref="TestConfigurationContext.Append"/>
+/// as convenient factory methods, or build via <see cref="TestOverrideBuilder"/> for the fixture pattern.
 /// </remarks>
 public sealed class TestConfigurationContext
 {
     /// <summary>
-    /// Gets the rules builder function for this test configuration.
+    /// Gets the rules builder function for this test configuration, or null if no rules override is set.
     /// </summary>
-    public Func<RulesBuilder, ConfigRule[]> Rules { get; }
+    public Func<RulesBuilder, ConfigRule[]>? Rules { get; }
 
     /// <summary>
-    /// Gets the mode for this test configuration (Replace or Append).
+    /// Gets the mode for this test configuration (Replace or Append), or null if no rules override is set.
     /// </summary>
-    public TestConfigurationMode Mode { get; }
+    public TestConfigurationMode? ConfigurationMode { get; }
 
     /// <summary>
     /// Gets the optional setup builder function for this test configuration.
@@ -208,25 +177,26 @@ public sealed class TestConfigurationContext
     public JsonSerializerOptions? SerializerOptions { get; set; }
 
     /// <summary>
-    /// Creates a new test configuration context.
+    /// Raw secrets setup override delegate. Typed as <see cref="Delegate"/> to avoid a hard dependency
+    /// on the Secrets package from the core library. The Secrets package casts this to the correct type.
     /// </summary>
-    /// <param name="rules">Function to build test rules using the fluent API.</param>
-    /// <param name="mode">The configuration override mode.</param>
-    /// <param name="setup">Optional function to build test setup using the fluent API.</param>
-    public TestConfigurationContext(
-        Func<RulesBuilder, ConfigRule[]> rules,
-        TestConfigurationMode mode,
-        Func<SetupBuilder, SetupDefinition[]>? setup = null)
+    internal Delegate? SecretsSetupOverride { get; init; }
+
+    internal TestConfigurationContext(
+        Func<RulesBuilder, ConfigRule[]>? rules = null,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null,
+        TestConfigurationMode? configurationMode = null,
+        Delegate? secretsSetupOverride = null)
     {
-        ArgumentNullException.ThrowIfNull(rules);
         Rules = rules;
-        Mode = mode;
         Setup = setup;
+        ConfigurationMode = configurationMode;
+        SecretsSetupOverride = secretsSetupOverride;
     }
 
     /// <summary>
     /// Creates a test configuration context that replaces all configured rules.
-    /// Original rules are completely skipped - ideal when providers would fail in test environment.
+    /// Original rules are completely skipped — ideal when providers would fail in the test environment.
     /// </summary>
     /// <param name="rules">Function to build test rules using the fluent API.</param>
     /// <param name="setup">Optional function to build test setup using the fluent API.</param>
@@ -239,9 +209,6 @@ public sealed class TestConfigurationContext
     ///         TestConfigurationContext.Replace(
     ///             rule => [
     ///                 rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = "test-db" })
-    ///             ],
-    ///             setup => [
-    ///                 setup.ConcreteType&lt;DbConfig&gt;()
     ///             ]);
     /// }
     /// </code>
@@ -249,7 +216,10 @@ public sealed class TestConfigurationContext
     public static TestConfigurationContext Replace(
         Func<RulesBuilder, ConfigRule[]> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
-        => new(rules, TestConfigurationMode.Replace, setup);
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        return new(rules, setup, TestConfigurationMode.Replace);
+    }
 
     /// <summary>
     /// Creates a test configuration context that appends test rules to configured rules.
@@ -266,9 +236,6 @@ public sealed class TestConfigurationContext
     ///         TestConfigurationContext.Append(
     ///             rule => [
     ///                 rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { MaxConnections = 5 })
-    ///             ],
-    ///             setup => [
-    ///                 setup.ConcreteType&lt;DbConfig&gt;()
     ///             ]);
     /// }
     /// </code>
@@ -276,7 +243,100 @@ public sealed class TestConfigurationContext
     public static TestConfigurationContext Append(
         Func<RulesBuilder, ConfigRule[]> rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
-        => new(rules, TestConfigurationMode.Append, setup);
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        return new(rules, setup, TestConfigurationMode.Append);
+    }
+}
+
+/// <summary>
+/// Fluent builder for composing test configuration overrides.
+/// Returned by <see cref="CocoarTestConfiguration.ReplaceConfiguration"/>,
+/// <see cref="CocoarTestConfiguration.AppendConfiguration"/>, and
+/// <see cref="CocoarTestConfiguration.ReplaceSecretsSetup"/>.
+/// When constructed via those static methods (auto-activate mode) each chained call immediately
+/// activates the accumulated context in the current async scope.
+/// Use <c>new TestOverrideBuilder()</c> (no-arg) for the fixture pattern — context is only activated
+/// when you later call <see cref="CocoarTestConfiguration.Apply"/>.
+/// Disposing a builder created in auto-activate mode calls <see cref="CocoarTestConfiguration.Clear"/>.
+/// </summary>
+public sealed class TestOverrideBuilder : IDisposable
+{
+    private readonly bool _autoActivate;
+    private Func<RulesBuilder, ConfigRule[]>? _rules;
+    private Func<SetupBuilder, SetupDefinition[]>? _setup;
+    private TestConfigurationMode? _configurationMode;
+    private Delegate? _secretsSetupOverride;
+
+    /// <summary>
+    /// Creates a builder for the fixture pattern. Does NOT auto-activate.
+    /// Call <see cref="Build"/> and then pass the result to <see cref="CocoarTestConfiguration.Apply"/>.
+    /// </summary>
+    public TestOverrideBuilder() { }
+
+    internal TestOverrideBuilder(bool autoActivate) => _autoActivate = autoActivate;
+
+    /// <summary>
+    /// Sets the rules override to Replace mode (original rules are skipped).
+    /// </summary>
+    public TestOverrideBuilder ReplaceConfiguration(
+        Func<RulesBuilder, ConfigRule[]> rules,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        _rules = rules;
+        _setup = setup ?? _setup;
+        _configurationMode = TestConfigurationMode.Replace;
+        if (_autoActivate) CocoarTestConfiguration.SetContext(Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the rules override to Append mode (test rules follow original rules, last-write-wins).
+    /// </summary>
+    public TestOverrideBuilder AppendConfiguration(
+        Func<RulesBuilder, ConfigRule[]> rules,
+        Func<SetupBuilder, SetupDefinition[]>? setup = null)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        _rules = rules;
+        _setup = setup ?? _setup;
+        _configurationMode = TestConfigurationMode.Append;
+        if (_autoActivate) CocoarTestConfiguration.SetContext(Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a raw secrets setup override delegate (used internally and by the Secrets package extension).
+    /// </summary>
+    internal TestOverrideBuilder ReplaceSecretsSetupCore(Delegate configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _secretsSetupOverride = configure;
+        if (_autoActivate) CocoarTestConfiguration.SetContext(Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Called by the Secrets package extension to store a strongly-typed override.
+    /// </summary>
+    public void SetSecretsSetupOverride(Delegate configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _secretsSetupOverride = configure;
+        if (_autoActivate) CocoarTestConfiguration.SetContext(Build());
+    }
+
+    /// <summary>
+    /// Builds a snapshot <see cref="TestConfigurationContext"/> without activating it.
+    /// </summary>
+    public TestConfigurationContext Build() =>
+        new(_rules, _setup, _configurationMode, _secretsSetupOverride);
+
+    /// <summary>
+    /// Clears the active test configuration context. Only meaningful in auto-activate mode.
+    /// </summary>
+    public void Dispose() => CocoarTestConfiguration.Clear();
 }
 
 /// <summary>
@@ -285,7 +345,7 @@ public sealed class TestConfigurationContext
 /// </summary>
 /// <example>
 /// <code>
-/// using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [...]);
+/// using var _ = CocoarTestConfiguration.Apply(context);
 /// // Test runs here
 /// // Configuration automatically cleared when scope is disposed
 /// </code>

--- a/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
+++ b/src/Cocoar.Configuration/Testing/CocoarTestConfiguration.cs
@@ -40,7 +40,7 @@ public static class CocoarTestConfiguration
     ///         rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = testDb })
     ///     ],
     ///     setup => [
-    ///         setup.Secrets().AllowPlaintext()
+    ///         setup.ConcreteType&lt;DbConfig&gt;()
     ///     ]);
     /// // Test configuration automatically cleared when scope is disposed
     /// </code>
@@ -68,7 +68,7 @@ public static class CocoarTestConfiguration
     ///         rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = testDb })
     ///     ],
     ///     setup => [
-    ///         setup.Secrets().AllowPlaintext()
+    ///         setup.ConcreteType&lt;DbConfig&gt;()
     ///     ]);
     /// // Test configuration automatically cleared when scope is disposed
     /// </code>
@@ -91,7 +91,7 @@ public static class CocoarTestConfiguration
     /// <example>
     /// <code>
     /// using var _ = CocoarTestConfiguration.WithSetup(setup => [
-    ///     setup.Secrets().AllowPlaintext()
+    ///     setup.ConcreteType&lt;DbConfig&gt;()
     /// ]);
     /// // Original rules are preserved, but setup includes test overrides
     /// </code>
@@ -242,7 +242,7 @@ public sealed class TestConfigurationContext
     ///                 rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { Connection = "test-db" })
     ///             ],
     ///             setup => [
-    ///                 setup.Secrets().AllowPlaintext()
+    ///                 setup.ConcreteType&lt;DbConfig&gt;()
     ///             ]);
     /// }
     /// </code>
@@ -269,7 +269,7 @@ public sealed class TestConfigurationContext
     ///                 rule.For&lt;DbConfig&gt;().FromStatic(_ => new DbConfig { MaxConnections = 5 })
     ///             ],
     ///             setup => [
-    ///                 setup.Secrets().AllowPlaintext()
+    ///                 setup.ConcreteType&lt;DbConfig&gt;()
     ///             ]);
     /// }
     /// </code>

--- a/src/Cocoar.Configuration/Utilities/SecureBytes.cs
+++ b/src/Cocoar.Configuration/Utilities/SecureBytes.cs
@@ -131,7 +131,7 @@ internal sealed class SecureBytes : IDisposable
         try
         {
             // Use cryptographically secure zeroization
-            CryptographicOperations.ZeroMemory(_buffer.AsSpan(0, _length));
+            CryptographicOperations.ZeroMemory(_buffer);
             
             if (_isPooled)
             {

--- a/src/Examples/AspNetCoreExample/Program.cs
+++ b/src/Examples/AspNetCoreExample/Program.cs
@@ -31,7 +31,7 @@ public static class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<AppSettings>().FromFile("config.json").Select("App"),
             rule.For<AppSettings>().FromEnvironment("APP_"),
             rule.For<DatabaseSettings>().FromFile("config.json").Select("Database"),
@@ -58,7 +58,7 @@ public static class Program
 
         app.MapGet("/manager", (ConfigManager manager) =>
         {
-            var appSettings = manager.GetRequiredConfig<IAppSettings>();
+            var appSettings = manager.GetConfig<IAppSettings>();
             var dbSettings = manager.GetConfig<DatabaseSettings>();
             return new
             {

--- a/src/Examples/AspNetCoreExample/Program.cs
+++ b/src/Examples/AspNetCoreExample/Program.cs
@@ -31,14 +31,14 @@ public static class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.AddCocoarConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<AppSettings>().FromFile("config.json").Select("App"),
             rule.For<AppSettings>().FromEnvironment("APP_"),
             rule.For<DatabaseSettings>().FromFile("config.json").Select("Database"),
             rule.For<DatabaseSettings>().FromEnvironment("DB_")
         ], setup => [
             setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>(),
-        ]);
+        ]));
 
         var app = builder.Build();
 

--- a/src/Examples/AspNetCoreExample/config.json
+++ b/src/Examples/AspNetCoreExample/config.json
@@ -1,0 +1,12 @@
+{
+  "App": {
+    "ApplicationName": "My ASP.NET Core App",
+    "Version": "1.0.0",
+    "IsProduction": false
+  },
+  "Database": {
+    "ConnectionString": "Server=localhost;Database=aspnetapp;Trusted_Connection=true",
+    "CommandTimeout": 30,
+    "EnableRetryOnFailure": true
+  }
+}

--- a/src/Examples/BasicUsage/Program.cs
+++ b/src/Examples/BasicUsage/Program.cs
@@ -30,7 +30,7 @@ public static class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<StartUpConfiguration>().FromFile("config.json").Select("StartUp"),
             rule.For<MartenStartupSettings>().FromFile("config.json").Select("Marten"),
             rule.For<StartUpConfiguration>().FromEnvironment(),

--- a/src/Examples/BasicUsage/Program.cs
+++ b/src/Examples/BasicUsage/Program.cs
@@ -30,14 +30,14 @@ public static class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.AddCocoarConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<StartUpConfiguration>().FromFile("config.json").Select("StartUp"),
             rule.For<MartenStartupSettings>().FromFile("config.json").Select("Marten"),
             rule.For<StartUpConfiguration>().FromEnvironment(),
             rule.For<MartenStartupSettings>().FromEnvironment("MARTEN_")
         ], setup => [
             setup.ConcreteType<StartUpConfiguration>().ExposeAs<IStartupSettings>()
-        ]);
+        ]));
 
         var app = builder.Build();
 

--- a/src/Examples/BasicUsage/config.json
+++ b/src/Examples/BasicUsage/config.json
@@ -1,0 +1,12 @@
+{
+  "StartUp": {
+    "ConnectionString": "Server=localhost;Database=myapp;Trusted_Connection=true",
+    "EnableLogging": true,
+    "TimeoutSeconds": 30
+  },
+  "Marten": {
+    "DatabaseConnection": "Server=localhost;Database=marten;Trusted_Connection=true",
+    "EnableMigrations": true,
+    "Schema": "public"
+  }
+}

--- a/src/Examples/CommandLineExample/Program.cs
+++ b/src/Examples/CommandLineExample/Program.cs
@@ -32,7 +32,7 @@ public class Program
         Console.WriteLine("--- Test 1: Default (--) prefix ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })
             ]));
 
@@ -53,7 +53,7 @@ public class Program
         Console.WriteLine("--- Test 2: Multiple prefixes (--, -, /) ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions
                 {
                     Args = args,
@@ -78,7 +78,7 @@ public class Program
         Console.WriteLine("--- Test 3: Semantic prefixes (@, #, %) ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<TargetConfig>().FromCommandLine(cm => new CommandLineRuleOptions
                 {
                     Args = args,
@@ -116,7 +116,7 @@ public class Program
         Console.WriteLine("--- Test 4: Prefix filtering (app_, db_) ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions
                 {
                     Args = args,
@@ -148,7 +148,7 @@ public class Program
         Console.WriteLine("--- Test 5: Nested configuration (: and __) ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<ServerConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })
             ]));
 

--- a/src/Examples/CommandLineExample/Program.cs
+++ b/src/Examples/CommandLineExample/Program.cs
@@ -32,10 +32,9 @@ public class Program
         Console.WriteLine("--- Test 1: Default (--) prefix ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
                 rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })
-            ]);
-            manager.Initialize();
+            ]));
 
             var config = manager.GetConfig<AppConfig>();
             Console.WriteLine($"Host: {config?.Host ?? "null"}");
@@ -54,14 +53,13 @@ public class Program
         Console.WriteLine("--- Test 2: Multiple prefixes (--, -, /) ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
-                rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+                rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["--", "-", "/"]
                 })
-            ]);
-            manager.Initialize();
+            ]));
 
             var config = manager.GetConfig<AppConfig>();
             Console.WriteLine($"Host: {config?.Host ?? "null"}");
@@ -80,24 +78,23 @@ public class Program
         Console.WriteLine("--- Test 3: Semantic prefixes (@, #, %) ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
-                rule.For<TargetConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+                rule.For<TargetConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["@"]
                 }),
-                rule.For<IssueConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+                rule.For<IssueConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["#"]
                 }),
-                rule.For<EnvConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+                rule.For<EnvConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["%"]
                 })
-            ]);
-            manager.Initialize();
+            ]));
 
             var target = manager.GetConfig<TargetConfig>();
             var issue = manager.GetConfig<IssueConfig>();
@@ -119,19 +116,18 @@ public class Program
         Console.WriteLine("--- Test 4: Prefix filtering (app_, db_) ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
-                rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+                rule.For<AppConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     Prefix = "app_"
                 }),
-                rule.For<DatabaseConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+                rule.For<DatabaseConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     Prefix = "db_"
                 })
-            ]);
-            manager.Initialize();
+            ]));
 
             var app = manager.GetConfig<AppConfig>();
             var db = manager.GetConfig<DatabaseConfig>();
@@ -152,10 +148,9 @@ public class Program
         Console.WriteLine("--- Test 5: Nested configuration (: and __) ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
                 rule.For<ServerConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })
-            ]);
-            manager.Initialize();
+            ]));
 
             var config = manager.GetConfig<ServerConfig>();
             Console.WriteLine($"Database Host: {config?.Database?.Host ?? "null"}");

--- a/src/Examples/ConditionalRulesExample/Program.cs
+++ b/src/Examples/ConditionalRulesExample/Program.cs
@@ -6,7 +6,7 @@ Console.WriteLine("=== Conditional Rules Example ===\n");
 Console.WriteLine("Demonstrates using When() with IConfigurationAccessor\n");
 
 // Setup: Load tenant configuration, then conditionally load premium features
-var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
     // Load tenant info first
     rule.For<TenantSettings>().FromStaticJson("""
                                               {
@@ -24,12 +24,12 @@ var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
                                                """)
         .When(accessor =>
         {
-            var tenant = accessor.GetRequiredConfig<TenantSettings>();
+            var tenant = accessor.GetConfig<TenantSettings>()!;
             return tenant.Tier == "Premium";
         })
 ]));
 
-var tenant = manager.GetRequiredConfig<TenantSettings>();
+var tenant = manager.GetConfig<TenantSettings>()!;
 var features = manager.GetConfig<PremiumFeatures>();
 
 Console.WriteLine($"Tenant: {tenant.TenantId}");

--- a/src/Examples/ConditionalRulesExample/Program.cs
+++ b/src/Examples/ConditionalRulesExample/Program.cs
@@ -6,7 +6,7 @@ Console.WriteLine("=== Conditional Rules Example ===\n");
 Console.WriteLine("Demonstrates using When() with IConfigurationAccessor\n");
 
 // Setup: Load tenant configuration, then conditionally load premium features
-var manager = new ConfigManager(rule => [
+var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
     // Load tenant info first
     rule.For<TenantSettings>().FromStaticJson("""
                                               {
@@ -14,7 +14,7 @@ var manager = new ConfigManager(rule => [
                                                   "Tier": "Premium"
                                               }
                                               """),
-    
+
     // Conditionally load premium features only for Premium tier tenants
     rule.For<PremiumFeatures>().FromStaticJson("""
                                                {
@@ -27,7 +27,7 @@ var manager = new ConfigManager(rule => [
             var tenant = accessor.GetRequiredConfig<TenantSettings>();
             return tenant.Tier == "Premium";
         })
-]).Initialize();
+]));
 
 var tenant = manager.GetRequiredConfig<TenantSettings>();
 var features = manager.GetConfig<PremiumFeatures>();

--- a/src/Examples/ConfigurationShowcase/Components/App.razor
+++ b/src/Examples/ConfigurationShowcase/Components/App.razor
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cocoar.Configuration Showcase</title>
+    <base href="/" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="ConfigurationShowcase.styles.css" />
+    <HeadOutlet @rendermode="InteractiveServer" />
+</head>
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/src/Examples/ConfigurationShowcase/Components/Layout/MainLayout.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Layout/MainLayout.razor
@@ -1,0 +1,23 @@
+@inherits LayoutComponentBase
+
+<div class="layout">
+    <nav class="sidebar">
+        <div class="sidebar-header">
+            <h2>Cocoar</h2>
+            <span class="sidebar-subtitle">Configuration v5.0</span>
+        </div>
+        <ul class="nav-links">
+            <li><NavLink href="" Match="NavLinkMatch.All">Dashboard</NavLink></li>
+            <li><NavLink href="explorer">Config Explorer</NavLink></li>
+            <li><NavLink href="health">Health Dashboard</NavLink></li>
+            <li><NavLink href="reactive">Reactive Demo</NavLink></li>
+            <li><NavLink href="rules">Rules Overview</NavLink></li>
+        </ul>
+        <div class="sidebar-footer">
+            <span>Builder Pattern API</span>
+        </div>
+    </nav>
+    <main class="content">
+        @Body
+    </main>
+</div>

--- a/src/Examples/ConfigurationShowcase/Components/Layout/MainLayout.razor.css
+++ b/src/Examples/ConfigurationShowcase/Components/Layout/MainLayout.razor.css
@@ -1,0 +1,74 @@
+.layout {
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.sidebar {
+    width: var(--sidebar-width);
+    min-width: var(--sidebar-width);
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem 0;
+}
+
+.sidebar-header {
+    padding: 0 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-header h2 {
+    color: var(--accent);
+    font-size: 1.25rem;
+    margin-bottom: 0.15rem;
+}
+
+.sidebar-subtitle {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.nav-links {
+    list-style: none;
+    padding: 0.75rem 0;
+    flex: 1;
+}
+
+.nav-links li {
+    margin: 0.1rem 0;
+}
+
+.nav-links ::deep a {
+    display: block;
+    padding: 0.6rem 1.25rem;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    transition: color 0.15s, background 0.15s;
+    border-left: 3px solid transparent;
+}
+
+.nav-links ::deep a:hover {
+    color: var(--text-primary);
+    background: rgba(108, 92, 231, 0.06);
+}
+
+.nav-links ::deep a.active {
+    color: var(--accent);
+    background: rgba(108, 92, 231, 0.1);
+    border-left-color: var(--accent);
+}
+
+.sidebar-footer {
+    padding: 1rem 1.25rem 0;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+
+.content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 2rem;
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/ConfigurationExplorer.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/ConfigurationExplorer.razor
@@ -1,0 +1,133 @@
+@page "/explorer"
+@implements IDisposable
+@inject IReactiveConfig<AppSettings> AppSettingsReactive
+@inject IReactiveConfig<DatabaseSettings> DbSettingsReactive
+@inject NotificationSettings NotificationSettings
+
+<h1>Configuration Explorer</h1>
+<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+    Live configuration values. Edit <code>config/*.json</code> files to see changes propagate in real time.
+</p>
+
+<div class="explorer-grid">
+    <div class="card @AppFlash">
+        <h3>AppSettings</h3>
+        <span class="badge badge-required" style="margin-bottom: 0.75rem;">File + Env</span>
+        <table>
+            <tr><td>ApplicationName</td><td>@app.ApplicationName</td></tr>
+            <tr><td>Version</td><td>@app.Version</td></tr>
+            <tr><td>MaxRetries</td><td>@app.MaxRetries</td></tr>
+            <tr><td>EnableDetailedErrors</td><td>@app.EnableDetailedErrors</td></tr>
+            <tr><td>WelcomeMessage</td><td>@app.WelcomeMessage</td></tr>
+        </table>
+    </div>
+
+    <div class="card @DbFlash">
+        <h3>DatabaseSettings</h3>
+        <span class="badge badge-required" style="margin-bottom: 0.75rem;">File</span>
+        <table>
+            <tr><td>ConnectionString</td><td>@db.ConnectionString</td></tr>
+            <tr><td>MaxPoolSize</td><td>@db.MaxPoolSize</td></tr>
+            <tr><td>CommandTimeout</td><td>@db.CommandTimeoutSeconds s</td></tr>
+            <tr><td>RetryOnFailure</td><td>@db.EnableRetryOnFailure</td></tr>
+            <tr><td colspan="2" style="padding-top: 0.75rem;">
+                <div style="border: 1px solid var(--border-color); border-radius: 8px; padding: 0.75rem; background: var(--bg-primary);">
+                    <div style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--accent); margin-bottom: 0.5rem; font-weight: 600;">
+                        Secret&lt;T&gt; Protection Demo
+                    </div>
+                    <table style="margin: 0;">
+                        <tr>
+                            <td style="color: var(--text-secondary);">ToString()</td>
+                            <td><code style="color: var(--danger);">@SecretToString()</code></td>
+                            <td style="font-size: 0.75rem; color: var(--text-muted);">Always masked - safe for logging</td>
+                        </tr>
+                        <tr>
+                            <td style="color: var(--text-secondary);">JSON serialization</td>
+                            <td><code style="color: var(--danger);">@SecretJsonDisplay()</code></td>
+                            <td style="font-size: 0.75rem; color: var(--text-muted);">Cannot leak through serializers</td>
+                        </tr>
+                        <tr>
+                            <td style="color: var(--text-secondary);">Open() lease</td>
+                            <td>
+                                @if (showSecret)
+                                {
+                                    <code style="color: var(--success);">@SecretOpenDisplay()</code>
+                                    <button style="margin-left: 0.5rem; padding: 0.15rem 0.5rem; font-size: 0.75rem;" @onclick="() => showSecret = false">Hide</button>
+                                }
+                                else
+                                {
+                                    <button style="padding: 0.15rem 0.5rem; font-size: 0.75rem;" @onclick="() => showSecret = true">Reveal via Open()</button>
+                                }
+                            </td>
+                            <td style="font-size: 0.75rem; color: var(--text-muted);">Explicit opt-in required to access value</td>
+                        </tr>
+                    </table>
+                </div>
+            </td></tr>
+        </table>
+    </div>
+
+    <div class="card">
+        <h3>NotificationSettings</h3>
+        <span class="badge badge-optional" style="margin-bottom: 0.75rem;">Static JSON</span>
+        <table>
+            <tr><td>SmtpServer</td><td>@NotificationSettings.SmtpServer</td></tr>
+            <tr><td>SmtpPort</td><td>@NotificationSettings.SmtpPort</td></tr>
+            <tr><td>FromAddress</td><td>@NotificationSettings.FromAddress</td></tr>
+            <tr><td>EnableSlack</td><td>@NotificationSettings.EnableSlack</td></tr>
+            <tr><td>SlackWebhookUrl</td><td>@NotificationSettings.SlackWebhookUrl</td></tr>
+        </table>
+    </div>
+</div>
+
+@code {
+    private AppSettings app = new();
+    private DatabaseSettings db = new();
+    private IDisposable? appSub;
+    private IDisposable? dbSub;
+    private string AppFlash = "";
+    private string DbFlash = "";
+    private bool showSecret;
+
+    protected override void OnInitialized()
+    {
+        app = AppSettingsReactive.CurrentValue;
+        db = DbSettingsReactive.CurrentValue;
+
+        appSub = AppSettingsReactive.Subscribe(v => { app = v; AppFlash = "flash"; InvokeAsync(StateHasChanged); _ = ClearFlash(() => AppFlash = ""); });
+        dbSub = DbSettingsReactive.Subscribe(v => { db = v; DbFlash = "flash"; InvokeAsync(StateHasChanged); _ = ClearFlash(() => DbFlash = ""); });
+    }
+
+    private async Task ClearFlash(Action clear)
+    {
+        await Task.Delay(1000);
+        clear();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private string SecretToString()
+    {
+        if (db.ApiKey == null) return "(none)";
+        return db.ApiKey.ToString()!; // Always returns "***"
+    }
+
+    private string SecretJsonDisplay()
+    {
+        if (db.ApiKey == null) return "(none)";
+        // Serializing a Secret<T> produces "***", never the real value
+        return System.Text.Json.JsonSerializer.Serialize(db.ApiKey);
+    }
+
+    private string SecretOpenDisplay()
+    {
+        if (db.ApiKey == null) return "(none)";
+        using var lease = db.ApiKey.Open();
+        return lease.Value;
+    }
+
+    public void Dispose()
+    {
+        appSub?.Dispose();
+        dbSub?.Dispose();
+    }
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/ConfigurationExplorer.razor.css
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/ConfigurationExplorer.razor.css
@@ -1,0 +1,15 @@
+.explorer-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.explorer-grid h3 {
+    margin-bottom: 0.25rem;
+}
+
+.explorer-grid td:first-child {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    width: 45%;
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/HealthDashboard.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/HealthDashboard.razor
@@ -1,0 +1,100 @@
+@page "/health"
+@implements IDisposable
+@inject IConfigurationHealthService HealthService
+
+<h1>Health Dashboard</h1>
+<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+    Real-time health status for all configuration rules. Powered by <code>IConfigurationHealthService</code>.
+</p>
+
+<div class="grid-3" style="margin-bottom: 1.5rem;">
+    <div class="card">
+        <div class="stat-label">Overall Status</div>
+        <div style="margin-top: 0.5rem;"><HealthStatusBadge Status="@snapshot.OverallStatus" /></div>
+    </div>
+    <div class="card">
+        <div class="stat-value">@snapshot.ConfigVersion</div>
+        <div class="stat-label">Config Version</div>
+    </div>
+    <div class="card">
+        <div class="stat-value">@snapshot.TimestampUtc.ToString("HH:mm:ss")</div>
+        <div class="stat-label">Last Updated (UTC)</div>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-bottom: 0.75rem;">Rule Health</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Name</th>
+                <th>Config Type</th>
+                <th>Provider</th>
+                <th>Required</th>
+                <th>Status</th>
+                <th>Failures</th>
+                <th>Last Success</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var rule in snapshot.Rules)
+            {
+                <tr>
+                    <td>@rule.Index</td>
+                    <td><strong>@(rule.Name ?? "(unnamed)")</strong></td>
+                    <td><code>@ShortTypeName(rule.ConfigType)</code></td>
+                    <td><code>@ShortTypeName(rule.ProviderType)</code></td>
+                    <td>
+                        @if (rule.Required)
+                        {
+                            <span class="badge badge-required">Required</span>
+                        }
+                        else
+                        {
+                            <span class="badge badge-optional">Optional</span>
+                        }
+                    </td>
+                    <td><RuleStatusBadge Status="@rule.Status" /></td>
+                    <td>@rule.FailureCount</td>
+                    <td class="health-time">@(rule.LastSuccessUtc?.ToString("HH:mm:ss") ?? "-")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+
+@if (snapshot.Summary.DeserializationFailures > 0)
+{
+    <div class="card" style="margin-top: 1rem; border-color: var(--warning);">
+        <h3 style="color: var(--warning); margin-bottom: 0.5rem;">Deserialization Issues</h3>
+        @foreach (var rule in snapshot.Rules.Where(r => r.DeserializationStatus is { Success: false }))
+        {
+            <p><strong>@rule.Name</strong>: @rule.DeserializationStatus?.ErrorMessage</p>
+        }
+    </div>
+}
+
+@code {
+    private ConfigHealthSnapshot snapshot = default!;
+    private IDisposable? sub;
+
+    protected override void OnInitialized()
+    {
+        snapshot = HealthService.Snapshot;
+        sub = HealthService.SnapshotStream.Subscribe(s =>
+        {
+            snapshot = s;
+            InvokeAsync(StateHasChanged);
+        });
+    }
+
+    private static string ShortTypeName(string? fullName)
+    {
+        if (string.IsNullOrEmpty(fullName)) return "-";
+        var idx = fullName.LastIndexOf('.');
+        return idx >= 0 ? fullName[(idx + 1)..] : fullName;
+    }
+
+    public void Dispose() => sub?.Dispose();
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/HealthDashboard.razor.css
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/HealthDashboard.razor.css
@@ -1,0 +1,5 @@
+.health-time {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/Home.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/Home.razor
@@ -1,0 +1,71 @@
+@page "/"
+@implements IDisposable
+@inject IAppSettings AppSettings
+@inject IConfigurationHealthService HealthService
+
+<h1>Dashboard</h1>
+<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">@appSettings.WelcomeMessage</p>
+
+<div class="grid-3" style="margin-bottom: 1.5rem;">
+    <div class="card">
+        <div class="stat-label">Overall Health</div>
+        <div style="margin-top: 0.5rem;"><HealthStatusBadge Status="@snapshot.OverallStatus" /></div>
+    </div>
+    <div class="card">
+        <div class="stat-value">@snapshot.Rules.Count</div>
+        <div class="stat-label">Active Rules</div>
+    </div>
+    <div class="card">
+        <div class="stat-value">v@snapshot.ConfigVersion</div>
+        <div class="stat-label">Config Version</div>
+    </div>
+</div>
+
+<div class="grid-2" style="margin-bottom: 1.5rem;">
+    <div class="card">
+        <h3 style="margin-bottom: 0.75rem;">Application Info</h3>
+        <table>
+            <tr><td style="color: var(--text-secondary);">Name</td><td>@appSettings.ApplicationName</td></tr>
+            <tr><td style="color: var(--text-secondary);">Version</td><td>@appSettings.Version</td></tr>
+            <tr><td style="color: var(--text-secondary);">Max Retries</td><td>@appSettings.MaxRetries</td></tr>
+            <tr><td style="color: var(--text-secondary);">Detailed Errors</td><td>@appSettings.EnableDetailedErrors</td></tr>
+        </table>
+    </div>
+    <div class="card">
+        <h3 style="margin-bottom: 0.75rem;">Health Summary</h3>
+        <div class="grid-3">
+            <div>
+                <div class="stat-value" style="color: var(--success);">@(snapshot.Rules.Count(r => r.Status == RuleResultStatus.Up))</div>
+                <div class="stat-label">Rules Up</div>
+            </div>
+            <div>
+                <div class="stat-value" style="color: var(--warning);">@snapshot.Summary.Skipped</div>
+                <div class="stat-label">Skipped</div>
+            </div>
+            <div>
+                <div class="stat-value" style="color: var(--danger);">@(snapshot.Summary.RequiredFailed + snapshot.Summary.OptionalFailed)</div>
+                <div class="stat-label">Failed</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    private IAppSettings appSettings = default!;
+    private ConfigHealthSnapshot snapshot = default!;
+    private IDisposable? healthSub;
+
+    protected override void OnInitialized()
+    {
+        appSettings = AppSettings;
+        snapshot = HealthService.Snapshot;
+
+        healthSub = HealthService.SnapshotStream.Subscribe(s =>
+        {
+            snapshot = s;
+            InvokeAsync(StateHasChanged);
+        });
+    }
+
+    public void Dispose() => healthSub?.Dispose();
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/ReactiveDemo.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/ReactiveDemo.razor
@@ -1,0 +1,169 @@
+@page "/reactive"
+@implements IDisposable
+@inject IReactiveConfig<AppSettings> AppSettingsReactive
+@inject IReactiveConfig<DatabaseSettings> DbSettingsReactive
+@inject IReactiveConfig<(AppSettings App, DatabaseSettings Db)> TupleReactive
+@inject IConfigurationHealthService HealthService
+@inject NavigationManager Nav
+
+<h1>Reactive Demo</h1>
+<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+    Edit the JSON below and click Save. The file watcher detects the change, the 500ms debounce fires,
+    rules recompute, and <code>IReactiveConfig&lt;T&gt;</code> emits new values.
+</p>
+
+<div class="grid-2" style="margin-bottom: 1.5rem;">
+    <div class="card">
+        <h3 style="margin-bottom: 0.5rem;">Edit app.json</h3>
+        <textarea @bind="appJsonEditor" />
+        <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+            <button class="btn-primary" @onclick="SaveAppJson">Save app.json</button>
+            <button @onclick="ReloadAppJson">Reset</button>
+        </div>
+        @if (saveMessage != null)
+        {
+            <p style="margin-top: 0.5rem; color: var(--success); font-size: 0.85rem;">@saveMessage</p>
+        }
+    </div>
+    <div class="card">
+        <h3 style="margin-bottom: 0.5rem;">Edit database.json</h3>
+        <textarea @bind="dbJsonEditor" />
+        <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+            <button class="btn-primary" @onclick="SaveDbJson">Save database.json</button>
+            <button @onclick="ReloadDbJson">Reset</button>
+        </div>
+    </div>
+</div>
+
+<div class="card" style="margin-bottom: 1.5rem;">
+    <h3 style="margin-bottom: 0.75rem;">Tuple Reactive: <code>IReactiveConfig&lt;(AppSettings, DatabaseSettings)&gt;</code></h3>
+    <p style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 0.75rem;">
+        Both configs update atomically in a single emission. No inconsistent intermediate state.
+    </p>
+    <div class="grid-2">
+        <div>
+            <h4 style="color: var(--accent); font-size: 0.85rem;">AppSettings (from tuple)</h4>
+            <table>
+                <tr><td>ApplicationName</td><td>@tupleValue.App.ApplicationName</td></tr>
+                <tr><td>Version</td><td>@tupleValue.App.Version</td></tr>
+                <tr><td>MaxRetries</td><td>@tupleValue.App.MaxRetries</td></tr>
+            </table>
+        </div>
+        <div>
+            <h4 style="color: var(--accent); font-size: 0.85rem;">DatabaseSettings (from tuple)</h4>
+            <table>
+                <tr><td>ConnectionString</td><td>@tupleValue.Db.ConnectionString</td></tr>
+                <tr><td>MaxPoolSize</td><td>@tupleValue.Db.MaxPoolSize</td></tr>
+                <tr><td>CommandTimeout</td><td>@tupleValue.Db.CommandTimeoutSeconds s</td></tr>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-bottom: 0.75rem;">Event Log</h3>
+    <div class="event-log">
+        @foreach (var entry in eventLog)
+        {
+            <div class="event-log-entry">
+                <span class="event-time">@entry.Time.ToString("HH:mm:ss.fff")</span>
+                <span class="event-type">@entry.Type</span>
+                <span class="event-detail">@entry.Detail</span>
+            </div>
+        }
+        @if (eventLog.Count == 0)
+        {
+            <div style="padding: 1rem; color: var(--text-muted);">Waiting for changes...</div>
+        }
+    </div>
+</div>
+
+@code {
+    private string appJsonEditor = "";
+    private string dbJsonEditor = "";
+    private string? saveMessage;
+    private (AppSettings App, DatabaseSettings Db) tupleValue;
+    private readonly List<EventEntry> eventLog = new();
+    private IDisposable? appSub;
+    private IDisposable? dbSub;
+    private IDisposable? tupleSub;
+    private IDisposable? healthSub;
+    private HttpClient? http;
+
+    private record EventEntry(DateTime Time, string Type, string Detail);
+
+    protected override async Task OnInitializedAsync()
+    {
+        http = new HttpClient { BaseAddress = new Uri(Nav.BaseUri) };
+        tupleValue = TupleReactive.CurrentValue;
+
+        await ReloadAppJson();
+        await ReloadDbJson();
+
+        appSub = AppSettingsReactive.Subscribe(v =>
+        {
+            AddEvent("AppSettings", $"Name={v.ApplicationName}, Version={v.Version}, Retries={v.MaxRetries}");
+            InvokeAsync(StateHasChanged);
+        });
+
+        dbSub = DbSettingsReactive.Subscribe(v =>
+        {
+            AddEvent("DatabaseSettings", $"Pool={v.MaxPoolSize}, Timeout={v.CommandTimeoutSeconds}s, Retry={v.EnableRetryOnFailure}");
+            InvokeAsync(StateHasChanged);
+        });
+
+        tupleSub = TupleReactive.Subscribe(v =>
+        {
+            tupleValue = v;
+            AddEvent("Tuple", $"Atomic update: App.Version={v.App.Version}, Db.Pool={v.Db.MaxPoolSize}");
+            InvokeAsync(StateHasChanged);
+        });
+
+        healthSub = HealthService.StatusStream.Subscribe(s =>
+        {
+            AddEvent("Health", $"Status changed to {s}");
+            InvokeAsync(StateHasChanged);
+        });
+    }
+
+    private void AddEvent(string type, string detail)
+    {
+        eventLog.Insert(0, new EventEntry(DateTime.Now, type, detail));
+        if (eventLog.Count > 50) eventLog.RemoveAt(eventLog.Count - 1);
+    }
+
+    private async Task SaveAppJson()
+    {
+        saveMessage = null;
+        var content = new StringContent(appJsonEditor, System.Text.Encoding.UTF8, "application/json");
+        await http!.PostAsync("/api/config/app", content);
+        saveMessage = "Saved! Watching for reactive update...";
+    }
+
+    private async Task SaveDbJson()
+    {
+        var content = new StringContent(dbJsonEditor, System.Text.Encoding.UTF8, "application/json");
+        await http!.PostAsync("/api/config/database", content);
+    }
+
+    private async Task ReloadAppJson()
+    {
+        if (http is not null)
+            appJsonEditor = await http.GetStringAsync("/api/config/app");
+    }
+
+    private async Task ReloadDbJson()
+    {
+        if (http is not null)
+            dbJsonEditor = await http.GetStringAsync("/api/config/database");
+    }
+
+    public void Dispose()
+    {
+        appSub?.Dispose();
+        dbSub?.Dispose();
+        tupleSub?.Dispose();
+        healthSub?.Dispose();
+        http?.Dispose();
+    }
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/ReactiveDemo.razor.css
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/ReactiveDemo.razor.css
@@ -1,0 +1,8 @@
+h4 {
+    margin-bottom: 0.5rem;
+}
+
+td:first-child {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}

--- a/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
@@ -1,0 +1,142 @@
+@page "/rules"
+
+<h1>Rules Overview</h1>
+<p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+    All configuration rules and setup definitions used in this showcase, demonstrating the <code>ConfigManager.Create()</code> Builder API.
+</p>
+
+<div class="card" style="margin-bottom: 1.5rem;">
+    <h3 style="margin-bottom: 0.75rem;">Configuration Rules</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Type</th>
+                <th>Provider</th>
+                <th>Modifiers</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>AppSettings</code></td>
+                <td><code>FromFile()</code></td>
+                <td><span class="badge badge-required">Required</span> <code>.Select("AppSettings")</code> <code>.Named()</code></td>
+                <td>Primary app config from <code>config/app.json</code>, scoped to the AppSettings section</td>
+            </tr>
+            <tr>
+                <td><code>AppSettings</code></td>
+                <td><code>FromEnvironment("APP_")</code></td>
+                <td><code>.Named()</code></td>
+                <td>Environment variable overlay. Set <code>APP_ApplicationName</code> to override.</td>
+            </tr>
+            <tr>
+                <td><code>DatabaseSettings</code></td>
+                <td><code>FromFile()</code></td>
+                <td><span class="badge badge-required">Required</span> <code>.Named()</code></td>
+                <td>Database config with <code>Secret&lt;string&gt;</code> for ApiKey</td>
+            </tr>
+            <tr>
+                <td><code>NotificationSettings</code></td>
+                <td><code>FromStaticJson()</code></td>
+                <td><code>.Named()</code></td>
+                <td>Embedded static JSON, demonstrates non-file providers</td>
+            </tr>
+            <tr>
+                <td><code>DiagnosticsConfig</code></td>
+                <td><code>FromStaticJson()</code></td>
+                <td><code>.When()</code> <code>.Named()</code></td>
+                <td>Conditional rule: only loads when <code>AppSettings.EnableDetailedErrors == true</code></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card" style="margin-bottom: 1.5rem;">
+    <h3 style="margin-bottom: 0.75rem;">Setup Definitions</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Pattern</th>
+                <th>Code</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>ConcreteType + ExposeAs</code></td>
+                <td><code>setup.ConcreteType&lt;AppSettings&gt;().ExposeAs&lt;IAppSettings&gt;()</code></td>
+                <td>Registers concrete type and exposes via interface for DI consumers</td>
+            </tr>
+            <tr>
+                <td><code>ConcreteType + ExposeAs</code></td>
+                <td><code>setup.ConcreteType&lt;DatabaseSettings&gt;().ExposeAs&lt;IDatabaseSettings&gt;()</code></td>
+                <td>Database settings exposed as read-only interface</td>
+            </tr>
+            <tr>
+                <td><code>Interface + DeserializeTo</code></td>
+                <td><code>setup.Interface&lt;INotificationSettings&gt;().DeserializeTo&lt;NotificationSettings&gt;()</code></td>
+                <td>Interface-first deserialization: consumers depend on the interface only</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card" style="margin-bottom: 1.5rem;">
+    <h3 style="margin-bottom: 0.75rem;">Secrets Setup</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Configuration</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>.WithSecretsSetup(secrets =&gt; secrets.AllowPlaintext())</code></td>
+                <td>Enables plaintext secret deserialization for demo purposes. In production, use certificate-based encryption.</td>
+            </tr>
+            <tr>
+                <td><code>DatabaseSettings.ApiKey</code> (<code>ISecret&lt;string&gt;</code>)</td>
+                <td>Demonstrates <code>Secret&lt;T&gt;</code> with memory-safe access via <code>Open()</code> / <code>SecretLease&lt;T&gt;</code></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card">
+    <h3 style="margin-bottom: 0.75rem;">Builder API (Program.cs)</h3>
+    <pre><code>builder.AddCocoarConfiguration(c => c
+    .WithConfiguration(
+        rules: rule => [
+            rule.For&lt;AppSettings&gt;()
+                .FromFile("config/app.json")
+                .Select("AppSettings")
+                .Named("AppSettings (file)")
+                .Required(),
+
+            rule.For&lt;AppSettings&gt;()
+                .FromEnvironment("APP_")
+                .Named("AppSettings (env)"),
+
+            rule.For&lt;DatabaseSettings&gt;()
+                .FromFile("config/database.json")
+                .Named("DatabaseSettings")
+                .Required(),
+
+            rule.For&lt;NotificationSettings&gt;()
+                .FromStaticJson("{ ... }")
+                .Named("NotificationSettings (static)"),
+
+            rule.For&lt;DiagnosticsConfig&gt;()
+                .FromStaticJson("{ ... }")
+                .Named("Diagnostics (conditional)")
+                .When(accessor => accessor.GetConfig&lt;AppSettings&gt;().EnableDetailedErrors)
+        ],
+        setup: setup => [
+            setup.ConcreteType&lt;AppSettings&gt;().ExposeAs&lt;IAppSettings&gt;(),
+            setup.ConcreteType&lt;DatabaseSettings&gt;().ExposeAs&lt;IDatabaseSettings&gt;(),
+            setup.Interface&lt;INotificationSettings&gt;().DeserializeTo&lt;NotificationSettings&gt;()
+        ])
+    .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+    .UseDebounce(500));</code></pre>
+</div>

--- a/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
@@ -106,7 +106,7 @@
 <div class="card">
     <h3 style="margin-bottom: 0.75rem;">Builder API (Program.cs)</h3>
     <pre><code>builder.AddCocoarConfiguration(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rules: rule => [
             rule.For&lt;AppSettings&gt;()
                 .FromFile("config/app.json")

--- a/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Pages/RulesOverview.razor
@@ -92,7 +92,7 @@
         </thead>
         <tbody>
             <tr>
-                <td><code>.WithSecretsSetup(secrets =&gt; secrets.AllowPlaintext())</code></td>
+                <td><code>.UseSecretsSetup(secrets =&gt; secrets.AllowPlaintext())</code></td>
                 <td>Enables plaintext secret deserialization for demo purposes. In production, use certificate-based encryption.</td>
             </tr>
             <tr>
@@ -137,6 +137,6 @@
             setup.ConcreteType&lt;DatabaseSettings&gt;().ExposeAs&lt;IDatabaseSettings&gt;(),
             setup.Interface&lt;INotificationSettings&gt;().DeserializeTo&lt;NotificationSettings&gt;()
         ])
-    .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+    .UseSecretsSetup(secrets => secrets.AllowPlaintext())
     .UseDebounce(500));</code></pre>
 </div>

--- a/src/Examples/ConfigurationShowcase/Components/Routes.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/Examples/ConfigurationShowcase/Components/Shared/HealthStatusBadge.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Shared/HealthStatusBadge.razor
@@ -1,0 +1,13 @@
+@code {
+    [Parameter] public HealthStatus Status { get; set; }
+
+    private string CssClass => Status switch
+    {
+        HealthStatus.Healthy => "badge badge-healthy",
+        HealthStatus.Degraded => "badge badge-degraded",
+        HealthStatus.Unhealthy => "badge badge-unhealthy",
+        _ => "badge badge-unknown"
+    };
+}
+
+<span class="@CssClass">@Status</span>

--- a/src/Examples/ConfigurationShowcase/Components/Shared/RuleStatusBadge.razor
+++ b/src/Examples/ConfigurationShowcase/Components/Shared/RuleStatusBadge.razor
@@ -1,0 +1,13 @@
+@code {
+    [Parameter] public RuleResultStatus Status { get; set; }
+
+    private string CssClass => Status switch
+    {
+        RuleResultStatus.Up => "badge badge-up",
+        RuleResultStatus.Down => "badge badge-down",
+        RuleResultStatus.Skipped => "badge badge-skipped",
+        _ => "badge badge-unknown"
+    };
+}
+
+<span class="@CssClass">@Status</span>

--- a/src/Examples/ConfigurationShowcase/Components/_Imports.razor
+++ b/src/Examples/ConfigurationShowcase/Components/_Imports.razor
@@ -1,0 +1,12 @@
+@using System.Net.Http
+@using System.Reactive.Linq
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.JSInterop
+@using ConfigurationShowcase.Components
+@using ConfigurationShowcase.Components.Shared
+@using ConfigurationShowcase.Models
+@using Cocoar.Configuration.Health
+@using Cocoar.Configuration.Reactive

--- a/src/Examples/ConfigurationShowcase/ConfigurationShowcase.csproj
+++ b/src/Examples/ConfigurationShowcase/ConfigurationShowcase.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ConfigurationShowcase</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cocoar.Configuration.AspNetCore\Cocoar.Configuration.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Cocoar.Configuration.Secrets\Cocoar.Configuration.Secrets.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="config\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/src/Examples/ConfigurationShowcase/Hubs/ConfigHub.cs
+++ b/src/Examples/ConfigurationShowcase/Hubs/ConfigHub.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace ConfigurationShowcase.Hubs;
+
+/// <summary>
+/// SignalR hub for pushing real-time configuration updates to external consumers.
+/// Push-only: clients subscribe by connecting; no client-to-server methods needed.
+/// </summary>
+public sealed class ConfigHub : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        await Clients.Caller.SendAsync("Connected", $"Connected at {DateTime.UtcNow:O}");
+        await base.OnConnectedAsync();
+    }
+}

--- a/src/Examples/ConfigurationShowcase/Models/AppSettings.cs
+++ b/src/Examples/ConfigurationShowcase/Models/AppSettings.cs
@@ -1,0 +1,19 @@
+namespace ConfigurationShowcase.Models;
+
+public interface IAppSettings
+{
+    string ApplicationName { get; }
+    string Version { get; }
+    int MaxRetries { get; }
+    bool EnableDetailedErrors { get; }
+    string WelcomeMessage { get; }
+}
+
+public class AppSettings : IAppSettings
+{
+    public string ApplicationName { get; set; } = "Cocoar Showcase";
+    public string Version { get; set; } = "1.0.0";
+    public int MaxRetries { get; set; } = 3;
+    public bool EnableDetailedErrors { get; set; }
+    public string WelcomeMessage { get; set; } = "";
+}

--- a/src/Examples/ConfigurationShowcase/Models/DatabaseSettings.cs
+++ b/src/Examples/ConfigurationShowcase/Models/DatabaseSettings.cs
@@ -1,0 +1,20 @@
+using Cocoar.Configuration.Secrets.SecretTypes;
+
+namespace ConfigurationShowcase.Models;
+
+public interface IDatabaseSettings
+{
+    string ConnectionString { get; }
+    int MaxPoolSize { get; }
+    int CommandTimeoutSeconds { get; }
+    bool EnableRetryOnFailure { get; }
+}
+
+public class DatabaseSettings : IDatabaseSettings
+{
+    public string ConnectionString { get; set; } = "";
+    public int MaxPoolSize { get; set; } = 50;
+    public int CommandTimeoutSeconds { get; set; } = 30;
+    public bool EnableRetryOnFailure { get; set; }
+    public ISecret<string>? ApiKey { get; set; }
+}

--- a/src/Examples/ConfigurationShowcase/Models/NotificationSettings.cs
+++ b/src/Examples/ConfigurationShowcase/Models/NotificationSettings.cs
@@ -1,0 +1,19 @@
+namespace ConfigurationShowcase.Models;
+
+public interface INotificationSettings
+{
+    string SmtpServer { get; }
+    int SmtpPort { get; }
+    string FromAddress { get; }
+    bool EnableSlack { get; }
+    string SlackWebhookUrl { get; }
+}
+
+public class NotificationSettings : INotificationSettings
+{
+    public string SmtpServer { get; set; } = "smtp.example.com";
+    public int SmtpPort { get; set; } = 587;
+    public string FromAddress { get; set; } = "noreply@example.com";
+    public bool EnableSlack { get; set; }
+    public string SlackWebhookUrl { get; set; } = "";
+}

--- a/src/Examples/ConfigurationShowcase/Models/PremiumAnalyticsConfig.cs
+++ b/src/Examples/ConfigurationShowcase/Models/PremiumAnalyticsConfig.cs
@@ -1,0 +1,9 @@
+namespace ConfigurationShowcase.Models;
+
+public class DiagnosticsConfig
+{
+    public bool EnableRequestTracing { get; set; }
+    public bool EnablePerformanceCounters { get; set; }
+    public int TraceRetentionMinutes { get; set; } = 60;
+    public string TraceEndpoint { get; set; } = "/diagnostics/traces";
+}

--- a/src/Examples/ConfigurationShowcase/Program.cs
+++ b/src/Examples/ConfigurationShowcase/Program.cs
@@ -72,7 +72,7 @@ builder.AddCocoarConfiguration(c => c
             // Interface deserialization pattern
             setup.Interface<INotificationSettings>().DeserializeTo<NotificationSettings>()
         ])
-    .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+    .UseSecretsSetup(secrets => secrets.AllowPlaintext())
     .UseDebounce(500));
 
 // Register tuple reactive config for the Reactive Demo page

--- a/src/Examples/ConfigurationShowcase/Program.cs
+++ b/src/Examples/ConfigurationShowcase/Program.cs
@@ -13,7 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 var configDir = Path.Combine(builder.Environment.ContentRootPath, "config");
 
 builder.AddCocoarConfiguration(c => c
-    .WithConfiguration(
+    .UseConfiguration(
         rules: rule =>
         [
             // --- File-based rules ---

--- a/src/Examples/ConfigurationShowcase/Program.cs
+++ b/src/Examples/ConfigurationShowcase/Program.cs
@@ -1,0 +1,122 @@
+using Cocoar.Configuration.AspNetCore;
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Providers;
+using Cocoar.Configuration.Reactive;
+using Cocoar.Configuration.Secrets;
+using ConfigurationShowcase.Hubs;
+using ConfigurationShowcase.Models;
+using ConfigurationShowcase.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Resolve config file paths relative to the app's content root
+var configDir = Path.Combine(builder.Environment.ContentRootPath, "config");
+
+builder.AddCocoarConfiguration(c => c
+    .WithConfiguration(
+        rules: rule =>
+        [
+            // --- File-based rules ---
+            rule.For<AppSettings>()
+                .FromFile(Path.Combine(configDir, "app.json"))
+                .Select("AppSettings")
+                .Named("AppSettings (file)")
+                .Required(),
+
+            // Environment overlay for AppSettings (prefix APP_)
+            rule.For<AppSettings>()
+                .FromEnvironment("APP_")
+                .Named("AppSettings (env)"),
+
+            rule.For<DatabaseSettings>()
+                .FromFile(Path.Combine(configDir, "database.json"))
+                .Named("DatabaseSettings")
+                .Required(),
+
+            // --- Static JSON rules ---
+            rule.For<NotificationSettings>()
+                .FromStaticJson("""
+                {
+                    "SmtpServer": "smtp.showcase.local",
+                    "SmtpPort": 587,
+                    "FromAddress": "showcase@cocoar.dev",
+                    "EnableSlack": true,
+                    "SlackWebhookUrl": "https://hooks.slack.example.com/showcase"
+                }
+                """)
+                .Named("NotificationSettings (static)"),
+
+            // --- Conditional rule: only loads when EnableDetailedErrors is true ---
+            rule.For<DiagnosticsConfig>()
+                .FromStaticJson("""
+                {
+                    "EnableRequestTracing": true,
+                    "EnablePerformanceCounters": true,
+                    "TraceRetentionMinutes": 30,
+                    "TraceEndpoint": "/diagnostics/traces"
+                }
+                """)
+                .Named("Diagnostics (conditional)")
+                .When(accessor =>
+                {
+                    var app = accessor.GetConfig<AppSettings>();
+                    return app.EnableDetailedErrors;
+                })
+        ],
+        setup: setup =>
+        [
+            // ConcreteType + ExposeAs (2 interface exposures)
+            setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>(),
+            setup.ConcreteType<DatabaseSettings>().ExposeAs<IDatabaseSettings>(),
+
+            // Interface deserialization pattern
+            setup.Interface<INotificationSettings>().DeserializeTo<NotificationSettings>()
+        ])
+    .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+    .UseDebounce(500));
+
+// Register tuple reactive config for the Reactive Demo page
+var configManager = builder.GetCocoarConfigManager();
+builder.Services.AddSingleton(configManager.GetReactiveConfig<(AppSettings App, DatabaseSettings Db)>());
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+builder.Services.AddSignalR();
+builder.Services.AddHostedService<ConfigWatcherService>();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+// API endpoint for the ReactiveDemo file editor
+app.MapPost("/api/config/app", async (HttpRequest request) =>
+{
+    var json = await new StreamReader(request.Body).ReadToEndAsync();
+    var filePath = Path.Combine(configDir, "app.json");
+    await File.WriteAllTextAsync(filePath, json);
+    return Results.Ok(new { saved = true });
+});
+
+app.MapPost("/api/config/database", async (HttpRequest request) =>
+{
+    var json = await new StreamReader(request.Body).ReadToEndAsync();
+    var filePath = Path.Combine(configDir, "database.json");
+    await File.WriteAllTextAsync(filePath, json);
+    return Results.Ok(new { saved = true });
+});
+
+app.MapGet("/api/config/{name}", (string name) =>
+{
+    var filePath = Path.Combine(configDir, $"{name}.json");
+    if (!File.Exists(filePath)) return Results.NotFound();
+    var content = File.ReadAllText(filePath);
+    return Results.Text(content, "application/json");
+});
+
+app.MapHub<ConfigHub>("/confighub");
+
+app.MapRazorComponents<ConfigurationShowcase.Components.App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/src/Examples/ConfigurationShowcase/Properties/launchSettings.json
+++ b/src/Examples/ConfigurationShowcase/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "ConfigurationShowcase": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5200",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "APP_ApplicationName": "Showcase (from env)"
+      }
+    }
+  }
+}

--- a/src/Examples/ConfigurationShowcase/Services/ConfigWatcherService.cs
+++ b/src/Examples/ConfigurationShowcase/Services/ConfigWatcherService.cs
@@ -1,0 +1,87 @@
+using System.Reactive.Linq;
+using Cocoar.Configuration.Health;
+using Cocoar.Configuration.Reactive;
+using ConfigurationShowcase.Hubs;
+using ConfigurationShowcase.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace ConfigurationShowcase.Services;
+
+/// <summary>
+/// Background service that subscribes to reactive config and health streams,
+/// then pushes updates to the SignalR ConfigHub for external consumers.
+/// </summary>
+public sealed class ConfigWatcherService : BackgroundService
+{
+    private readonly IHubContext<ConfigHub> _hubContext;
+    private readonly IReactiveConfig<AppSettings> _appConfig;
+    private readonly IReactiveConfig<DatabaseSettings> _dbConfig;
+    private readonly IConfigurationHealthService _healthService;
+
+    public ConfigWatcherService(
+        IHubContext<ConfigHub> hubContext,
+        IReactiveConfig<AppSettings> appConfig,
+        IReactiveConfig<DatabaseSettings> dbConfig,
+        IConfigurationHealthService healthService)
+    {
+        _hubContext = hubContext;
+        _appConfig = appConfig;
+        _dbConfig = dbConfig;
+        _healthService = healthService;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var appSub = _appConfig.Subscribe(config =>
+            _hubContext.Clients.All.SendAsync("AppSettingsChanged", new
+            {
+                config.ApplicationName,
+                config.Version,
+                config.MaxRetries,
+                config.EnableDetailedErrors,
+                config.WelcomeMessage,
+                Timestamp = DateTime.UtcNow
+            }, stoppingToken));
+
+        var dbSub = _dbConfig.Subscribe(config =>
+            _hubContext.Clients.All.SendAsync("DatabaseSettingsChanged", new
+            {
+                config.ConnectionString,
+                config.MaxPoolSize,
+                config.CommandTimeoutSeconds,
+                config.EnableRetryOnFailure,
+                Timestamp = DateTime.UtcNow
+            }, stoppingToken));
+
+        var healthSub = _healthService.SnapshotStream.Subscribe(snapshot =>
+            _hubContext.Clients.All.SendAsync("HealthUpdated", new
+            {
+                snapshot.OverallStatus,
+                snapshot.ConfigVersion,
+                snapshot.TimestampUtc,
+                RuleCount = snapshot.Rules.Count,
+                Summary = new
+                {
+                    snapshot.Summary.Total,
+                    snapshot.Summary.RequiredFailed,
+                    snapshot.Summary.OptionalFailed,
+                    snapshot.Summary.Skipped
+                }
+            }, stoppingToken));
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down
+        }
+        finally
+        {
+            appSub.Dispose();
+            dbSub.Dispose();
+            healthSub.Dispose();
+        }
+    }
+}

--- a/src/Examples/ConfigurationShowcase/config/app.json
+++ b/src/Examples/ConfigurationShowcase/config/app.json
@@ -1,0 +1,9 @@
+{
+  "AppSettings": {
+    "ApplicationName": "Configuration Showcase",
+    "Version": "5.0.0",
+    "MaxRetries": 3,
+    "EnableDetailedErrors": true,
+    "WelcomeMessage": "Welcome to the Cocoar.Configuration v5.0 Showcase!"
+  }
+}

--- a/src/Examples/ConfigurationShowcase/config/database.json
+++ b/src/Examples/ConfigurationShowcase/config/database.json
@@ -1,0 +1,7 @@
+{
+  "ConnectionString": "Server=localhost;Database=showcase;Trusted_Connection=true",
+  "MaxPoolSize": 100,
+  "CommandTimeoutSeconds": 30,
+  "EnableRetryOnFailure": true,
+  "ApiKey": "sk-demo-plaintext-secret-12345"
+}

--- a/src/Examples/ConfigurationShowcase/wwwroot/css/app.css
+++ b/src/Examples/ConfigurationShowcase/wwwroot/css/app.css
@@ -1,0 +1,202 @@
+:root {
+    --bg-primary: #0f1117;
+    --bg-secondary: #1a1d27;
+    --bg-card: #212430;
+    --bg-input: #2a2d3a;
+    --border-color: #2e3244;
+    --text-primary: #e4e6ed;
+    --text-secondary: #8b8fa3;
+    --text-muted: #5c6078;
+    --accent: #6c5ce7;
+    --accent-hover: #7d6ff0;
+    --success: #00d68f;
+    --warning: #ffaa00;
+    --danger: #ff4757;
+    --info: #5b9bd5;
+    --sidebar-width: 240px;
+    --font-mono: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', monospace;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+#app {
+    height: 100%;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+a:hover {
+    color: var(--accent-hover);
+}
+
+h1, h2, h3, h4 {
+    font-weight: 600;
+    letter-spacing: -0.02em;
+}
+h1 { font-size: 1.75rem; }
+h2 { font-size: 1.35rem; }
+h3 { font-size: 1.1rem; }
+
+code, pre {
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+}
+pre {
+    background: var(--bg-input);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    line-height: 1.5;
+}
+code {
+    background: var(--bg-input);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.85em;
+}
+pre code {
+    background: none;
+    padding: 0;
+}
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1.25rem;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2em 0.65em;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.badge-healthy, .badge-up { background: rgba(0,214,143,0.15); color: var(--success); }
+.badge-degraded { background: rgba(255,170,0,0.15); color: var(--warning); }
+.badge-unhealthy, .badge-down { background: rgba(255,71,87,0.15); color: var(--danger); }
+.badge-unknown, .badge-skipped { background: rgba(91,155,213,0.15); color: var(--info); }
+.badge-required { background: rgba(108,92,231,0.15); color: var(--accent); }
+.badge-optional { background: rgba(139,143,163,0.1); color: var(--text-secondary); }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+th, td {
+    padding: 0.65rem 0.85rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+button, .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.15s, border-color 0.15s;
+}
+button:hover, .btn:hover {
+    background: var(--bg-card);
+    border-color: var(--accent);
+}
+.btn-primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+.btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+
+textarea {
+    width: 100%;
+    min-height: 200px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    resize: vertical;
+    line-height: 1.5;
+}
+textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem; }
+
+.stat-value {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1;
+}
+.stat-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 0.25rem;
+}
+
+.event-log {
+    max-height: 300px;
+    overflow-y: auto;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+.event-log-entry {
+    padding: 0.35rem 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    gap: 0.75rem;
+}
+.event-log-entry:last-child { border-bottom: none; }
+.event-time { color: var(--text-muted); white-space: nowrap; }
+.event-type { color: var(--accent); font-weight: 600; min-width: 120px; }
+.event-detail { color: var(--text-secondary); }
+
+.flash {
+    animation: flash-highlight 1s ease-out;
+}
+@keyframes flash-highlight {
+    0% { background-color: rgba(108,92,231,0.3); }
+    100% { background-color: transparent; }
+}

--- a/src/Examples/DynamicDependencies/Program.cs
+++ b/src/Examples/DynamicDependencies/Program.cs
@@ -36,7 +36,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
 
             rule.For<ApiSettings>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config.json")).Select("Api")
                 .Required(),
@@ -46,7 +46,7 @@ public static class Program
                 var apiSettings = configManager.GetRequiredConfig<ApiSettings>();
                 if (apiSettings.BaseUrl.Contains("staging"))
                 {
-                    return new FeatureFlags { EnableNewDashboard = true, EnableBetaFeatures = true, Theme = "staging" };        
+                    return new FeatureFlags { EnableNewDashboard = true, EnableBetaFeatures = true, Theme = "staging" };
                 }
                 return new FeatureFlags { EnableNewDashboard = false, EnableBetaFeatures = false, Theme = "production" };
             }),
@@ -65,7 +65,7 @@ public static class Program
                 };
             })
 
-        ]);
+        ]));
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/src/Examples/DynamicDependencies/Program.cs
+++ b/src/Examples/DynamicDependencies/Program.cs
@@ -36,14 +36,14 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
 
             rule.For<ApiSettings>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config.json")).Select("Api")
                 .Required(),
 
             rule.For<FeatureFlags>().FromStatic(configManager =>
             {
-                var apiSettings = configManager.GetRequiredConfig<ApiSettings>();
+                var apiSettings = configManager.GetConfig<ApiSettings>()!;
                 if (apiSettings.BaseUrl.Contains("staging"))
                 {
                     return new FeatureFlags { EnableNewDashboard = true, EnableBetaFeatures = true, Theme = "staging" };
@@ -56,7 +56,7 @@ public static class Program
 
             rule.For<RegionSpecificConfig>().FromStatic(configManager =>
             {
-                var regionSettings = configManager.GetRequiredConfig<RegionSettings>();
+                var regionSettings = configManager.GetConfig<RegionSettings>()!;
                 return regionSettings.Region switch
                 {
                     "us-west-2" => new RegionSpecificConfig { DatabaseEndpoint = "db-oregon.example.com", CdnUrl = "https://cdn-us-west.example.com", AvailableLanguages = new[] { "en", "es" } },

--- a/src/Examples/DynamicDependencies/config.json
+++ b/src/Examples/DynamicDependencies/config.json
@@ -1,0 +1,10 @@
+{
+  "Api": {
+    "BaseUrl": "https://api.example.com",
+    "ApiKey": "demo-api-key-12345"
+  },
+  "Region": {
+    "Region": "us-west-2",
+    "DataCenter": "oregon-dc-01"
+  }
+}

--- a/src/Examples/EmojiPrefixTest/Program.cs
+++ b/src/Examples/EmojiPrefixTest/Program.cs
@@ -24,24 +24,23 @@ public class Program
         Console.WriteLine("--- Test 1: Individual emoji prefixes ---");
         try
         {
-            using var manager = new ConfigManager(rule => [
-                rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+                rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["💀"]
                 }),
-                rule.For<FireConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+                rule.For<FireConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["🔥"]
                 }),
-                rule.For<RocketConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+                rule.For<RocketConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = args,
                     SwitchPrefixes = ["🚀"]
                 })
-            ]);
-            manager.Initialize();
+            ]));
 
             var skull = manager.GetConfig<SkullConfig>();
             var fire = manager.GetConfig<FireConfig>();
@@ -63,14 +62,13 @@ public class Program
         var mixedArgs = new[] { "💀host=emojihost", "--host=dashhost", "@host=athost" };
         try
         {
-            using var manager = new ConfigManager(rule => [
-                rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions 
-                { 
+            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+                rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+                {
                     Args = mixedArgs,
                     SwitchPrefixes = ["💀", "--", "@"]
                 })
-            ]);
-            manager.Initialize();
+            ]));
 
             var config = manager.GetConfig<SkullConfig>();
             Console.WriteLine($"Host (should be 'athost' - last wins): {config?.Host ?? "null"}");

--- a/src/Examples/EmojiPrefixTest/Program.cs
+++ b/src/Examples/EmojiPrefixTest/Program.cs
@@ -9,9 +9,9 @@ public class Program
     public static void Main()
     {
         Console.OutputEncoding = System.Text.Encoding.UTF8;
-        
+
         var args = new[] { "💀host=localhost", "🔥port=8080", "🚀verbose" };
-        
+
         Console.WriteLine("=== Emoji Prefix Test ===\n");
         Console.WriteLine($"Input args:");
         foreach (var arg in args)
@@ -19,12 +19,12 @@ public class Program
             Console.WriteLine($"  {arg}");
         }
         Console.WriteLine();
-        
+
         // Test 1: Emoji prefixes
         Console.WriteLine("--- Test 1: Individual emoji prefixes ---");
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions
                 {
                     Args = args,
@@ -56,13 +56,13 @@ public class Program
             Console.WriteLine($"❌ ERROR: {ex.Message}");
         }
         Console.WriteLine();
-        
+
         // Test 2: Mixed emoji and traditional
         Console.WriteLine("--- Test 2: Mixed emoji and traditional prefixes ---");
         var mixedArgs = new[] { "💀host=emojihost", "--host=dashhost", "@host=athost" };
         try
         {
-            using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<SkullConfig>().FromCommandLine(cm => new CommandLineRuleOptions
                 {
                     Args = mixedArgs,

--- a/src/Examples/ExposeExample/Program.cs
+++ b/src/Examples/ExposeExample/Program.cs
@@ -71,7 +71,7 @@ public static class Program
 
         try
         {           
-            var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 rule.For<PaymentConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/payment.json")),
                 rule.For<FeatureToggleConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/features.json")),
                 rule.For<DatabaseConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/database.json"))
@@ -129,7 +129,7 @@ public static class Program
             // 8. Show API patterns
             Console.WriteLine("📖 Key Exposure Patterns:");
             Console.WriteLine("   ✓ Setup.ConcreteType<T>().ExposeAs<IInterface>().Build()");
-            Console.WriteLine("   ✓ ConfigManager.Create(c => c.WithConfiguration(rules, setup))");
+            Console.WriteLine("   ✓ ConfigManager.Create(c => c.UseConfiguration(rules, setup))");
             Console.WriteLine("   ✓ manager.GetConfig<IInterface>() // resolves via exposure");
             Console.WriteLine("   ✓ manager.GetConfig<ConcreteType>() // direct access");
             Console.WriteLine("   ✓ Multiple interfaces per concrete type");

--- a/src/Examples/ExposeExample/Program.cs
+++ b/src/Examples/ExposeExample/Program.cs
@@ -71,16 +71,14 @@ public static class Program
 
         try
         {           
-            var manager = new ConfigManager(rule => [
+            var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
                 rule.For<PaymentConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/payment.json")),
                 rule.For<FeatureToggleConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/features.json")),
                 rule.For<DatabaseConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/database.json"))
             ], setup => [
                 setup.ConcreteType<PaymentConfig>().ExposeAs<IPaymentConfig>(),
                 setup.ConcreteType<FeatureToggleConfig>().ExposeAs<IFeatureToggles>().ExposeAs<IReadOnlyFeatureToggles>()
-            ]);
-
-            manager.Initialize();
+            ]));
 
             Console.WriteLine("📋 ConfigManager initialized successfully!");
             Console.WriteLine();
@@ -131,7 +129,7 @@ public static class Program
             // 8. Show API patterns
             Console.WriteLine("📖 Key Exposure Patterns:");
             Console.WriteLine("   ✓ Setup.ConcreteType<T>().ExposeAs<IInterface>().Build()");
-            Console.WriteLine("   ✓ new ConfigManager(rules, configuredBuilders)");
+            Console.WriteLine("   ✓ ConfigManager.Create(c => c.WithConfiguration(rules, setup))");
             Console.WriteLine("   ✓ manager.GetConfig<IInterface>() // resolves via exposure");
             Console.WriteLine("   ✓ manager.GetConfig<ConcreteType>() // direct access");
             Console.WriteLine("   ✓ Multiple interfaces per concrete type");

--- a/src/Examples/FileLayering/Program.cs
+++ b/src/Examples/FileLayering/Program.cs
@@ -20,7 +20,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<AppConfig>().FromFile("base.json").Select("App"),
             rule.For<AppConfig>().FromFile("production.json").Select("App"),
             rule.For<AppConfig>().FromFile("local.json").Select("App")

--- a/src/Examples/FileLayering/Program.cs
+++ b/src/Examples/FileLayering/Program.cs
@@ -20,11 +20,11 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<AppConfig>().FromFile("base.json").Select("App"),
             rule.For<AppConfig>().FromFile("production.json").Select("App"),
             rule.For<AppConfig>().FromFile("local.json").Select("App")
-        ]);
+        ]));
 
         var serviceProvider = services.BuildServiceProvider();
         var config = serviceProvider.GetService<AppConfig>();

--- a/src/Examples/FileLayering/base.json
+++ b/src/Examples/FileLayering/base.json
@@ -1,0 +1,13 @@
+{
+  "App": {
+    "ApplicationName": "File Layering Example",
+    "Version": "1.0.0",
+    "EnableLogging": true,
+    "LogLevel": "Information",
+    "MaxConnections": 100,
+    "AllowedOrigins": [
+      "https://example.com",
+      "https://www.example.com"
+    ]
+  }
+}

--- a/src/Examples/FileLayering/local.json
+++ b/src/Examples/FileLayering/local.json
@@ -1,0 +1,5 @@
+{
+  "App": {
+    "LogLevel": "Debug"
+  }
+}

--- a/src/Examples/FileLayering/production.json
+++ b/src/Examples/FileLayering/production.json
@@ -1,0 +1,6 @@
+{
+  "App": {
+    "LogLevel": "Warning",
+    "MaxConnections": 500
+  }
+}

--- a/src/Examples/GenericProviderAPI/Program.cs
+++ b/src/Examples/GenericProviderAPI/Program.cs
@@ -17,11 +17,11 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<AppSettings>().FromFile(_ => FileSourceRuleOptions.FromFilePath("./appsettings.json"))
                 .Select("App")
                 .Required()
-        ]);
+        ]));
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/src/Examples/GenericProviderAPI/Program.cs
+++ b/src/Examples/GenericProviderAPI/Program.cs
@@ -17,7 +17,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<AppSettings>().FromFile(_ => FileSourceRuleOptions.FromFilePath("./appsettings.json"))
                 .Select("App")
                 .Required()

--- a/src/Examples/GenericProviderAPI/appsettings.json
+++ b/src/Examples/GenericProviderAPI/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "App": {
+    "ApplicationName": "Generic Provider API Example",
+    "EnableFeatureA": true,
+    "MaxRetries": 3
+  }
+}

--- a/src/Examples/HttpPollingExample/Program.cs
+++ b/src/Examples/HttpPollingExample/Program.cs
@@ -26,7 +26,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
 
             rule.For<ApiConfiguration>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config.json")).Select("Api")
                 .Required(),

--- a/src/Examples/HttpPollingExample/Program.cs
+++ b/src/Examples/HttpPollingExample/Program.cs
@@ -26,7 +26,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
 
             rule.For<ApiConfiguration>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config.json")).Select("Api")
                 .Required(),
@@ -38,7 +38,7 @@ public static class Program
                 AllowedRegions = DefaultAllowedRegions
             })
 
-        ]);
+        ]));
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/src/Examples/HttpPollingExample/config.json
+++ b/src/Examples/HttpPollingExample/config.json
@@ -1,0 +1,7 @@
+{
+  "Api": {
+    "BaseUrl": "https://api.example.com",
+    "ApiKey": "demo-api-key-12345",
+    "PollIntervalSeconds": 30
+  }
+}

--- a/src/Examples/MicrosoftAdapterExample/Program.cs
+++ b/src/Examples/MicrosoftAdapterExample/Program.cs
@@ -24,7 +24,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
 
             rule.For<DatabaseSettings>().FromMicrosoftSource(_ => new(
                     new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
@@ -49,7 +49,7 @@ public static class Program
                 ))
                 .Required()
 
-        ]);
+        ]));
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/src/Examples/MicrosoftAdapterExample/Program.cs
+++ b/src/Examples/MicrosoftAdapterExample/Program.cs
@@ -24,7 +24,7 @@ public static class Program
     {
         var services = new ServiceCollection();
 
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
 
             rule.For<DatabaseSettings>().FromMicrosoftSource(_ => new(
                     new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>

--- a/src/Examples/SecretsBasicExample/Program.cs
+++ b/src/Examples/SecretsBasicExample/Program.cs
@@ -39,14 +39,13 @@ class Program
             overwrite: true);
 
         // Create ConfigManager with certificate-based secrets
-        var manager = new ConfigManager(rule => [
-            rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
-        ], setup => [
-            // Load certificate explicitly (no auto-creation)
-            setup.Secrets()
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rule => [
+                rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
+            ])
+            .WithSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(certPath)
-                .WithKeyId("dev-secrets")
-        ]).Initialize();
+                .WithKeyId("dev-secrets")));
 
         // Retrieve configuration
         var config = manager.GetConfig<AppConfig>();

--- a/src/Examples/SecretsBasicExample/Program.cs
+++ b/src/Examples/SecretsBasicExample/Program.cs
@@ -43,7 +43,7 @@ class Program
             .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
             ])
-            .WithSecretsSetup(secrets => secrets
+            .UseSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(certPath)
                 .WithKeyId("dev-secrets")));
 

--- a/src/Examples/SecretsBasicExample/Program.cs
+++ b/src/Examples/SecretsBasicExample/Program.cs
@@ -40,7 +40,7 @@ class Program
 
         // Create ConfigManager with certificate-based secrets
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rule => [
+            .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
             ])
             .WithSecretsSetup(secrets => secrets

--- a/src/Examples/SecretsBasicExample/README.md
+++ b/src/Examples/SecretsBasicExample/README.md
@@ -20,7 +20,7 @@ dotnet run --project Examples\SecretsBasicExample\SecretsBasicExample.csproj
 
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
     ])
     .WithSecretsSetup(secrets => secrets

--- a/src/Examples/SecretsBasicExample/README.md
+++ b/src/Examples/SecretsBasicExample/README.md
@@ -21,7 +21,7 @@ dotnet run --project Examples\SecretsBasicExample\SecretsBasicExample.csproj
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
-        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
+        rule.For<AppConfig>().FromFile("appsettings.json")
     ])
     .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")  // Password-less certificate

--- a/src/Examples/SecretsBasicExample/README.md
+++ b/src/Examples/SecretsBasicExample/README.md
@@ -23,7 +23,7 @@ var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
     ])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")  // Password-less certificate
         .WithKeyId("dev-secrets")));
 

--- a/src/Examples/SecretsBasicExample/README.md
+++ b/src/Examples/SecretsBasicExample/README.md
@@ -19,13 +19,13 @@ dotnet run --project Examples\SecretsBasicExample\SecretsBasicExample.csproj
 ## Key Code Snippet
 
 ```csharp
-var manager = new ConfigManager(rule => [
-    rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
-], setup => [
-    setup.Secrets()
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
+    ])
+    .WithSecretsSetup(secrets => secrets
         .UseCertificateFromFile("secrets.pfx")  // Password-less certificate
-        .WithKeyId("dev-secrets")
-]).Initialize();
+        .WithKeyId("dev-secrets")));
 
 var config = manager.GetConfig<AppConfig>();
 

--- a/src/Examples/SecretsCertificateExample/Program.cs
+++ b/src/Examples/SecretsCertificateExample/Program.cs
@@ -49,7 +49,7 @@ class Program
             .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
             ])
-            .WithSecretsSetup(secrets => secrets
+            .UseSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(devCertPath)
                 .WithKeyId("dev-secrets")));
 
@@ -97,7 +97,7 @@ class Program
             .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
             ])
-            .WithSecretsSetup(secrets => secrets
+            .UseSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(prodCertPath)
                 .WithKeyId("prod-secrets")));
 

--- a/src/Examples/SecretsCertificateExample/Program.cs
+++ b/src/Examples/SecretsCertificateExample/Program.cs
@@ -45,14 +45,13 @@ class Program
             keySize: 2048,
             overwrite: true);
 
-        var manager = new ConfigManager(rule => [
-            rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
-        ], setup => [
-            // Development: Load certificate explicitly
-            setup.Secrets()
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rule => [
+                rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
+            ])
+            .WithSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(devCertPath)
-                .WithKeyId("dev-secrets")
-        ]).Initialize();
+                .WithKeyId("dev-secrets")));
 
         var config = manager.GetConfig<AppConfig>();
 
@@ -94,14 +93,13 @@ class Program
             keySize: 2048,
             overwrite: true);
 
-        var manager = new ConfigManager(rule => [
-            rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
-        ], setup => [
-            // Production: Decrypt pre-encrypted secrets with explicit certificate
-            setup.Secrets()
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rule => [
+                rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
+            ])
+            .WithSecretsSetup(secrets => secrets
                 .UseCertificateFromFile(prodCertPath)
-                .WithKeyId("prod-secrets")
-        ]).Initialize();
+                .WithKeyId("prod-secrets")));
 
         var config = manager.GetConfig<AppConfig>();
 

--- a/src/Examples/SecretsCertificateExample/Program.cs
+++ b/src/Examples/SecretsCertificateExample/Program.cs
@@ -46,7 +46,7 @@ class Program
             overwrite: true);
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rule => [
+            .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
             ])
             .WithSecretsSetup(secrets => secrets
@@ -94,7 +94,7 @@ class Program
             overwrite: true);
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rule => [
+            .UseConfiguration(rule => [
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.encrypted.json"))
             ])
             .WithSecretsSetup(secrets => secrets

--- a/src/Examples/SecretsCertificateExample/README.md
+++ b/src/Examples/SecretsCertificateExample/README.md
@@ -26,61 +26,40 @@ cocoar-secrets generate-cert -o certs/dev.pfx
 
 Then configure the manager:
 ```csharp
-var manager = new ConfigManager(rule => [
-    rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.dev.json"))
-], setup => [
-    setup.Secrets()
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.dev.json"))
+    ])
+    .WithSecretsSetup(secrets => secrets
         .UseCertificateFromFile("certs/dev.pfx")
-        .WithKeyId("dev-secrets")
-        .Build()
-]).Initialize();
+        .WithKeyId("dev-secrets")));
 ```
 
 ### Production Setup with Rotation
 
 ```csharp
-var manager = new ConfigManager(rule => [
-    rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.prod.json"))
-], setup => [
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.prod.json"))
+    ])
     // Folder-based with automatic rotation
     // Uses kid-based folders: C:\certs\prod\production-secrets\*.pfx
-    setup.Secrets()
-        .UseCertificatesFromFolder(@"C:\certs\prod", 
-            cacheDurationSeconds: 30),
-    
-    // Legacy support for old Kids
-    setup.Secrets()
-        .UseCertificateFromFile("certs/legacy.pfx")
-        .WithKeyId("hybrid-encryption")
-        .WithAdditionalKeyId("prod-v1")  // Backward compatibility
-        .Build()
-]).Initialize();
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificatesFromFolder(@"C:\certs\prod",
+            cacheDurationSeconds: 30)));
 ```
 
 ### Multi-Tier Security
 
 ```csharp
-var manager = new ConfigManager(rule => [
-    rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
-], setup => [
+var manager = ConfigManager.Create(c => c
+    .WithConfiguration(rule => [
+        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
+    ])
     // Critical secrets - no cache, load fresh every time
-    // Folder structure: C:\certs\pci\pci-data\*.pfx
-    setup.Secrets()
-        .UseCertificatesFromFolder(@"C:\certs\pci", 
-            cacheDurationSeconds: 0),  // Maximum security
-    
-    // API keys - balanced 30-second cache
-    // Folder structure: C:\certs\api\api-keys\*.pfx
-    setup.Secrets()
-        .UseCertificatesFromFolder(@"C:\certs\api", 
-            cacheDurationSeconds: 30),
-    
-    // Feature flags - 1-hour cache for performance
-    // Folder structure: C:\certs\config\feature-flags\*.pfx
-    setup.Secrets()
-        .UseCertificatesFromFolder(@"C:\certs\config", 
-            cacheDurationSeconds: 3600)
-]).Initialize();
+    .WithSecretsSetup(secrets => secrets
+        .UseCertificatesFromFolder(@"C:\certs\pci",
+            cacheDurationSeconds: 0)));  // Maximum security
 ```
 
 ## Certificate Management

--- a/src/Examples/SecretsCertificateExample/README.md
+++ b/src/Examples/SecretsCertificateExample/README.md
@@ -28,7 +28,7 @@ Then configure the manager:
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
-        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.dev.json"))
+        rule.For<AppConfig>().FromFile("appsettings.dev.json")
     ])
     .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("certs/dev.pfx")
@@ -40,7 +40,7 @@ var manager = ConfigManager.Create(c => c
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
-        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.prod.json"))
+        rule.For<AppConfig>().FromFile("appsettings.prod.json")
     ])
     // Folder-based with automatic rotation
     // Uses kid-based folders: C:\certs\prod\production-secrets\*.pfx
@@ -54,7 +54,7 @@ var manager = ConfigManager.Create(c => c
 ```csharp
 var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
-        rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
+        rule.For<AppConfig>().FromFile("appsettings.json")
     ])
     // Critical secrets - no cache, load fresh every time
     .UseSecretsSetup(secrets => secrets

--- a/src/Examples/SecretsCertificateExample/README.md
+++ b/src/Examples/SecretsCertificateExample/README.md
@@ -30,7 +30,7 @@ var manager = ConfigManager.Create(c => c
     .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.dev.json"))
     ])
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificateFromFile("certs/dev.pfx")
         .WithKeyId("dev-secrets")));
 ```
@@ -44,7 +44,7 @@ var manager = ConfigManager.Create(c => c
     ])
     // Folder-based with automatic rotation
     // Uses kid-based folders: C:\certs\prod\production-secrets\*.pfx
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs\prod",
             cacheDurationSeconds: 30)));
 ```
@@ -57,7 +57,7 @@ var manager = ConfigManager.Create(c => c
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
     ])
     // Critical secrets - no cache, load fresh every time
-    .WithSecretsSetup(secrets => secrets
+    .UseSecretsSetup(secrets => secrets
         .UseCertificatesFromFolder(@"C:\certs\pci",
             cacheDurationSeconds: 0)));  // Maximum security
 ```

--- a/src/Examples/SecretsCertificateExample/README.md
+++ b/src/Examples/SecretsCertificateExample/README.md
@@ -27,7 +27,7 @@ cocoar-secrets generate-cert -o certs/dev.pfx
 Then configure the manager:
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.dev.json"))
     ])
     .WithSecretsSetup(secrets => secrets
@@ -39,7 +39,7 @@ var manager = ConfigManager.Create(c => c
 
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.prod.json"))
     ])
     // Folder-based with automatic rotation
@@ -53,7 +53,7 @@ var manager = ConfigManager.Create(c => c
 
 ```csharp
 var manager = ConfigManager.Create(c => c
-    .WithConfiguration(rule => [
+    .UseConfiguration(rule => [
         rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("appsettings.json"))
     ])
     // Critical secrets - no cache, load fresh every time

--- a/src/Examples/SimplifiedCoreExample/Program.cs
+++ b/src/Examples/SimplifiedCoreExample/Program.cs
@@ -39,7 +39,7 @@ public static class Program
         Console.WriteLine();
 
         // 1. Build rules using the function-based API
-        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/app.json")),
 
             rule.For<DatabaseConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/database.json")),
@@ -83,7 +83,7 @@ public static class Program
             // 4. Demonstrate rule layering by creating a scenario with overrides
             Console.WriteLine("🔄 Demonstrating rule layering (later rules override earlier ones):");
             
-            var layeredManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+            var layeredManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
                 // Base configuration
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/app.json")),
 
@@ -102,7 +102,7 @@ public static class Program
             Console.WriteLine("📖 Key API Patterns in Simplified Core:");
             Console.WriteLine("   ✓ rule.For<ConcreteType>().FromFile(...)");
             Console.WriteLine("   ✓ rule.Static(...).For<ConcreteType>()");
-            Console.WriteLine("   ✓ ConfigManager.Create(c => c.WithConfiguration(rule => [...]))");
+            Console.WriteLine("   ✓ ConfigManager.Create(c => c.UseConfiguration(rule => [...]))");
             Console.WriteLine("   ✓ manager.GetConfig<ConcreteType>()");
             Console.WriteLine("   ✗ No .As<Interface>() (removed from core)");
             Console.WriteLine("   ✗ No service lifetimes (moved to DI package)");

--- a/src/Examples/SimplifiedCoreExample/Program.cs
+++ b/src/Examples/SimplifiedCoreExample/Program.cs
@@ -39,13 +39,13 @@ public static class Program
         Console.WriteLine();
 
         // 1. Build rules using the function-based API
-        var manager = new ConfigManager(rule => [
+        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/app.json")),
-                
+
             rule.For<DatabaseConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/database.json")),
-                
+
             rule.For<FeatureConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/features.json"))
-        ]).Initialize();
+        ]));
         
         Console.WriteLine("📋 Configuration Manager initialized");
         Console.WriteLine();
@@ -83,13 +83,13 @@ public static class Program
             // 4. Demonstrate rule layering by creating a scenario with overrides
             Console.WriteLine("🔄 Demonstrating rule layering (later rules override earlier ones):");
             
-            var layeredManager = new ConfigManager(rule => [
+            var layeredManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
                 // Base configuration
                 rule.For<AppConfig>().FromFile(_ => FileSourceRuleOptions.FromFilePath("config/app.json")),
-                    
+
                 // Override via static JSON (simulating environment-specific override)
                 rule.For<AppConfig>().FromStaticJson("""{"Environment": "Production", "LogLevel": "Warning"}""")
-            ]).Initialize();
+            ]));
             
             var overriddenApp = layeredManager.GetConfig<AppConfig>();
             
@@ -102,7 +102,7 @@ public static class Program
             Console.WriteLine("📖 Key API Patterns in Simplified Core:");
             Console.WriteLine("   ✓ rule.For<ConcreteType>().FromFile(...)");
             Console.WriteLine("   ✓ rule.Static(...).For<ConcreteType>()");
-            Console.WriteLine("   ✓ new ConfigManager(rule => [...]).Initialize()");
+            Console.WriteLine("   ✓ ConfigManager.Create(c => c.WithConfiguration(rule => [...]))");
             Console.WriteLine("   ✓ manager.GetConfig<ConcreteType>()");
             Console.WriteLine("   ✗ No .As<Interface>() (removed from core)");
             Console.WriteLine("   ✗ No service lifetimes (moved to DI package)");

--- a/src/Examples/SimplifiedCoreExample/README.md
+++ b/src/Examples/SimplifiedCoreExample/README.md
@@ -23,13 +23,13 @@ Rule.From.File("app.json").For<AppConfig>()
 ### ✅ Direct Manager Usage
 ```csharp
 // Manual configuration manager (no DI)
-var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
+var manager = ConfigManager.Create(c => c.UseConfiguration(rules));
 var config = manager.GetConfig<AppConfig>();
 ```
 
 ### ❌ Removed Features (moved to DI package)
 - `.As<TInterface>()` - interface exposure
-- `ServiceLifetime` parameters - DI lifetimes  
+- `ServiceLifetime` parameters - DI lifetimes
 - `AddCocoarConfiguration()` - DI integration
 - Service keys - keyed DI registrations
 
@@ -45,7 +45,7 @@ dotnet run
 ```
 config/
 ├── app.json        # Application metadata
-├── database.json   # Database connection settings  
+├── database.json   # Database connection settings
 └── features.json   # Feature toggles
 ```
 

--- a/src/Examples/SimplifiedCoreExample/README.md
+++ b/src/Examples/SimplifiedCoreExample/README.md
@@ -23,7 +23,7 @@ Rule.From.File("app.json").For<AppConfig>()
 ### ✅ Direct Manager Usage
 ```csharp
 // Manual configuration manager (no DI)
-var manager = new ConfigManager(rules).Initialize();
+var manager = ConfigManager.Create(c => c.WithConfiguration(rules));
 var config = manager.GetConfig<AppConfig>();
 ```
 

--- a/src/Examples/StaticProviderExample/Program.cs
+++ b/src/Examples/StaticProviderExample/Program.cs
@@ -28,7 +28,7 @@ public static class Program
     {
         Console.WriteLine("=== StaticJsonProvider Demo: JSON Strings + Factory Functions ===\n");
 
-        var manager = new ConfigManager(rule => [
+        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             // 1. JSON string approach - great for configuration templates, testing, defaults
             rule.For<CoreDefaults>().FromStaticJson("""
                                                     {
@@ -38,7 +38,7 @@ public static class Program
                                                     }
                                                     """),
 
-            // 2. Direct JSON string for database configuration  
+            // 2. Direct JSON string for database configuration
             rule.For<DatabaseSettings>().FromStaticJson("""
                                                         {
                                                             "ConnectionString": "Server=localhost;Database=MyApp;Integrated Security=true",
@@ -50,7 +50,7 @@ public static class Program
             // 3. Factory approach - dynamic composition using previously resolved configs
             rule.For<Wrapper>().FromStatic(cm => {
                 var coreConfig = cm.GetRequiredConfig<CoreDefaults>();
-                return new Wrapper { 
+                return new Wrapper {
                     Inner = new CoreDefaults {
                         Feature = $"Enhanced_{coreConfig.Feature}",
                         Enabled = coreConfig.Enabled,
@@ -58,7 +58,7 @@ public static class Program
                     }
                 };
             })
-        ]).Initialize();
+        ]));
 
         // Retrieve and display configurations
         var coreDefaults = manager.GetRequiredConfig<CoreDefaults>();

--- a/src/Examples/StaticProviderExample/Program.cs
+++ b/src/Examples/StaticProviderExample/Program.cs
@@ -28,7 +28,7 @@ public static class Program
     {
         Console.WriteLine("=== StaticJsonProvider Demo: JSON Strings + Factory Functions ===\n");
 
-        var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             // 1. JSON string approach - great for configuration templates, testing, defaults
             rule.For<CoreDefaults>().FromStaticJson("""
                                                     {
@@ -49,7 +49,7 @@ public static class Program
 
             // 3. Factory approach - dynamic composition using previously resolved configs
             rule.For<Wrapper>().FromStatic(cm => {
-                var coreConfig = cm.GetRequiredConfig<CoreDefaults>();
+                var coreConfig = cm.GetConfig<CoreDefaults>()!;
                 return new Wrapper {
                     Inner = new CoreDefaults {
                         Feature = $"Enhanced_{coreConfig.Feature}",
@@ -61,9 +61,9 @@ public static class Program
         ]));
 
         // Retrieve and display configurations
-        var coreDefaults = manager.GetRequiredConfig<CoreDefaults>();
-        var dbSettings = manager.GetRequiredConfig<DatabaseSettings>();  
-        var wrapper = manager.GetRequiredConfig<Wrapper>();
+        var coreDefaults = manager.GetConfig<CoreDefaults>()!;
+        var dbSettings = manager.GetConfig<DatabaseSettings>()!;
+        var wrapper = manager.GetConfig<Wrapper>()!;
 
         Console.WriteLine("📋 Core Configuration (from JSON string):");
         Console.WriteLine($"   Feature: {coreDefaults.Feature}");

--- a/src/Examples/TestingOverridesExample/Program.cs
+++ b/src/Examples/TestingOverridesExample/Program.cs
@@ -22,10 +22,10 @@ public partial class Program
         var builder = WebApplication.CreateBuilder(args);
 
         // Regular configuration - these rules would normally run
-        builder.AddCocoarConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<DbConfig>().FromFile("config.json").Select("Database"),
             rule.For<ApiSettings>().FromFile("config.json").Select("Api")
-        ]);
+        ]));
 
         var app = builder.Build();
 

--- a/src/Examples/TestingOverridesExample/Program.cs
+++ b/src/Examples/TestingOverridesExample/Program.cs
@@ -22,7 +22,7 @@ public partial class Program
         var builder = WebApplication.CreateBuilder(args);
 
         // Regular configuration - these rules would normally run
-        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<DbConfig>().FromFile("config.json").Select("Database"),
             rule.For<ApiSettings>().FromFile("config.json").Select("Api")
         ]));

--- a/src/Examples/TestingOverridesExample/README.md
+++ b/src/Examples/TestingOverridesExample/README.md
@@ -151,11 +151,11 @@ public void DirectConfigManagerTest()
     ]);
 
     // Works with direct instantiation
-    var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+    var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
         rule.For<DbConfig>().FromFile("config.json") // SKIPPED in test
     ]));
 
-    var config = configManager.GetRequiredConfig<DbConfig>();
+    var config = configManager.GetConfig<DbConfig>()!;
     // config comes from test rules, not file
 }
 ```

--- a/src/Examples/TestingOverridesExample/README.md
+++ b/src/Examples/TestingOverridesExample/README.md
@@ -24,7 +24,7 @@ But with Cocoar.Configuration, you want the same capability using the rule-based
 Set test configuration **before** creating `ConfigManager` (or `WebApplicationFactory`) using `AsyncLocal` context.
 
 **Works universally:**
-- ✅ Direct `new ConfigManager(...)` instantiation
+- ✅ Direct `ConfigManager.Create(...)` instantiation
 - ✅ `services.AddCocoarConfiguration(...)` in DI
 - ✅ `builder.AddCocoarConfiguration(...)` in ASP.NET Core
 - ✅ `WebApplicationFactory<Program>` in integration tests
@@ -84,7 +84,7 @@ public async Task TestWithSetupOverride()
 {
     // Override setup options only, keep original rules
     CocoarTestConfiguration.WithSetup(setup => [
-        setup.Secrets().AllowPlaintext()
+        setup.ConcreteType<DbConfig>()
     ]);
 
     await using var factory = new WebApplicationFactory<Program>();
@@ -111,7 +111,7 @@ public async Task TestWithRulesAndSetup()
             })
         ],
         setup => [
-            setup.Secrets().AllowPlaintext()
+            setup.ConcreteType<DbConfig>()
         ]);
 
     await using var factory = new WebApplicationFactory<Program>();
@@ -151,10 +151,9 @@ public void DirectConfigManagerTest()
     ]);
 
     // Works with direct instantiation
-    var configManager = new ConfigManager(rule => [
+    var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
         rule.For<DbConfig>().FromFile("config.json") // SKIPPED in test
-    ]);
-    configManager.Initialize();
+    ]));
 
     var config = configManager.GetRequiredConfig<DbConfig>();
     // config comes from test rules, not file
@@ -193,7 +192,7 @@ public class IntegrationTestFixture
                 rule.For<ApiSettings>().FromStatic(_ => new ApiSettings { BaseUrl = "https://test.api" })
             ],
             setup => [
-                setup.Secrets().AllowPlaintext()  // Enable plaintext secrets for all tests
+                setup.ConcreteType<DbConfig>()  // Enable plaintext secrets for all tests
             ]);
 }
 

--- a/src/Examples/TestingOverridesExample/README.md
+++ b/src/Examples/TestingOverridesExample/README.md
@@ -25,6 +25,7 @@ Set test configuration **before** creating `ConfigManager` (or `WebApplicationFa
 
 **Works universally:**
 - ✅ Direct `ConfigManager.Create(...)` instantiation
+- ✅ `ConfigManager.CreateAsync(...)` async factory
 - ✅ `services.AddCocoarConfiguration(...)` in DI
 - ✅ `builder.AddCocoarConfiguration(...)` in ASP.NET Core
 - ✅ `WebApplicationFactory<Program>` in integration tests
@@ -36,7 +37,7 @@ Set test configuration **before** creating `ConfigManager` (or `WebApplicationFa
 public async Task TestWithReplacedConfig()
 {
     // Set test configuration BEFORE creating ConfigManager
-    CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => new DbConfig {
             ConnectionString = testDb
         })
@@ -60,7 +61,7 @@ public async Task TestWithReplacedConfig()
 public async Task TestWithPartialOverride()
 {
     // Append test rules to end (last-write-wins)
-    CocoarTestConfiguration.AppendTestRules(rule => [
+    using var _ = CocoarTestConfiguration.AppendConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => new DbConfig {
             ConnectionString = testDb
         })
@@ -76,52 +77,61 @@ public async Task TestWithPartialOverride()
 - Other configs can come from original sources (files, environment)
 - Partial testing scenarios
 
-### Option 3: Setup-Only Override
+### Option 3: Replace Secrets Setup (Independent of Rule Mode)
 
 ```csharp
 [Fact]
-public async Task TestWithSetupOverride()
+public async Task TestWithPlaintextSecrets()
 {
-    // Override setup options only, keep original rules
-    CocoarTestConfiguration.WithSetup(setup => [
-        setup.ConcreteType<DbConfig>()
-    ]);
+    // Override secrets setup only — original rules still run
+    using var _ = CocoarTestConfiguration
+        .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
 
     await using var factory = new WebApplicationFactory<Program>();
-    // Original rules execute, but setup includes test overrides
+    // Secrets can now be provided as plaintext in test fixtures
 }
 ```
 
 **Use when:**
-- You need to enable test-specific capabilities (e.g., plaintext secrets)
+- You need to enable test-specific secrets behavior (e.g., plaintext)
 - Original rules should still execute
-- No rule changes needed
+- Requires `Cocoar.Configuration.Secrets` package
 
-### Option 4: Rules with Setup Override
+### Option 4: Mix and Match (Per-Concern Independence)
+
+Each concern is independent — combine freely:
 
 ```csharp
 [Fact]
-public async Task TestWithRulesAndSetup()
+public async Task TestWithRulesAndSecrets()
 {
-    // Override both rules AND setup
-    CocoarTestConfiguration.ReplaceAllRules(
-        rule => [
+    // Replace rules AND override secrets setup independently
+    using var _ = CocoarTestConfiguration
+        .ReplaceConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig {
                 ConnectionString = testDb
             })
-        ],
-        setup => [
-            setup.ConcreteType<DbConfig>()
-        ]);
+        ])
+        .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
 
     await using var factory = new WebApplicationFactory<Program>();
-    // Test rules execute with test setup options
 }
 ```
 
-**Use when:**
-- You need both rule overrides and setup overrides
-- Testing with plaintext secrets in test fixtures
+```csharp
+[Fact]
+public async Task TestAppendWithSecrets()
+{
+    // Append rules AND override secrets setup
+    using var _ = CocoarTestConfiguration
+        .AppendConfiguration(rule => [
+            rule.For<FeatureFlags>().FromStatic(_ => new FeatureFlags { NewFeature = true })
+        ])
+        .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+
+    await using var factory = new WebApplicationFactory<Program>();
+}
+```
 
 ## Running the Example
 
@@ -136,7 +146,8 @@ dotnet test
 2. **AsyncLocal Context** - Test configuration flows through async/await automatically
 3. **No Application Changes** - `Program.cs` doesn't need test-aware code
 4. **Per-Test Isolation** - Each test can set different configuration
-5. **Clean Up** - Call `CocoarTestConfiguration.Clear()` or implement `IDisposable`
+5. **Per-Concern Independence** - Rules mode and secrets setup override independently
+6. **Clean Up** - `using var _` disposes the scope; or call `CocoarTestConfiguration.Clear()`
 
 ## Direct ConfigManager Usage
 
@@ -146,7 +157,7 @@ Test overrides also work when creating ConfigManager directly (without DI):
 [Fact]
 public void DirectConfigManagerTest()
 {
-    CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => testConfig)
     ]);
 
@@ -160,20 +171,21 @@ public void DirectConfigManagerTest()
 }
 ```
 
-## Using Scope Pattern (Recommended)
-
-The methods now return a `TestConfigurationScope` that clears configuration when disposed:
+Also works with `ConfigManager.CreateAsync()`:
 
 ```csharp
 [Fact]
-public async Task TestWithScope()
+public async Task DirectConfigManagerAsyncTest()
 {
-    using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+    using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
         rule.For<DbConfig>().FromStatic(_ => testConfig)
     ]);
 
-    await using var factory = new WebApplicationFactory<Program>();
-    // Configuration automatically cleared when scope is disposed
+    var configManager = await ConfigManager.CreateAsync(c => c.UseConfiguration(rule => [
+        rule.For<DbConfig>().FromFile("config.json") // SKIPPED in test
+    ]));
+
+    var config = configManager.GetConfig<DbConfig>()!;
 }
 ```
 
@@ -190,9 +202,6 @@ public class IntegrationTestFixture
             rule => [
                 rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" }),
                 rule.For<ApiSettings>().FromStatic(_ => new ApiSettings { BaseUrl = "https://test.api" })
-            ],
-            setup => [
-                setup.ConcreteType<DbConfig>()  // Enable plaintext secrets for all tests
             ]);
 }
 
@@ -224,34 +233,30 @@ public class MyTests : IClassFixture<IntegrationTestFixture>, IDisposable
 
 **Why Apply()?** AsyncLocal flows within the same async context, but xUnit runs fixture setup and test methods in separate contexts. `Apply()` bridges this gap.
 
-## Test Base Class Pattern
+## Fixture-Based Pattern with Secrets
+
+Use `TestOverrideBuilder` directly for fixture-based patterns that need secrets:
 
 ```csharp
-public abstract class IntegrationTestBase : IDisposable
+public class IntegrationTestFixture
 {
-    protected void UseTestConfig(Func<RulesBuilder, ConfigRule[]> rules)
-    {
-        CocoarTestConfiguration.ReplaceAllRules(rules);
-    }
-
-    public void Dispose()
-    {
-        CocoarTestConfiguration.Clear();
-    }
+    public TestConfigurationContext TestContext { get; } =
+        new TestOverrideBuilder()
+            .ReplaceConfiguration(rule => [
+                rule.For<DbConfig>().FromStatic(_ => new DbConfig { Connection = "test-db" })
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext())
+            .Build();
 }
 
-public class MyTests : IntegrationTestBase
+public class MyTests : IClassFixture<IntegrationTestFixture>, IDisposable
 {
-    [Fact]
-    public async Task MyTest()
+    public MyTests(IntegrationTestFixture fixture)
     {
-        UseTestConfig(rule => [
-            rule.For<DbConfig>().FromStatic(_ => testConfig)
-        ]);
-
-        await using var factory = new WebApplicationFactory<Program>();
-        // Test runs with overridden config
+        CocoarTestConfiguration.Apply(fixture.TestContext);
     }
+
+    public void Dispose() => CocoarTestConfiguration.Clear();
 }
 ```
 
@@ -259,3 +264,4 @@ public class MyTests : IntegrationTestBase
 
 - [BasicUsage Example](../BasicUsage) - Simple configuration setup
 - [Cocoar.Configuration.Testing](../../Cocoar.Configuration/Testing) - Testing API reference
+- [Testing Overrides Quick Reference](../../../docs/testing-overrides-quickref.md) - Full patterns

--- a/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
@@ -20,11 +20,11 @@ public class DirectConfigManagerTests : IDisposable
         ]);
 
         // Act - Create ConfigManager directly (no DI, no AspNetCore)
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<DbConfig>().FromFile("config.json").Select("Database") // This will be SKIPPED
         ]));
 
-        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+        var dbConfig = configManager.GetConfig<DbConfig>()!;
 
         // Assert - Test rules were used, not config.json
         Assert.Equal("Server=test-direct;Database=DirectTest;", dbConfig.ConnectionString);
@@ -43,7 +43,7 @@ public class DirectConfigManagerTests : IDisposable
         ]);
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=base;",
@@ -51,7 +51,7 @@ public class DirectConfigManagerTests : IDisposable
             })
         ]));
 
-        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+        var dbConfig = configManager.GetConfig<DbConfig>()!;
 
         // Assert - Base rule + test override merged (last-write-wins)
         Assert.Equal(999, dbConfig.MaxConnections); // From test override
@@ -63,7 +63,7 @@ public class DirectConfigManagerTests : IDisposable
         // No CocoarTestConfiguration set
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=normal;",
@@ -71,7 +71,7 @@ public class DirectConfigManagerTests : IDisposable
             })
         ]));
 
-        var dbConfig = configManager.GetRequiredConfig<DbConfig>();
+        var dbConfig = configManager.GetConfig<DbConfig>()!;
 
         // Assert - Normal behavior
         Assert.Equal("Server=normal;", dbConfig.ConnectionString);

--- a/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
@@ -11,7 +11,7 @@ public class DirectConfigManagerTests : IDisposable
     public void DirectConfigManager_AppliesTestOverrides_ReplaceMode()
     {
         // Arrange - Set test configuration BEFORE creating ConfigManager
-        CocoarTestConfiguration.ReplaceAllRules(rule => [
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=test-direct;Database=DirectTest;",
@@ -35,7 +35,7 @@ public class DirectConfigManagerTests : IDisposable
     public void DirectConfigManager_AppliesTestOverrides_AppendMode()
     {
         // Arrange
-        CocoarTestConfiguration.AppendTestRules(rule => [
+        CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 MaxConnections = 999 // Override only MaxConnections

--- a/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/DirectConfigManagerTests.cs
@@ -20,10 +20,9 @@ public class DirectConfigManagerTests : IDisposable
         ]);
 
         // Act - Create ConfigManager directly (no DI, no AspNetCore)
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<DbConfig>().FromFile("config.json").Select("Database") // This will be SKIPPED
-        ]);
-        configManager.Initialize();
+        ]));
 
         var dbConfig = configManager.GetRequiredConfig<DbConfig>();
 
@@ -44,14 +43,13 @@ public class DirectConfigManagerTests : IDisposable
         ]);
 
         // Act
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=base;",
                 MaxConnections = 10
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var dbConfig = configManager.GetRequiredConfig<DbConfig>();
 
@@ -65,14 +63,13 @@ public class DirectConfigManagerTests : IDisposable
         // No CocoarTestConfiguration set
 
         // Act
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=normal;",
                 MaxConnections = 50
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var dbConfig = configManager.GetRequiredConfig<DbConfig>();
 

--- a/src/Examples/TestingOverridesExample/Tests/FixtureBasedTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/FixtureBasedTests.cs
@@ -12,8 +12,7 @@ namespace Examples.TestingOverridesExample.Tests;
 public class SharedIntegrationTestFixture
 {
     /// <summary>
-    /// Pre-built test configuration context.
-    /// Using the factory method for cleaner initialization.
+    /// Pre-built test configuration context built via <see cref="TestOverrideBuilder"/> (fixture pattern).
     /// </summary>
     public TestConfigurationContext TestContext { get; } =
         TestConfigurationContext.Replace(rule => [
@@ -88,12 +87,12 @@ public class FixtureBasedIntegrationTests : IClassFixture<SharedIntegrationTestF
         // The configuration should be active in test methods
         Assert.True(CocoarTestConfiguration.IsActive);
         Assert.NotNull(CocoarTestConfiguration.Current);
-        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.ConfigurationMode);
     }
 }
 
 /// <summary>
-/// Demonstrates using TestConfigurationScope for automatic cleanup.
+/// Demonstrates using TestOverrideBuilder (disposable scope) for automatic cleanup.
 /// </summary>
 public class ScopeBasedTests
 {
@@ -104,11 +103,10 @@ public class ScopeBasedTests
         Assert.False(CocoarTestConfiguration.IsActive);
 
         // Act - Create scope
-        using (var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        using (var scope = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig { ConnectionString = "test" })
         ]))
         {
-            Assert.True(scope.IsActive);
             Assert.True(CocoarTestConfiguration.IsActive);
         }
 
@@ -124,7 +122,7 @@ public class ScopeBasedTests
 
         try
         {
-            using var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+            using var scope = CocoarTestConfiguration.ReplaceConfiguration(rule => [
                 rule.For<DbConfig>().FromStatic(_ => new DbConfig { ConnectionString = "test" })
             ]);
 
@@ -141,16 +139,16 @@ public class ScopeBasedTests
     }
 
     [Fact]
-    public void AppendTestRules_ReturnsScope()
+    public void AppendConfiguration_ReturnsScope()
     {
         Assert.False(CocoarTestConfiguration.IsActive);
 
-        using (var scope = CocoarTestConfiguration.AppendTestRules(rule => [
+        using (var scope = CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig { ConnectionString = "test" })
         ]))
         {
-            Assert.True(scope.IsActive);
-            Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current!.Mode);
+            Assert.True(CocoarTestConfiguration.IsActive);
+            Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current!.ConfigurationMode);
         }
 
         Assert.False(CocoarTestConfiguration.IsActive);
@@ -158,7 +156,7 @@ public class ScopeBasedTests
 }
 
 /// <summary>
-/// Tests for TestConfigurationContext factory methods.
+/// Tests for TestConfigurationContext factory methods and TestOverrideBuilder.
 /// </summary>
 public class TestConfigurationContextFactoryTests
 {
@@ -171,7 +169,7 @@ public class TestConfigurationContextFactoryTests
         ]);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
     }
 
@@ -184,7 +182,7 @@ public class TestConfigurationContextFactoryTests
         ]);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Append, context.Mode);
+        Assert.Equal(TestConfigurationMode.Append, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
     }
 
@@ -213,13 +211,6 @@ public class TestConfigurationContextFactoryTests
     }
 
     [Fact]
-    public void Constructor_ThrowsOnNullRules()
-    {
-        Assert.Throws<ArgumentNullException>(() =>
-            new TestConfigurationContext(null!, TestConfigurationMode.Replace));
-    }
-
-    [Fact]
     public void Replace_ThrowsOnNullRules()
     {
         Assert.Throws<ArgumentNullException>(() =>
@@ -231,5 +222,13 @@ public class TestConfigurationContextFactoryTests
     {
         Assert.Throws<ArgumentNullException>(() =>
             TestConfigurationContext.Append(null!));
+    }
+
+    [Fact]
+    public void TestOverrideBuilder_ReplaceConfiguration_ThrowsOnNullRules()
+    {
+        // The public constructor is for the fixture pattern; null rules should throw
+        Assert.Throws<ArgumentNullException>(() =>
+            new TestOverrideBuilder().ReplaceConfiguration(null!));
     }
 }

--- a/src/Examples/TestingOverridesExample/Tests/IntegrationTests.cs
+++ b/src/Examples/TestingOverridesExample/Tests/IntegrationTests.cs
@@ -8,10 +8,10 @@ namespace Examples.TestingOverridesExample.Tests;
 public class IntegrationTestsWithReplace : IDisposable
 {
     [Fact]
-    public async Task ReplaceAllRules_OverridesAllConfiguration()
+    public async Task ReplaceConfiguration_OverridesAllConfiguration()
     {
         // Arrange - Set test configuration BEFORE creating WebApplicationFactory
-        CocoarTestConfiguration.ReplaceAllRules(rule => [
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=test-db;Database=TestDb;",
@@ -51,10 +51,10 @@ public class IntegrationTestsWithReplace : IDisposable
 public class IntegrationTestsWithAppend : IDisposable
 {
     [Fact]
-    public async Task AppendTestRules_OverridesSpecificValues()
+    public async Task AppendConfiguration_OverridesSpecificValues()
     {
         // Arrange - Append test rules (config.json runs first, then test rules override)
-        CocoarTestConfiguration.AppendTestRules(rule => [
+        CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<DbConfig>().FromStatic(_ => new DbConfig
             {
                 ConnectionString = "Server=test-db;Database=TestDb;",
@@ -94,7 +94,7 @@ public class IntegrationTestsRealWorldScenario
         // Scenario: App normally polls HTTP endpoint that's unavailable in tests
         // Replace mode prevents HTTP provider from running at all
 
-        CocoarTestConfiguration.ReplaceAllRules(rule => [
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<ApiSettings>().FromStatic(_ => new ApiSettings
             {
                 BaseUrl = "https://test.local",

--- a/src/Examples/TupleReactiveExample/Program.cs
+++ b/src/Examples/TupleReactiveExample/Program.cs
@@ -26,7 +26,7 @@ var appSubject = new System.Reactive.Subjects.BehaviorSubject<AppSettings>(new A
 var flagsSubject = new System.Reactive.Subjects.BehaviorSubject<FeatureFlags>(new FeatureFlags { Flags = defaultFlags });
 
 // Define configuration rules using observable providers for dynamic types and static JSON for logging
-builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
     rule.For<AppSettings>().FromObservable(appSubject),
     rule.For<FeatureFlags>().FromObservable(flagsSubject),
     rule.For<LoggingConfig>().FromStaticJson("{ \"Level\": \"Info\" }")

--- a/src/Examples/TupleReactiveExample/Program.cs
+++ b/src/Examples/TupleReactiveExample/Program.cs
@@ -26,13 +26,13 @@ var appSubject = new System.Reactive.Subjects.BehaviorSubject<AppSettings>(new A
 var flagsSubject = new System.Reactive.Subjects.BehaviorSubject<FeatureFlags>(new FeatureFlags { Flags = defaultFlags });
 
 // Define configuration rules using observable providers for dynamic types and static JSON for logging
-builder.Services.AddCocoarConfiguration(rule => [
+builder.Services.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
     rule.For<AppSettings>().FromObservable(appSubject),
     rule.For<FeatureFlags>().FromObservable(flagsSubject),
     rule.For<LoggingConfig>().FromStaticJson("{ \"Level\": \"Info\" }")
 ], setup => [
     setup.ConcreteType<AppSettings>().ExposeAs<IAppSettings>()
-]);
+]));
 
 var app = builder.Build();
 

--- a/src/ShowCase/Program.cs
+++ b/src/ShowCase/Program.cs
@@ -14,7 +14,7 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
 
         var configManager = ConfigManager.Create(c => c
-            .WithConfiguration(rule => [
+            .UseConfiguration(rule => [
                 rule.For<StartUpConfiguration>().FromFile("config.json").Select("Startup"),
                 rule.For<StartUpConfiguration>().FromEnvironment(),
             ])

--- a/src/ShowCase/Program.cs
+++ b/src/ShowCase/Program.cs
@@ -18,7 +18,7 @@ public class Program
                 rule.For<StartUpConfiguration>().FromFile("config.json").Select("Startup"),
                 rule.For<StartUpConfiguration>().FromEnvironment(),
             ])
-            .WithSecretsSetup(secrets => secrets
+            .UseSecretsSetup(secrets => secrets
                 .UseCertificatesFromFolder("certs")));
 
         builder.AddCocoarConfiguration(configManager);

--- a/src/ShowCase/Program.cs
+++ b/src/ShowCase/Program.cs
@@ -13,17 +13,15 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.AddCocoarConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c
+            .WithConfiguration(rule => [
                 rule.For<StartUpConfiguration>().FromFile("config.json").Select("Startup"),
                 rule.For<StartUpConfiguration>().FromEnvironment(),
-            ], setup => [
-                // Password-less certificates - protected by file permissions only
-                setup.Secrets().UseCertificatesFromFolder("certs")
-                
-                // Or with password (if needed):
-                // setup.Secrets().UseCertificatesFromFolder("certs", (c) => [c.Config.GetRequiredConfig<StartUpConfiguration>().CertPassword])
-            ]
-        );
+            ])
+            .WithSecretsSetup(secrets => secrets
+                .UseCertificatesFromFolder("certs")));
+
+        builder.AddCocoarConfiguration(configManager);
 
         var app = builder.Build();
 

--- a/src/tests/Cocoar.Configuration.Analyzers.Tests/RuleOrderingAnalyzerTests.cs
+++ b/src/tests/Cocoar.Configuration.Analyzers.Tests/RuleOrderingAnalyzerTests.cs
@@ -32,12 +32,12 @@ class Program
     void Configure()
     {
         var builder = new ServiceCollection();
-        builder.AddCocoarConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<AppSettings>().FromFile(""app.json""),
             rule.For<DerivedConfig>()
                 .FromFile(""derived.json"")
                 .When(accessor => accessor.GetRequiredConfig<AppSettings>().IsEnabled)
-        ]);
+        ]));
     }
 }
 
@@ -70,12 +70,12 @@ class Program
     void Configure()
     {
         var builder = new ServiceCollection();
-        builder.AddCocoarConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
             rule.For<DerivedConfig>()
                 .FromFile(""derived.json"")
                 .When(accessor => accessor.GetRequiredConfig<AppSettings>().IsEnabled),
             rule.For<AppSettings>().FromFile(""app.json"")
-        ]);
+        ]));
     }
 }
 

--- a/src/tests/Cocoar.Configuration.Analyzers.Tests/RuleOrderingAnalyzerTests.cs
+++ b/src/tests/Cocoar.Configuration.Analyzers.Tests/RuleOrderingAnalyzerTests.cs
@@ -32,7 +32,7 @@ class Program
     void Configure()
     {
         var builder = new ServiceCollection();
-        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<AppSettings>().FromFile(""app.json""),
             rule.For<DerivedConfig>()
                 .FromFile(""derived.json"")
@@ -70,7 +70,7 @@ class Program
     void Configure()
     {
         var builder = new ServiceCollection();
-        builder.AddCocoarConfiguration(c => c.WithConfiguration(rule => [
+        builder.AddCocoarConfiguration(c => c.UseConfiguration(rule => [
             rule.For<DerivedConfig>()
                 .FromFile(""derived.json"")
                 .When(accessor => accessor.GetRequiredConfig<AppSettings>().IsEnabled),

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerBuilderTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerBuilderTests.cs
@@ -1,0 +1,163 @@
+using Cocoar.Configuration.Core.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cocoar.Configuration.Core.Tests.Core;
+
+public class ConfigManagerBuilderTests
+{
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithRulesOnly_Works()
+    {
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 42}""")
+            ]));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+        Assert.Equal(42, config!.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithRulesAndSetup_Works()
+    {
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<TestConfig>().FromStaticJson("""{"Value": 7}""")],
+                setup => [setup.ConcreteType<TestConfig>()]));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+        Assert.Equal(7, config!.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithPrebuiltRules_Works()
+    {
+        var rule = TestRules.StaticJson<TestConfig>("""{"Enabled": true}""");
+
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(new[] { rule }));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+        Assert.True(config!.Enabled);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithEmptyBuilder_Works()
+    {
+        using var manager = ConfigManager.Create(c => { });
+
+        // No rules = no configs, but manager should be valid
+        var result = manager.TryGetConfig<TestConfig>(out _);
+        Assert.False(result);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithLogger_PassesLogger()
+    {
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
+            ])
+            .UseLogger(NullLogger.Instance));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_WithDebounce_PassesDebounce()
+    {
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
+            ])
+            .UseDebounce(50));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void AfterBuild_ExecutesAfterInitialization()
+    {
+        var afterBuildCalled = false;
+        ConfigManager? capturedManager = null;
+
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 99}""")
+            ])
+            .AfterBuild(m =>
+            {
+                afterBuildCalled = true;
+                capturedManager = m;
+                // Manager should be initialized — we can access config
+                var config = m.GetConfig<TestConfig>();
+                Assert.NotNull(config);
+                Assert.Equal(99, config!.Value);
+            }));
+
+        Assert.True(afterBuildCalled);
+        Assert.Same(manager, capturedManager);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void AfterBuild_MultipleActions_ExecuteInOrder()
+    {
+        var order = new List<int>();
+
+        using var manager = ConfigManager.Create(c => c
+            .WithConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
+            ])
+            .AfterBuild(_ => order.Add(1))
+            .AfterBuild(_ => order.Add(2))
+            .AfterBuild(_ => order.Add(3)));
+
+        Assert.Equal([1, 2, 3], order);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void Create_NullConfigure_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ConfigManager.Create(null!));
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public void AfterBuild_NullAction_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            ConfigManager.Create(c => c.AfterBuild(null!));
+        });
+    }
+
+    public sealed class TestConfig
+    {
+        public bool Enabled { get; set; }
+        public int Value { get; set; }
+    }
+}

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerBuilderTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerBuilderTests.cs
@@ -11,7 +11,7 @@ public class ConfigManagerBuilderTests
     public void Create_WithRulesOnly_Works()
     {
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rules => [
+            .UseConfiguration(rules => [
                 rules.For<TestConfig>().FromStaticJson("""{"Value": 42}""")
             ]));
 
@@ -26,7 +26,7 @@ public class ConfigManagerBuilderTests
     public void Create_WithRulesAndSetup_Works()
     {
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<TestConfig>().FromStaticJson("""{"Value": 7}""")],
                 setup => [setup.ConcreteType<TestConfig>()]));
 
@@ -43,7 +43,7 @@ public class ConfigManagerBuilderTests
         var rule = TestRules.StaticJson<TestConfig>("""{"Enabled": true}""");
 
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(new[] { rule }));
+            .UseConfiguration(new[] { rule }));
 
         var config = manager.GetConfig<TestConfig>();
         Assert.NotNull(config);
@@ -68,7 +68,7 @@ public class ConfigManagerBuilderTests
     public void Create_WithLogger_PassesLogger()
     {
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rules => [
+            .UseConfiguration(rules => [
                 rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
             ])
             .UseLogger(NullLogger.Instance));
@@ -83,7 +83,7 @@ public class ConfigManagerBuilderTests
     public void Create_WithDebounce_PassesDebounce()
     {
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rules => [
+            .UseConfiguration(rules => [
                 rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
             ])
             .UseDebounce(50));
@@ -101,7 +101,7 @@ public class ConfigManagerBuilderTests
         ConfigManager? capturedManager = null;
 
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rules => [
+            .UseConfiguration(rules => [
                 rules.For<TestConfig>().FromStaticJson("""{"Value": 99}""")
             ])
             .AfterBuild(m =>
@@ -126,7 +126,7 @@ public class ConfigManagerBuilderTests
         var order = new List<int>();
 
         using var manager = ConfigManager.Create(c => c
-            .WithConfiguration(rules => [
+            .UseConfiguration(rules => [
                 rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
             ])
             .AfterBuild(_ => order.Add(1))
@@ -153,6 +153,64 @@ public class ConfigManagerBuilderTests
         {
             ConfigManager.Create(c => c.AfterBuild(null!));
         });
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public async Task CreateAsync_ReturnsInitializedManager()
+    {
+        await using var manager = await ConfigManager.CreateAsync(c => c
+            .UseConfiguration(rules => [
+                rules.For<TestConfig>().FromStaticJson("""{"Value": 42}""")
+            ]));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+        Assert.Equal(42, config!.Value);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public async Task CreateAsync_WithCancellation_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ConfigManager.CreateAsync(
+                c => c.UseConfiguration(rules => [
+                    rules.For<TestConfig>().FromStaticJson("""{"Value": 1}""")
+                ]),
+                cts.Token));
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public async Task CreateAsync_WithStaticJson_ProducesCorrectConfig()
+    {
+        await using var manager = await ConfigManager.CreateAsync(c => c
+            .UseConfiguration(
+                rules => [
+                    rules.For<TestConfig>().FromStaticJson("""{"Value": 7, "Enabled": true}""")
+                ],
+                setup => [setup.ConcreteType<TestConfig>()]));
+
+        var config = manager.GetConfig<TestConfig>();
+        Assert.NotNull(config);
+        Assert.Equal(7, config!.Value);
+        Assert.True(config.Enabled);
+    }
+
+    [Fact]
+    [Trait("Type", "Unit")]
+    [Trait("Component", "ConfigManagerBuilder")]
+    public async Task CreateAsync_NullConfigure_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            ConfigManager.CreateAsync(null!));
     }
 
     public sealed class TestConfig

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerOrchestrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerOrchestrationTests.cs
@@ -25,7 +25,7 @@ public class ConfigManagerOrchestrationTests
         
         var rule = TestRules.ObservableString<TestConfig>(behaviorSubject, required: true);
 
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { rule }));
         
         var initialConfig = manager.GetConfig<TestConfig>();
         Assert.NotNull(initialConfig);
@@ -53,7 +53,7 @@ public class ConfigManagerOrchestrationTests
     {
         var rule = TestRules.StaticJson<TestConfig>("""{"Enabled": true, "Value": 42}""", required: true);
 
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { rule }));
         var config = manager.GetConfig<TestConfig>();
 
         Assert.NotNull(config);
@@ -74,7 +74,7 @@ public class ConfigManagerOrchestrationTests
             """{"additional": "config2", "shared": "from-second"}""",
             required: true);
 
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule1, rule2 }));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { rule1, rule2 }));
         var config = manager.GetConfig<Dictionary<string, object>>();
 
         Assert.NotNull(config);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerOrchestrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/ConfigManagerOrchestrationTests.cs
@@ -25,8 +25,7 @@ public class ConfigManagerOrchestrationTests
         
         var rule = TestRules.ObservableString<TestConfig>(behaviorSubject, required: true);
 
-        using var manager = new ConfigManager(new[] { rule });
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
         
         var initialConfig = manager.GetConfig<TestConfig>();
         Assert.NotNull(initialConfig);
@@ -54,8 +53,7 @@ public class ConfigManagerOrchestrationTests
     {
         var rule = TestRules.StaticJson<TestConfig>("""{"Enabled": true, "Value": 42}""", required: true);
 
-        using var manager = new ConfigManager(new[] { rule });
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
         var config = manager.GetConfig<TestConfig>();
 
         Assert.NotNull(config);
@@ -76,8 +74,7 @@ public class ConfigManagerOrchestrationTests
             """{"additional": "config2", "shared": "from-second"}""",
             required: true);
 
-        using var manager = new ConfigManager(new[] { rule1, rule2 });
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule1, rule2 }));
         var config = manager.GetConfig<Dictionary<string, object>>();
 
         Assert.NotNull(config);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
@@ -6,7 +6,7 @@ using Cocoar.Configuration.Secrets.Protectors.Hybrid;
 namespace Cocoar.Configuration.Core.Tests.Core;
 
 /// <summary>
-/// Tests for the fluent Secrets() extension method on SetupBuilder.
+/// Tests for the WithSecretsSetup() extension method on ConfigManagerBuilder.
 /// </summary>
 public class SecretsFluentApiTests
 {
@@ -18,7 +18,7 @@ public class SecretsFluentApiTests
         // Arrange & Act
         var kid = "test-key";
         var pfxPath = Path.Combine(Path.GetTempPath(), $"{kid}.pfx");
-        
+
         try
         {
             // Generate certificate explicitly
@@ -28,20 +28,13 @@ public class SecretsFluentApiTests
                 "CN=Test Certificate",
                 validYears: 1,
                 keySize: 2048);
-            
-            var manager = new ConfigManager(
-                rules: Array.Empty<ConfigRule>(),
-                setup: builder => [
-                    builder.Secrets()
-                        .UseCertificateFromFile(pfxPath)
-                        .WithKeyId(kid)
-                        .Build()
-                ]
-            );
-            
-            // Configuration is deferred until Initialize()
-            manager.Initialize();
-            
+
+            var manager = ConfigManager.Create(c => c
+                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .WithSecretsSetup(secrets => secrets
+                    .UseCertificateFromFile(pfxPath)
+                    .WithKeyId(kid)));
+
             // Assert
             Assert.NotNull(manager);
         }
@@ -59,9 +52,9 @@ public class SecretsFluentApiTests
     {
         // Arrange
         var kid = $"test-{Guid.NewGuid():N}";
-        
+
         var pfxPath = Path.Combine(Path.GetTempPath(), $"{kid}.pfx");
-        
+
         try
         {
             // Generate certificate explicitly
@@ -71,30 +64,24 @@ public class SecretsFluentApiTests
                 "CN=Test Certificate",
                 validYears: 1,
                 keySize: 2048);
-            
-            var manager = new ConfigManager(
-                rules: Array.Empty<ConfigRule>(),
-                setup: builder => [
-                    builder.Secrets()
-                        .UseCertificateFromFile(pfxPath)
-                        .WithKeyId(kid)
-                        .Build()
-                ]
-            );
-            
-            manager.Initialize();
-            
+
+            var manager = ConfigManager.Create(c => c
+                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .WithSecretsSetup(secrets => secrets
+                    .UseCertificateFromFile(pfxPath)
+                    .WithKeyId(kid)));
+
             // Assert
             Assert.NotNull(manager);
-            
+
             // Verify the capability-based implementation was used by checking the composition
             // Use Owner.GetComposition() - no generic parameter needed with ConfigManagerCapabilityScope!
             var composition = manager.CapabilityScope.Owner.GetComposition();
             Assert.NotNull(composition);
-            
+
             // Should have SecretsSetupDeferredConfiguration
             Assert.True(composition!.Has<SecretsSetupDeferredConfiguration>());
-            
+
             // Should have CertificateProtectorConfig (unified)
             Assert.True(composition.Has<CertificateProtectorConfig>());
         }
@@ -115,7 +102,7 @@ public class SecretsFluentApiTests
         var kid2 = $"manager2-{Guid.NewGuid():N}";
         var pfxPath1 = Path.Combine(Path.GetTempPath(), $"{kid1}.pfx");
         var pfxPath2 = Path.Combine(Path.GetTempPath(), $"{kid2}.pfx");
-        
+
         try
         {
             // Generate certificates explicitly
@@ -125,39 +112,31 @@ public class SecretsFluentApiTests
                 "CN=Test Certificate 1",
                 validYears: 1,
                 keySize: 2048);
-            
+
             X509CertificateGenerator.GenerateAndSave(
                 pfxPath2,
                 null,  // Password-less certificate
                 "CN=Test Certificate 2",
                 validYears: 1,
                 keySize: 2048);
-            
+
             // Act - create two different ConfigManagers with different secrets configurations
-            var manager1 = new ConfigManager(
-                rules: Array.Empty<ConfigRule>(),
-                setup: builder => [
-                    builder.Secrets()
-                        .UseCertificateFromFile(pfxPath1)
-                        .WithKeyId(kid1)
-                        .Build()
-                ]
-            );
-            
-            var manager2 = new ConfigManager(
-                rules: Array.Empty<ConfigRule>(),
-                setup: builder => [
-                    builder.Secrets()
-                        .UseCertificateFromFile(pfxPath2)
-                        .WithKeyId(kid2)
-                        .Build()
-                ]
-            );
-            
+            var manager1 = ConfigManager.Create(c => c
+                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .WithSecretsSetup(secrets => secrets
+                    .UseCertificateFromFile(pfxPath1)
+                    .WithKeyId(kid1)));
+
+            var manager2 = ConfigManager.Create(c => c
+                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .WithSecretsSetup(secrets => secrets
+                    .UseCertificateFromFile(pfxPath2)
+                    .WithKeyId(kid2)));
+
             // Assert - both should be created successfully without interfering with each other
             Assert.NotNull(manager1);
             Assert.NotNull(manager2);
-            
+
             // Note: We'd need to expose the runtime or capabilities API to verify complete isolation,
             // but this test at least proves that two different managers can be created with
             // different secrets configurations without errors
@@ -171,6 +150,3 @@ public class SecretsFluentApiTests
         }
     }
 }
-
-
-

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
@@ -6,7 +6,7 @@ using Cocoar.Configuration.Secrets.Protectors.Hybrid;
 namespace Cocoar.Configuration.Core.Tests.Core;
 
 /// <summary>
-/// Tests for the WithSecretsSetup() extension method on ConfigManagerBuilder.
+/// Tests for the UseSecretsSetup() extension method on ConfigManagerBuilder.
 /// </summary>
 public class SecretsFluentApiTests
 {
@@ -31,7 +31,7 @@ public class SecretsFluentApiTests
 
             var manager = ConfigManager.Create(c => c
                 .UseConfiguration(rules: Array.Empty<ConfigRule>())
-                .WithSecretsSetup(secrets => secrets
+                .UseSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath)
                     .WithKeyId(kid)));
 
@@ -67,7 +67,7 @@ public class SecretsFluentApiTests
 
             var manager = ConfigManager.Create(c => c
                 .UseConfiguration(rules: Array.Empty<ConfigRule>())
-                .WithSecretsSetup(secrets => secrets
+                .UseSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath)
                     .WithKeyId(kid)));
 
@@ -123,13 +123,13 @@ public class SecretsFluentApiTests
             // Act - create two different ConfigManagers with different secrets configurations
             var manager1 = ConfigManager.Create(c => c
                 .UseConfiguration(rules: Array.Empty<ConfigRule>())
-                .WithSecretsSetup(secrets => secrets
+                .UseSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath1)
                     .WithKeyId(kid1)));
 
             var manager2 = ConfigManager.Create(c => c
                 .UseConfiguration(rules: Array.Empty<ConfigRule>())
-                .WithSecretsSetup(secrets => secrets
+                .UseSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath2)
                     .WithKeyId(kid2)));
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Core/SecretsFluentApiTests.cs
@@ -30,7 +30,7 @@ public class SecretsFluentApiTests
                 keySize: 2048);
 
             var manager = ConfigManager.Create(c => c
-                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .UseConfiguration(rules: Array.Empty<ConfigRule>())
                 .WithSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath)
                     .WithKeyId(kid)));
@@ -66,7 +66,7 @@ public class SecretsFluentApiTests
                 keySize: 2048);
 
             var manager = ConfigManager.Create(c => c
-                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .UseConfiguration(rules: Array.Empty<ConfigRule>())
                 .WithSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath)
                     .WithKeyId(kid)));
@@ -122,13 +122,13 @@ public class SecretsFluentApiTests
 
             // Act - create two different ConfigManagers with different secrets configurations
             var manager1 = ConfigManager.Create(c => c
-                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .UseConfiguration(rules: Array.Empty<ConfigRule>())
                 .WithSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath1)
                     .WithKeyId(kid1)));
 
             var manager2 = ConfigManager.Create(c => c
-                .WithConfiguration(rules: Array.Empty<ConfigRule>())
+                .UseConfiguration(rules: Array.Empty<ConfigRule>())
                 .WithSecretsSetup(secrets => secrets
                     .UseCertificateFromFile(pfxPath2)
                     .WithKeyId(kid2)));

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthCancellationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthCancellationTests.cs
@@ -27,8 +27,7 @@ public class ConfigManagerHealthCancellationTests
             options: new(Required: true)
         );
 
-        using var configManager = new ConfigManager(new[] {rule}, logger: NullLogger.Instance);
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}).UseLogger(NullLogger.Instance));
 
         var healthService = configManager.GetHealthService();
         var healthEmissions = new List<ConfigHealthSnapshot>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthCancellationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthCancellationTests.cs
@@ -27,7 +27,7 @@ public class ConfigManagerHealthCancellationTests
             options: new(Required: true)
         );
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}).UseLogger(NullLogger.Instance));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {rule}).UseLogger(NullLogger.Instance));
 
         var healthService = configManager.GetHealthService();
         var healthEmissions = new List<ConfigHealthSnapshot>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthIntegrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthIntegrationTests.cs
@@ -18,7 +18,7 @@ public class ConfigManagerHealthIntegrationTests
     [Fact]
     [Trait("Type", "Integration")]
     [Trait("Area", "Health")]
-    public void ConfigManager_GetHealth_ReturnsInitialHealthInfo()
+    public void ConfigManager_AfterCreate_HasHealthyStatus()
     {
         using var document = JsonDocument.Parse("{}");
         var providerOptions = new StaticJsonProviderOptions(document.RootElement);
@@ -26,13 +26,12 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = new ConfigManager(new[] {rule});
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.NotNull(health);
-        Assert.Equal(HealthStatus.Unknown, health.OverallStatus);
         Assert.Single(health.Rules);
-        Assert.Equal(RuleResultStatus.Unknown, health.Rules[0].Status);
+        Assert.Equal(RuleResultStatus.Up, health.Rules[0].Status);
         Assert.False(health.Rules[0].Required);
     }
 
@@ -47,13 +46,11 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = new ConfigManager(new[] {rule});
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
         var healthUpdates = new List<ConfigHealthSnapshot>();
 
         using var subscription = configManager.GetHealthService().SnapshotStream
             .Subscribe(s => healthUpdates.Add(s));
-
-        configManager.Initialize();
 
         // Wait for the observable to emit health update
         await ActiveWaitHelpers.WaitUntilAsync(
@@ -62,7 +59,7 @@ public class ConfigManagerHealthIntegrationTests
             description: "initial health update emission");
 
         Assert.True(healthUpdates.Count >= 1);
-        
+
         // Check that we get health updates
         var latestHealth = configManager.GetHealthService().Snapshot;
         Assert.Single(latestHealth.Rules);
@@ -82,8 +79,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = new ConfigManager(new[] {rule});
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -108,8 +104,7 @@ public class ConfigManagerHealthIntegrationTests
         var optionalRule = new ConfigRule(typeof(StaticJsonProvider), optionalProviderOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = new ConfigManager(new[] {requiredRule, optionalRule});
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {requiredRule, optionalRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -140,8 +135,7 @@ public class ConfigManagerHealthIntegrationTests
         var unnamedRule = new ConfigRule(typeof(StaticJsonProvider), providerOptions2, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = new ConfigManager(new[] {namedRule, unnamedRule});
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {namedRule, unnamedRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -171,8 +165,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false, Name: "Explicit Name", MountPath: "MountPath"));
 
-        using var configManager = new ConfigManager(new[] {rule});
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Single(health.Rules);
@@ -196,8 +189,7 @@ public class ConfigManagerHealthIntegrationTests
         var alwaysRule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false, Name: "Always Rule"));
 
-        using var configManager = new ConfigManager(new[] {conditionalRule, alwaysRule});
-        configManager.Initialize();
+        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {conditionalRule, alwaysRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthIntegrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthIntegrationTests.cs
@@ -26,7 +26,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.NotNull(health);
@@ -46,7 +46,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {rule}));
         var healthUpdates = new List<ConfigHealthSnapshot>();
 
         using var subscription = configManager.GetHealthService().SnapshotStream
@@ -79,7 +79,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -104,7 +104,7 @@ public class ConfigManagerHealthIntegrationTests
         var optionalRule = new ConfigRule(typeof(StaticJsonProvider), optionalProviderOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {requiredRule, optionalRule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {requiredRule, optionalRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -135,7 +135,7 @@ public class ConfigManagerHealthIntegrationTests
         var unnamedRule = new ConfigRule(typeof(StaticJsonProvider), providerOptions2, queryOptions, typeof(SimpleConfig),
             new(Required: false));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {namedRule, unnamedRule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {namedRule, unnamedRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);
@@ -165,7 +165,7 @@ public class ConfigManagerHealthIntegrationTests
         var rule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false, Name: "Explicit Name", MountPath: "MountPath"));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {rule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {rule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Single(health.Rules);
@@ -189,7 +189,7 @@ public class ConfigManagerHealthIntegrationTests
         var alwaysRule = new ConfigRule(typeof(StaticJsonProvider), providerOptions, queryOptions, typeof(SimpleConfig),
             new(Required: false, Name: "Always Rule"));
 
-        using var configManager = ConfigManager.Create(c => c.WithConfiguration(new[] {conditionalRule, alwaysRule}));
+        using var configManager = ConfigManager.Create(c => c.UseConfiguration(new[] {conditionalRule, alwaysRule}));
         var health = configManager.GetHealthService().Snapshot;
 
         Assert.Equal(HealthStatus.Healthy, health.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRecoveryTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRecoveryTests.cs
@@ -46,8 +46,7 @@ public sealed class ConfigManagerHealthRecoveryTests
             new ConfigRule(typeof(FlakyStaticProvider), new DummyProviderOptions(), new DummyProviderQuery(), typeof(RecoveryConfig), new(Required: false))
         };
 
-        var manager = new ConfigManager(rules, null, NullLogger.Instance, (t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!);
-    manager.Initialize(); // Optional failure does not throw
+        var manager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
     var health1 = manager.GetHealthService().Snapshot; // snapshot after optional failure
     Assert.Equal(HealthStatus.Degraded, health1.OverallStatus);
         Assert.Single(health1.Rules);
@@ -55,8 +54,7 @@ public sealed class ConfigManagerHealthRecoveryTests
         Assert.Equal(RuleResultStatus.Down, health1.Rules[0].Status);
 
         // Second attempt: call Initialize again (idempotent pattern not guaranteed) - we re-create manager to simulate retry
-    var manager2 = new ConfigManager(rules, null, NullLogger.Instance, (t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!);
-    manager2.Initialize();
+    var manager2 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
 
     var health2 = manager2.GetHealthService().Snapshot;
     Assert.Equal(HealthStatus.Healthy, health2.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRecoveryTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRecoveryTests.cs
@@ -46,7 +46,7 @@ public sealed class ConfigManagerHealthRecoveryTests
             new ConfigRule(typeof(FlakyStaticProvider), new DummyProviderOptions(), new DummyProviderQuery(), typeof(RecoveryConfig), new(Required: false))
         };
 
-        var manager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
+        var manager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
     var health1 = manager.GetHealthService().Snapshot; // snapshot after optional failure
     Assert.Equal(HealthStatus.Degraded, health1.OverallStatus);
         Assert.Single(health1.Rules);
@@ -54,7 +54,7 @@ public sealed class ConfigManagerHealthRecoveryTests
         Assert.Equal(RuleResultStatus.Down, health1.Rules[0].Status);
 
         // Second attempt: call Initialize again (idempotent pattern not guaranteed) - we re-create manager to simulate retry
-    var manager2 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
+    var manager2 = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseProviderFactory((t, _) => (ConfigurationProvider)Activator.CreateInstance(t, new DummyProviderOptions())!));
 
     var health2 = manager2.GetHealthService().Snapshot;
     Assert.Equal(HealthStatus.Healthy, health2.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRuntimeRecoveryTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRuntimeRecoveryTests.cs
@@ -20,7 +20,7 @@ public sealed class ConfigManagerHealthRuntimeRecoveryTests
         var failingRule = BuildAlwaysFailingRule(required: false, new InvalidOperationException("Test runtime failure"));
         
         // Initialization will attempt recompute - second optional fails -> degraded
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { goodRule, failingRule }));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { goodRule, failingRule }));
         
         var snap = manager.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Degraded, snap.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRuntimeRecoveryTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigManagerHealthRuntimeRecoveryTests.cs
@@ -19,10 +19,8 @@ public sealed class ConfigManagerHealthRuntimeRecoveryTests
         var goodRule = BuildWorkingRule(required: true);
         var failingRule = BuildAlwaysFailingRule(required: false, new InvalidOperationException("Test runtime failure"));
         
-        using var manager = new ConfigManager(new[] { goodRule, failingRule });
-        
         // Initialization will attempt recompute - second optional fails -> degraded
-        try { manager.Initialize(); } catch { /* required rule didn't fail so ignore */ }
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { goodRule, failingRule }));
         
         var snap = manager.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Degraded, snap.OverallStatus);

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigurationHealthTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/ConfigurationHealthTests.cs
@@ -1,4 +1,4 @@
-
+using Cocoar.Configuration.Health;
 using Cocoar.Configuration.Core.Tests.Helpers;
 
 namespace Cocoar.Configuration.Core.Tests.Health;
@@ -8,26 +8,23 @@ public class ConfigurationHealthTests
     [Fact]
     [Trait("Type", "Unit")]
     [Trait("Area", "Health")]
-    public void ConfigurationHealthStatus_HasExpectedValues()
+    public void HealthStatus_HasExpectedValues()
     {
-
-        Assert.Equal(0, (int)ConfigurationHealthStatus.Healthy);
-        Assert.Equal(1, (int)ConfigurationHealthStatus.Degraded);
-        Assert.Equal(2, (int)ConfigurationHealthStatus.Unhealthy);
-        Assert.Equal(3, (int)ConfigurationHealthStatus.Unknown);
+        Assert.Equal(0, (int)HealthStatus.Unknown);
+        Assert.Equal(1, (int)HealthStatus.Healthy);
+        Assert.Equal(2, (int)HealthStatus.Degraded);
+        Assert.Equal(3, (int)HealthStatus.Unhealthy);
     }
 
     [Fact]
     [Trait("Type", "Unit")]
     [Trait("Area", "Health")]
-    public void RuleEvaluationState_HasExpectedValues()
+    public void RuleResultStatus_HasExpectedValues()
     {
-
-        Assert.Equal(0, (int)RuleEvaluationState.NotEvaluated);
-        Assert.Equal(1, (int)RuleEvaluationState.Skipped);
-        Assert.Equal(2, (int)RuleEvaluationState.Evaluating);
-        Assert.Equal(3, (int)RuleEvaluationState.Success);
-        Assert.Equal(4, (int)RuleEvaluationState.Failed);
+        Assert.Equal(0, (int)RuleResultStatus.Unknown);
+        Assert.Equal(1, (int)RuleResultStatus.Up);
+        Assert.Equal(2, (int)RuleResultStatus.Down);
+        Assert.Equal(3, (int)RuleResultStatus.Skipped);
     }
 
     [Fact]
@@ -36,12 +33,12 @@ public class ConfigurationHealthTests
     public void RuleHealthInfo_CanBeCreated()
     {
         var ruleHealth = new RuleHealthInfo(
-            RuleEvaluationState.Success,
+            RuleResultStatus.Up,
             IsRequired: true,
             IsSkipped: false
         );
 
-        Assert.Equal(RuleEvaluationState.Success, ruleHealth.State);
+        Assert.Equal(RuleResultStatus.Up, ruleHealth.Status);
         Assert.True(ruleHealth.IsRequired);
         Assert.False(ruleHealth.IsSkipped);
     }
@@ -53,17 +50,17 @@ public class ConfigurationHealthTests
     {
         var rules = new[]
         {
-            new RuleHealthInfo(RuleEvaluationState.Success, IsRequired: true, IsSkipped: false),
-            new RuleHealthInfo(RuleEvaluationState.Success, IsRequired: false, IsSkipped: false)
+            new RuleHealthInfo(RuleResultStatus.Up, IsRequired: true, IsSkipped: false),
+            new RuleHealthInfo(RuleResultStatus.Up, IsRequired: false, IsSkipped: false)
         };
 
         var healthInfo = new ConfigurationHealthInfo(rules);
 
-        Assert.Equal(ConfigurationHealthStatus.Healthy, healthInfo.State);
+        Assert.Equal(HealthStatus.Healthy, healthInfo.State);
         Assert.Equal(2, healthInfo.Rules.Count);
-        Assert.Equal(RuleEvaluationState.Success, healthInfo.Rules[0].State);
+        Assert.Equal(RuleResultStatus.Up, healthInfo.Rules[0].Status);
         Assert.True(healthInfo.Rules[0].IsRequired);
-        Assert.Equal(RuleEvaluationState.Success, healthInfo.Rules[1].State);
+        Assert.Equal(RuleResultStatus.Up, healthInfo.Rules[1].Status);
         Assert.False(healthInfo.Rules[1].IsRequired);
     }
 
@@ -74,7 +71,7 @@ public class ConfigurationHealthTests
     {
         var healthInfo = new ConfigurationHealthInfo(Array.Empty<RuleHealthInfo>());
 
-        Assert.Equal(ConfigurationHealthStatus.Unknown, healthInfo.State);
+        Assert.Equal(HealthStatus.Unknown, healthInfo.State);
         Assert.Empty(healthInfo.Rules);
     }
 
@@ -85,15 +82,15 @@ public class ConfigurationHealthTests
     {
         var rules = new[]
         {
-            new RuleHealthInfo(RuleEvaluationState.Success, IsRequired: true, IsSkipped: false),
-            new RuleHealthInfo(RuleEvaluationState.Skipped, IsRequired: false, IsSkipped: true)
+            new RuleHealthInfo(RuleResultStatus.Up, IsRequired: true, IsSkipped: false),
+            new RuleHealthInfo(RuleResultStatus.Skipped, IsRequired: false, IsSkipped: true)
         };
 
         var healthInfo = new ConfigurationHealthInfo(rules);
 
-        Assert.Equal(ConfigurationHealthStatus.Healthy, healthInfo.State);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.Success && r.IsRequired);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.Skipped && r.IsSkipped);
+        Assert.Equal(HealthStatus.Healthy, healthInfo.State);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Up && r.IsRequired);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Skipped && r.IsSkipped);
     }
 
     [Fact]
@@ -103,15 +100,15 @@ public class ConfigurationHealthTests
     {
         var rules = new[]
         {
-            new RuleHealthInfo(RuleEvaluationState.Success, IsRequired: true, IsSkipped: false),
-            new RuleHealthInfo(RuleEvaluationState.Failed, IsRequired: false, IsSkipped: false)
+            new RuleHealthInfo(RuleResultStatus.Up, IsRequired: true, IsSkipped: false),
+            new RuleHealthInfo(RuleResultStatus.Down, IsRequired: false, IsSkipped: false)
         };
 
         var healthInfo = new ConfigurationHealthInfo(rules);
 
-        Assert.Equal(ConfigurationHealthStatus.Degraded, healthInfo.State);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.Success && r.IsRequired);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.Failed && !r.IsRequired);
+        Assert.Equal(HealthStatus.Degraded, healthInfo.State);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Up && r.IsRequired);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Down && !r.IsRequired);
     }
 
     [Fact]
@@ -121,32 +118,28 @@ public class ConfigurationHealthTests
     {
         var rules = new[]
         {
-            new RuleHealthInfo(RuleEvaluationState.Failed, IsRequired: true, IsSkipped: false),
-            new RuleHealthInfo(RuleEvaluationState.NotEvaluated, IsRequired: false, IsSkipped: false)
+            new RuleHealthInfo(RuleResultStatus.Down, IsRequired: true, IsSkipped: false),
+            new RuleHealthInfo(RuleResultStatus.Unknown, IsRequired: false, IsSkipped: false)
         };
 
         var healthInfo = new ConfigurationHealthInfo(rules);
 
-        Assert.Equal(ConfigurationHealthStatus.Unhealthy, healthInfo.State);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.Failed && r.IsRequired);
-        Assert.Contains(healthInfo.Rules, r => r.State == RuleEvaluationState.NotEvaluated);
+        Assert.Equal(HealthStatus.Unhealthy, healthInfo.State);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Down && r.IsRequired);
+        Assert.Contains(healthInfo.Rules, r => r.Status == RuleResultStatus.Unknown);
     }
 
     [Theory]
     [Trait("Type", "Unit")]
     [Trait("Area", "Health")]
-    [InlineData(RuleEvaluationState.NotEvaluated)]
-    [InlineData(RuleEvaluationState.Skipped)]
-    [InlineData(RuleEvaluationState.Evaluating)]
-    [InlineData(RuleEvaluationState.Success)]
-    [InlineData(RuleEvaluationState.Failed)]
-    public void RuleHealthInfo_SupportsAllEvaluationStates(RuleEvaluationState state)
+    [InlineData(RuleResultStatus.Unknown)]
+    [InlineData(RuleResultStatus.Up)]
+    [InlineData(RuleResultStatus.Down)]
+    [InlineData(RuleResultStatus.Skipped)]
+    public void RuleHealthInfo_SupportsAllResultStatuses(RuleResultStatus status)
     {
-        var ruleHealth = new RuleHealthInfo(state, IsRequired: true, IsSkipped: false);
+        var ruleHealth = new RuleHealthInfo(status, IsRequired: true, IsSkipped: false);
 
-        Assert.Equal(state, ruleHealth.State);
+        Assert.Equal(status, ruleHealth.Status);
     }
 }
-
-
-

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/LeanHealthIntegrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/LeanHealthIntegrationTests.cs
@@ -13,7 +13,7 @@ public class LeanHealthIntegrationTests
     public void AfterCreate_ShouldBeHealthy()
     {
         var rule = BuildStaticRule(required:true);
-        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
+        using var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
         var health = mgr.GetHealthService();
         Assert.Equal(HealthStatus.Healthy, health.Status);
     }
@@ -22,7 +22,7 @@ public class LeanHealthIntegrationTests
     public void AfterInitialization_AllRequiredUp_ShouldBeHealthy()
     {
         var rule = BuildStaticRule(required:true);
-        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
+        using var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Healthy, snap.OverallStatus);
         Assert.All(snap.Rules, r => Assert.Equal(RuleResultStatus.Up, r.Status));
@@ -34,7 +34,7 @@ public class LeanHealthIntegrationTests
         var ok = BuildStaticRule(required:true);
         var failing = BuildFailingRule(required:false, new InvalidOperationException("json parse failed"));
         // Initialization will attempt recompute - second optional fails -> degraded
-        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance));
+        using var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Degraded, snap.OverallStatus);
         Assert.Equal(RuleResultStatus.Up, snap.Rules[0].Status);
@@ -47,7 +47,7 @@ public class LeanHealthIntegrationTests
         var ok = BuildStaticRule(required:true);
         var failing = BuildFailingRule(required:true, new TimeoutException("timeout"));
         Assert.ThrowsAny<Exception>(() =>
-            ConfigManager.Create(c => c.WithConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance)));
+            ConfigManager.Create(c => c.UseConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance)));
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class LeanHealthIntegrationTests
         var r4 = BuildStaticRule(true);
         var r5 = BuildStaticRule(true);
         Assert.ThrowsAny<Exception>(() =>
-            ConfigManager.Create(c => c.WithConfiguration(new[]{r1,r2,failing,r4,r5}).UseLogger(NullLogger.Instance)));
+            ConfigManager.Create(c => c.UseConfiguration(new[]{r1,r2,failing,r4,r5}).UseLogger(NullLogger.Instance)));
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class LeanHealthIntegrationTests
             typeof(object),
             new(Required: true, UseWhen: _ => false) // logically required but inactive
         );
-        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{requiredRule, skippedRule}).UseLogger(NullLogger.Instance));
+        using var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{requiredRule, skippedRule}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(2, snap.Rules.Count);
         Assert.Equal(HealthStatus.Healthy, snap.OverallStatus); // skipped does not degrade

--- a/src/tests/Cocoar.Configuration.Core.Tests/Health/LeanHealthIntegrationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Health/LeanHealthIntegrationTests.cs
@@ -10,20 +10,19 @@ namespace Cocoar.Configuration.Core.Tests.Health;
 public class LeanHealthIntegrationTests
 {
     [Fact]
-    public void Initial_State_ShouldBeUnknown()
+    public void AfterCreate_ShouldBeHealthy()
     {
         var rule = BuildStaticRule(required:true);
-        using var mgr = new ConfigManager(new[]{rule}, logger: NullLogger.Instance);
+        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
         var health = mgr.GetHealthService();
-        Assert.Equal(HealthStatus.Unknown, health.Status);
+        Assert.Equal(HealthStatus.Healthy, health.Status);
     }
 
     [Fact]
     public void AfterInitialization_AllRequiredUp_ShouldBeHealthy()
     {
         var rule = BuildStaticRule(required:true);
-        using var mgr = new ConfigManager(new[]{rule}, logger: NullLogger.Instance);
-        mgr.Initialize();
+        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Healthy, snap.OverallStatus);
         Assert.All(snap.Rules, r => Assert.Equal(RuleResultStatus.Up, r.Status));
@@ -34,9 +33,8 @@ public class LeanHealthIntegrationTests
     {
         var ok = BuildStaticRule(required:true);
         var failing = BuildFailingRule(required:false, new InvalidOperationException("json parse failed"));
-        using var mgr = new ConfigManager(new[]{ok, failing}, logger: NullLogger.Instance);
         // Initialization will attempt recompute - second optional fails -> degraded
-        try { mgr.Initialize(); } catch { /* required rule didn't fail so ignore */ }
+        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(HealthStatus.Degraded, snap.OverallStatus);
         Assert.Equal(RuleResultStatus.Up, snap.Rules[0].Status);
@@ -44,21 +42,16 @@ public class LeanHealthIntegrationTests
     }
 
     [Fact]
-    public void RequiredFailure_ShouldYieldUnhealthy_AndPreserveConfigVersion()
+    public void RequiredFailure_ShouldThrowAndYieldUnhealthy()
     {
         var ok = BuildStaticRule(required:true);
         var failing = BuildFailingRule(required:true, new TimeoutException("timeout"));
-        using var mgr = new ConfigManager(new[]{ok, failing}, logger: NullLogger.Instance);
-        Assert.ThrowsAny<Exception>(()=> mgr.Initialize());
-        var snap = mgr.GetHealthService().Snapshot;
-        Assert.Equal(HealthStatus.Unhealthy, snap.OverallStatus);
-        Assert.Equal(RuleResultStatus.Up, snap.Rules[0].Status); // first succeeded then second failed abort
-        Assert.Equal(RuleResultStatus.Down, snap.Rules[1].Status);
-        Assert.Equal(0, snap.ConfigVersion); // failure should not advance version
+        Assert.ThrowsAny<Exception>(() =>
+            ConfigManager.Create(c => c.WithConfiguration(new[]{ok, failing}).UseLogger(NullLogger.Instance)));
     }
 
     [Fact]
-    public void MidSequenceRequiredFailure_ShouldMarkTrailingUnknown()
+    public void MidSequenceRequiredFailure_ShouldThrow()
     {
         // Build 5 rules where the 3rd fails required
         var r1 = BuildStaticRule(true);
@@ -66,15 +59,8 @@ public class LeanHealthIntegrationTests
         var failing = BuildFailingRule(true, new InvalidOperationException("boom"));
         var r4 = BuildStaticRule(true);
         var r5 = BuildStaticRule(true);
-        using var mgr = new ConfigManager(new[]{r1,r2,failing,r4,r5}, logger: NullLogger.Instance);
-        Assert.ThrowsAny<Exception>(()=> mgr.Initialize());
-        var snap = mgr.GetHealthService().Snapshot;
-        Assert.Equal(HealthStatus.Unhealthy, snap.OverallStatus);
-        Assert.Equal(RuleResultStatus.Up, snap.Rules[0].Status);
-        Assert.Equal(RuleResultStatus.Up, snap.Rules[1].Status);
-        Assert.Equal(RuleResultStatus.Down, snap.Rules[2].Status);
-        Assert.Equal(RuleResultStatus.Unknown, snap.Rules[3].Status);
-        Assert.Equal(RuleResultStatus.Unknown, snap.Rules[4].Status);
+        Assert.ThrowsAny<Exception>(() =>
+            ConfigManager.Create(c => c.WithConfiguration(new[]{r1,r2,failing,r4,r5}).UseLogger(NullLogger.Instance)));
     }
 
     [Fact]
@@ -91,8 +77,7 @@ public class LeanHealthIntegrationTests
             typeof(object),
             new(Required: true, UseWhen: _ => false) // logically required but inactive
         );
-        using var mgr = new ConfigManager(new[]{requiredRule, skippedRule}, logger: NullLogger.Instance);
-        mgr.Initialize();
+        using var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{requiredRule, skippedRule}).UseLogger(NullLogger.Instance));
         var snap = mgr.GetHealthService().Snapshot;
         Assert.Equal(2, snap.Rules.Count);
         Assert.Equal(HealthStatus.Healthy, snap.OverallStatus); // skipped does not degrade

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/ConfigMergingDebugTest.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/ConfigMergingDebugTest.cs
@@ -57,7 +57,7 @@ public class ConfigMergingDebugTest
             TestRules.StaticJson<TestConfig>(observablePartialJson)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<TestConfig>();
 
         // Expected flattened merge:

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/ConfigMergingDebugTest.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/ConfigMergingDebugTest.cs
@@ -57,7 +57,7 @@ public class ConfigMergingDebugTest
             TestRules.StaticJson<TestConfig>(observablePartialJson)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<TestConfig>();
 
         // Expected flattened merge:

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/InterfaceDeserializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/InterfaceDeserializationTests.cs
@@ -47,7 +47,7 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rules: rule => [
                 rule.For<AppConfiguration>().FromStaticJson(json)
             ],
@@ -80,7 +80,7 @@ public class InterfaceDeserializationTests
 
         try
         {
-            var configManager = ConfigManager.Create(c => c.WithConfiguration(
+            var configManager = ConfigManager.Create(c => c.UseConfiguration(
                 rules: rule => [
                     rule.For<AppConfiguration>().FromEnvironment()
                 ],
@@ -147,7 +147,7 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rules: rule => [
                 rule.For<ComplexConfiguration>().FromStaticJson(json)
             ],
@@ -217,7 +217,7 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rules: rule => [
                 rule.For<NestedConfiguration>().FromStaticJson(json)
             ],
@@ -302,7 +302,7 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rules: rule => [
                 rule.For<DeepConfiguration>().FromStaticJson(json)
             ],

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/InterfaceDeserializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/InterfaceDeserializationTests.cs
@@ -47,14 +47,13 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rules: rule => [
                 rule.For<AppConfiguration>().FromStaticJson(json)
             ],
             setup: setup => [
                 setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>()
-            ]
-        ).Initialize();
+            ]));
 
         // Act
         var config = configManager.GetRequiredConfig<AppConfiguration>();
@@ -81,14 +80,13 @@ public class InterfaceDeserializationTests
 
         try
         {
-            var configManager = new ConfigManager(
+            var configManager = ConfigManager.Create(c => c.WithConfiguration(
                 rules: rule => [
                     rule.For<AppConfiguration>().FromEnvironment()
                 ],
                 setup: setup => [
                     setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>()
-                ]
-            ).Initialize();
+                ]));
 
             // Act
             var config = configManager.GetRequiredConfig<AppConfiguration>();
@@ -149,15 +147,14 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rules: rule => [
                 rule.For<ComplexConfiguration>().FromStaticJson(json)
             ],
             setup: setup => [
                 setup.Interface<ILoggingConfig>().DeserializeTo<LoggingConfig>(),
                 setup.Interface<IDatabaseConfig>().DeserializeTo<DatabaseConfig>()
-            ]
-        ).Initialize();
+            ]));
 
         // Act
         var config = configManager.GetRequiredConfig<ComplexConfiguration>();
@@ -220,15 +217,14 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rules: rule => [
                 rule.For<NestedConfiguration>().FromStaticJson(json)
             ],
             setup: setup => [
                 setup.Interface<IAdvancedLoggingConfig>().DeserializeTo<AdvancedLoggingConfig>(),
                 setup.Interface<IRetryPolicy>().DeserializeTo<RetryPolicy>()
-            ]
-        ).Initialize();
+            ]));
 
         // Act
         var config = configManager.GetRequiredConfig<NestedConfiguration>();
@@ -306,7 +302,7 @@ public class InterfaceDeserializationTests
         }
         """;
 
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rules: rule => [
                 rule.For<DeepConfiguration>().FromStaticJson(json)
             ],
@@ -314,8 +310,7 @@ public class InterfaceDeserializationTests
                 setup.Interface<IDeepLoggingConfig>().DeserializeTo<DeepLoggingConfig>(),
                 setup.Interface<IAdvancedRetryPolicy>().DeserializeTo<AdvancedRetryPolicy>(),
                 setup.Interface<ICircuitBreaker>().DeserializeTo<CircuitBreaker>()
-            ]
-        ).Initialize();
+            ]));
 
         // Act
         var config = configManager.GetRequiredConfig<DeepConfiguration>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderIsolationTests.cs
@@ -30,11 +30,11 @@ public class MultiProviderIsolationTests
 
         using var subject = new BehaviorSubject<string>(initialJson);
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromObservable(subject).Select("AppSettings"),
-                
+
             rules.For<DatabaseConfig>().FromObservable(subject).Select("DatabaseSettings")
-        ], debounceMilliseconds: 100).Initialize();
+        ]).UseDebounce(100));
         
         var appConfig = configManager.GetReactiveConfig<AppConfig>();
         var databaseConfig = configManager.GetReactiveConfig<DatabaseConfig>();
@@ -100,7 +100,7 @@ public class MultiProviderIsolationTests
         var subject2 = new BehaviorSubject<string>("""{"Rule2Value": 10}""");
         var subject3 = new BehaviorSubject<string>("""{"Rule3Value": 100}""");
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<Dictionary<string, object>>().FromStaticJson("""{"Static": "Base", "Priority": 1}"""),
 
             rules.For<Dictionary<string, object>>().FromObservable(subject1),
@@ -108,7 +108,7 @@ public class MultiProviderIsolationTests
             rules.For<Dictionary<string, object>>().FromObservable(subject2),
 
             rules.For<Dictionary<string, object>>().FromObservable(subject3)
-        ], debounceMilliseconds: 30).Initialize();
+        ]).UseDebounce(30));
         
         var config = configManager.GetReactiveConfig<Dictionary<string, object>>();
 
@@ -174,10 +174,10 @@ public class MultiProviderIsolationTests
     {
         var subject = new BehaviorSubject<string>("""{"Value": 0, "Timestamp": "initial"}""");
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             // Single observable rule to isolate emission behavior
             rules.For<Dictionary<string, object>>().FromObservable(subject)
-        ], debounceMilliseconds: 50).Initialize();
+        ]).UseDebounce(50));
         
         var config = configManager.GetReactiveConfig<Dictionary<string, object>>();
 
@@ -260,7 +260,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<ScalarMergeConfig>(scalarOverride)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<ScalarMergeConfig>();
         Assert.NotNull(config);
 
@@ -294,7 +294,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<ArrayMergeConfig>(objectOverride)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<ArrayMergeConfig>();
         Assert.NotNull(config);
 
@@ -332,7 +332,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<NullMergeConfig>(nullOverride)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<NullMergeConfig>();
         Assert.NotNull(config);
 
@@ -358,7 +358,7 @@ public class MultiProviderIsolationTests
             TestRules.ObservableString<SnapshotConfig>(observable)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
 
     var snapshot1 = configManager.GetConfig<SnapshotConfig>();
     Assert.NotNull(snapshot1);
@@ -405,14 +405,14 @@ public class MultiProviderIsolationTests
         }
         """;
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             // This rule selects a non-existent path - should contribute nothing
             rules.For<SelectMountConfig>().FromStaticJson(jsonWithoutPath)
                 .Select("NonExistentSection"),  // This path doesn't exist - selection will be empty
-            
+
             // Base rule to ensure we have some configuration
             rules.For<SelectMountConfig>().FromStaticJson("""{"DefaultValue": "present"}""")
-        ]).Initialize();
+        ]));
 
         var config = configManager.GetConfig<SelectMountConfig>();
         Assert.NotNull(config);
@@ -454,8 +454,8 @@ public class MultiProviderIsolationTests
         }
         """;
 
-        var configManager1 = new ConfigManager([TestRules.StaticJson<AppConfig>(config1)]).Initialize();
-        var configManager2 = new ConfigManager([TestRules.StaticJson<AppConfig>(config2)]).Initialize();
+        var configManager1 = ConfigManager.Create(c => c.WithConfiguration([TestRules.StaticJson<AppConfig>(config1)]));
+        var configManager2 = ConfigManager.Create(c => c.WithConfiguration([TestRules.StaticJson<AppConfig>(config2)]));
 
     var result1 = configManager1.GetConfig<AppConfig>();
     var result2 = configManager2.GetConfig<AppConfig>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderIsolationTests.cs
@@ -30,7 +30,7 @@ public class MultiProviderIsolationTests
 
         using var subject = new BehaviorSubject<string>(initialJson);
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromObservable(subject).Select("AppSettings"),
 
             rules.For<DatabaseConfig>().FromObservable(subject).Select("DatabaseSettings")
@@ -100,7 +100,7 @@ public class MultiProviderIsolationTests
         var subject2 = new BehaviorSubject<string>("""{"Rule2Value": 10}""");
         var subject3 = new BehaviorSubject<string>("""{"Rule3Value": 100}""");
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<Dictionary<string, object>>().FromStaticJson("""{"Static": "Base", "Priority": 1}"""),
 
             rules.For<Dictionary<string, object>>().FromObservable(subject1),
@@ -174,7 +174,7 @@ public class MultiProviderIsolationTests
     {
         var subject = new BehaviorSubject<string>("""{"Value": 0, "Timestamp": "initial"}""");
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             // Single observable rule to isolate emission behavior
             rules.For<Dictionary<string, object>>().FromObservable(subject)
         ]).UseDebounce(50));
@@ -260,7 +260,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<ScalarMergeConfig>(scalarOverride)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<ScalarMergeConfig>();
         Assert.NotNull(config);
 
@@ -294,7 +294,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<ArrayMergeConfig>(objectOverride)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<ArrayMergeConfig>();
         Assert.NotNull(config);
 
@@ -332,7 +332,7 @@ public class MultiProviderIsolationTests
             TestRules.StaticJson<NullMergeConfig>(nullOverride)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<NullMergeConfig>();
         Assert.NotNull(config);
 
@@ -358,7 +358,7 @@ public class MultiProviderIsolationTests
             TestRules.ObservableString<SnapshotConfig>(observable)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
 
     var snapshot1 = configManager.GetConfig<SnapshotConfig>();
     Assert.NotNull(snapshot1);
@@ -405,7 +405,7 @@ public class MultiProviderIsolationTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             // This rule selects a non-existent path - should contribute nothing
             rules.For<SelectMountConfig>().FromStaticJson(jsonWithoutPath)
                 .Select("NonExistentSection"),  // This path doesn't exist - selection will be empty
@@ -454,8 +454,8 @@ public class MultiProviderIsolationTests
         }
         """;
 
-        var configManager1 = ConfigManager.Create(c => c.WithConfiguration([TestRules.StaticJson<AppConfig>(config1)]));
-        var configManager2 = ConfigManager.Create(c => c.WithConfiguration([TestRules.StaticJson<AppConfig>(config2)]));
+        var configManager1 = ConfigManager.Create(c => c.UseConfiguration([TestRules.StaticJson<AppConfig>(config1)]));
+        var configManager2 = ConfigManager.Create(c => c.UseConfiguration([TestRules.StaticJson<AppConfig>(config2)]));
 
     var result1 = configManager1.GetConfig<AppConfig>();
     var result2 = configManager2.GetConfig<AppConfig>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderMergingTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderMergingTests.cs
@@ -55,7 +55,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(overrideConfigJson)  // Rule 1 (wins)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -104,7 +104,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(baseConfig)        // Rule 1 (wins!)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -161,7 +161,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(observablePartialJson)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -198,7 +198,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(finalConfig)        // Rule 2: Final (wins!)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderMergingTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderMergingTests.cs
@@ -55,7 +55,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(overrideConfigJson)  // Rule 1 (wins)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -104,7 +104,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(baseConfig)        // Rule 1 (wins!)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -161,7 +161,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(observablePartialJson)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -198,7 +198,7 @@ public class MultiProviderMergingTests
             TestRules.StaticJson<AppConfig>(finalConfig)        // Rule 2: Final (wins!)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderPerformanceTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderPerformanceTests.cs
@@ -33,7 +33,7 @@ public class MultiProviderPerformanceTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -77,7 +77,7 @@ public class MultiProviderPerformanceTests
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
 
         stopwatch.Stop();
@@ -124,7 +124,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var observableRule = new ConfigRule(typeof(ObservableProvider<string>), observableOptions, observableQuery, typeof(TestConfig));
 
-        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
+        var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => fetchCount > 0,
@@ -199,7 +199,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var obs1Rule = new ConfigRule(typeof(ObservableProvider<string>), obs1Options, observableQuery, typeof(TestConfig));
         var obs2Rule = new ConfigRule(typeof(ObservableProvider<string>), obs2Options, observableQuery, typeof(TestConfig));
-        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, obs1Rule, obs2Rule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(100));
+        var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { staticRule, obs1Rule, obs2Rule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(100));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => manager.GetConfig<TestConfig>()?.Name == "Observable2",
@@ -287,7 +287,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var observableRule = new ConfigRule(typeof(ObservableProvider<string>), observableOptions, observableQuery, typeof(TestConfig));
 
-        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
+        var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => manager.GetConfig<TestConfig>()?.Name == "InitialValue",
@@ -428,7 +428,7 @@ public class MultiProviderPerformanceTests
         }
         """;
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<ComplexConfig>().FromStaticJson(baseConfig),                          // Rule 0: Base config
             rules.For<ComplexConfig>().FromStaticJson(databaseOverride).MountAt("Database"), // Rule 1: Replace Database section
             rules.For<ComplexConfig>().FromStaticJson(featuresConfig).Select("NewFeatures").MountAt("Features"), // Rule 2: Mount NewFeatures as Features
@@ -507,7 +507,7 @@ public class MultiProviderPerformanceTests
         }
         """);
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<NestedConfig>().FromStaticJson(baseConfig),                                       // Rule 0: Base
             rules.For<NestedConfig>().FromObservable(dynamicSubject)                                    // Rule 1: Select deep path, mount at new location
                 .Select("DynamicSection:Deep:Nested")

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderPerformanceTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderPerformanceTests.cs
@@ -33,7 +33,7 @@ public class MultiProviderPerformanceTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
         Assert.NotNull(config);
 
@@ -77,7 +77,7 @@ public class MultiProviderPerformanceTests
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
         var config = configManager.GetConfig<AppConfig>();
 
         stopwatch.Stop();
@@ -124,8 +124,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var observableRule = new ConfigRule(typeof(ObservableProvider<string>), observableOptions, observableQuery, typeof(TestConfig));
 
-        var manager = new ConfigManager(new[] { staticRule, observableRule }, null, NullLogger.Instance, Factory, debounceMilliseconds: 50)
-            .Initialize();
+        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => fetchCount > 0,
@@ -200,8 +199,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var obs1Rule = new ConfigRule(typeof(ObservableProvider<string>), obs1Options, observableQuery, typeof(TestConfig));
         var obs2Rule = new ConfigRule(typeof(ObservableProvider<string>), obs2Options, observableQuery, typeof(TestConfig));
-        var manager = new ConfigManager(new[] { staticRule, obs1Rule, obs2Rule }, null, NullLogger.Instance, Factory, debounceMilliseconds: 100)
-            .Initialize();
+        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, obs1Rule, obs2Rule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(100));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => manager.GetConfig<TestConfig>()?.Name == "Observable2",
@@ -289,8 +287,7 @@ public class MultiProviderPerformanceTests
         var staticRule = new ConfigRule(typeof(TrackableStaticJsonProvider), staticOptions, dummyQuery, typeof(TestConfig));
         var observableRule = new ConfigRule(typeof(ObservableProvider<string>), observableOptions, observableQuery, typeof(TestConfig));
 
-        var manager = new ConfigManager(new[] { staticRule, observableRule }, null, NullLogger.Instance, Factory, debounceMilliseconds: 50)
-            .Initialize();
+        var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { staticRule, observableRule }).UseLogger(NullLogger.Instance).UseProviderFactory(Factory).UseDebounce(50));
 
         await ActiveWaitHelpers.WaitUntilAsync(
             () => manager.GetConfig<TestConfig>()?.Name == "InitialValue",
@@ -431,12 +428,12 @@ public class MultiProviderPerformanceTests
         }
         """;
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<ComplexConfig>().FromStaticJson(baseConfig),                          // Rule 0: Base config
             rules.For<ComplexConfig>().FromStaticJson(databaseOverride).MountAt("Database"), // Rule 1: Replace Database section
             rules.For<ComplexConfig>().FromStaticJson(featuresConfig).Select("NewFeatures").MountAt("Features"), // Rule 2: Mount NewFeatures as Features
             rules.For<ComplexConfig>().FromStaticJson(featuresConfig).Select("Legacy").MountAt("LegacySettings") // Rule 3: Mount Legacy under new path
-        ]).Initialize();
+        ]));
 
         var config = configManager.GetConfig<ComplexConfig>();
         Assert.NotNull(config);
@@ -510,12 +507,12 @@ public class MultiProviderPerformanceTests
         }
         """);
 
-        var configManager = new ConfigManager(rules => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<NestedConfig>().FromStaticJson(baseConfig),                                       // Rule 0: Base
             rules.For<NestedConfig>().FromObservable(dynamicSubject)                                    // Rule 1: Select deep path, mount at new location
                 .Select("DynamicSection:Deep:Nested")
                 .MountAt("Root:Dynamic")
-        ]).Initialize();
+        ]));
 
         // Wait for initial configuration to be available
         await ActiveWaitHelpers.WaitUntilAsync(

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderReactiveTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderReactiveTests.cs
@@ -26,7 +26,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)  // Observable (rule 1, wins)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -99,7 +99,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(50));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
 
         var emissions = new List<AppConfig>();
@@ -176,7 +176,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(subject)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -228,7 +228,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(subject)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -277,7 +277,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfigWithArray>(subject)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfigWithArray>();
         
         var emissions = new List<AppConfigWithArray>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderReactiveTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Integration/MultiProviderReactiveTests.cs
@@ -26,7 +26,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)  // Observable (rule 1, wins)
         };
 
-        var configManager = new ConfigManager(rules, debounceMilliseconds: 100).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -99,7 +99,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(behaviorSubject)
         };
 
-        var configManager = new ConfigManager(rules, debounceMilliseconds: 50).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(50));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
 
         var emissions = new List<AppConfig>();
@@ -176,7 +176,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(subject)
         };
 
-        var configManager = new ConfigManager(rules, debounceMilliseconds: 100).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -228,7 +228,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfig>(subject)
         };
 
-        var configManager = new ConfigManager(rules, debounceMilliseconds: 100).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfig>();
         
         var emissions = new List<AppConfig>();
@@ -277,7 +277,7 @@ public class MultiProviderReactiveTests
             TestRules.ObservableString<AppConfigWithArray>(subject)
         };
 
-        var configManager = new ConfigManager(rules, debounceMilliseconds: 100).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseDebounce(100));
         var reactiveConfig = configManager.GetReactiveConfig<AppConfigWithArray>();
         
         var emissions = new List<AppConfigWithArray>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
@@ -56,14 +56,14 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: JSON is missing the required "Name" property
         var json = """{"Value": 42}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
-            logger: _logger);
-        TrackForDisposal(configManager);
-
         // Act & Assert: With Master Backplane, deserialization failures at startup throw
         var exception = Assert.Throws<ConfigurationDeserializationException>(
-            () => configManager.Initialize());
+            () =>
+            {
+                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                    r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
+                TrackForDisposal(configManager);
+            });
 
         Assert.Single(exception.Failures);
         Assert.Equal(typeof(ConfigWithRequired), exception.Failures[0].ConfigType);
@@ -80,14 +80,14 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: JSON is missing the required "Name" property
         var json = """{"Value": 42}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
-            logger: _logger);
-        TrackForDisposal(configManager);
-
         // Act & Assert
         var exception = Assert.Throws<ConfigurationDeserializationException>(
-            () => configManager.Initialize());
+            () =>
+            {
+                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                    r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
+                TrackForDisposal(configManager);
+            });
 
         // The exception should include a JSON preview
         Assert.NotNull(exception.Failures[0].JsonPreview);
@@ -104,11 +104,9 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: JSON has all required properties
         var json = """{"Name": "test", "Value": 42}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
-            logger: _logger);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+            r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Act
         var result = configManager.GetConfig<ConfigWithRequired>();
@@ -131,14 +129,14 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: JSON has a string where an int is expected
         var json = """{"Count": "not-a-number"}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithInt>().FromStaticJson(json)],
-            logger: _logger);
-        TrackForDisposal(configManager);
-
         // Act & Assert: With Master Backplane, deserialization failures at startup throw
         var exception = Assert.Throws<ConfigurationDeserializationException>(
-            () => configManager.Initialize());
+            () =>
+            {
+                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                    r => [r.For<ConfigWithInt>().FromStaticJson(json)]).UseLogger(_logger));
+                TrackForDisposal(configManager);
+            });
 
         Assert.Single(exception.Failures);
         Assert.Equal(typeof(ConfigWithInt), exception.Failures[0].ConfigType);
@@ -155,17 +153,17 @@ public class ConfigManagerDeserializationTests : IDisposable
         var json1 = """{"Value": 123}"""; // Missing Name
         var json2 = """{"Count": "not-a-number"}"""; // Type mismatch
 
-        var configManager = new ConfigManager(
-            r => [
-                r.For<ConfigWithRequired>().FromStaticJson(json1),
-                r.For<ConfigWithInt>().FromStaticJson(json2)
-            ],
-            logger: _logger);
-        TrackForDisposal(configManager);
-
         // Act & Assert
         var exception = Assert.Throws<ConfigurationDeserializationException>(
-            () => configManager.Initialize());
+            () =>
+            {
+                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                    r => [
+                        r.For<ConfigWithRequired>().FromStaticJson(json1),
+                        r.For<ConfigWithInt>().FromStaticJson(json2)
+                    ]).UseLogger(_logger));
+                TrackForDisposal(configManager);
+            });
 
         Assert.Equal(2, exception.Failures.Count);
         Assert.Contains(exception.Failures, f => f.ConfigType == typeof(ConfigWithRequired));
@@ -182,11 +180,9 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: Simple config without required properties
         var json = """{"Name": "test"}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<SimpleConfig>().FromStaticJson(json)],
-            logger: _logger);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+            r => [r.For<SimpleConfig>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Act
         var result = configManager.GetConfig<SimpleConfig>();
@@ -209,11 +205,9 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: Valid JSON
         var json = """{"Name": "test", "Value": 42}""";
 
-        var configManager = new ConfigManager(
-            r => [r.For<ConfigWithRequired>().FromStaticJson(json)],
-            logger: _logger);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+            r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Act: Get config multiple times
         var result1 = configManager.GetConfig<ConfigWithRequired>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerDeserializationTests.cs
@@ -60,7 +60,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         var exception = Assert.Throws<ConfigurationDeserializationException>(
             () =>
             {
-                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                var configManager = ConfigManager.Create(c => c.UseConfiguration(
                     r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
                 TrackForDisposal(configManager);
             });
@@ -84,7 +84,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         var exception = Assert.Throws<ConfigurationDeserializationException>(
             () =>
             {
-                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                var configManager = ConfigManager.Create(c => c.UseConfiguration(
                     r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
                 TrackForDisposal(configManager);
             });
@@ -104,7 +104,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: JSON has all required properties
         var json = """{"Name": "test", "Value": 42}""";
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
 
@@ -133,7 +133,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         var exception = Assert.Throws<ConfigurationDeserializationException>(
             () =>
             {
-                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                var configManager = ConfigManager.Create(c => c.UseConfiguration(
                     r => [r.For<ConfigWithInt>().FromStaticJson(json)]).UseLogger(_logger));
                 TrackForDisposal(configManager);
             });
@@ -157,7 +157,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         var exception = Assert.Throws<ConfigurationDeserializationException>(
             () =>
             {
-                var configManager = ConfigManager.Create(c => c.WithConfiguration(
+                var configManager = ConfigManager.Create(c => c.UseConfiguration(
                     r => [
                         r.For<ConfigWithRequired>().FromStaticJson(json1),
                         r.For<ConfigWithInt>().FromStaticJson(json2)
@@ -180,7 +180,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: Simple config without required properties
         var json = """{"Name": "test"}""";
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             r => [r.For<SimpleConfig>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
 
@@ -205,7 +205,7 @@ public class ConfigManagerDeserializationTests : IDisposable
         // Arrange: Valid JSON
         var json = """{"Name": "test", "Value": 42}""";
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             r => [r.For<ConfigWithRequired>().FromStaticJson(json)]).UseLogger(_logger));
         TrackForDisposal(configManager);
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerErrorHandlingTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerErrorHandlingTests.cs
@@ -53,7 +53,7 @@ public class ConfigManagerErrorHandlingTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+            var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
             TrackForDisposal(configManager);
         });
 
@@ -88,7 +88,7 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var config = configManager.GetConfig<TestConfig>();
 
@@ -124,7 +124,7 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false)) // Optional rule
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var config = configManager.GetConfig<TestConfig>();
 
@@ -166,7 +166,7 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var config = configManager.GetConfig<TestConfig>();
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerErrorHandlingTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerErrorHandlingTests.cs
@@ -51,11 +51,11 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: true))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
-        TrackForDisposal(configManager);
-
-
-        var exception = Assert.Throws<InvalidOperationException>(() => configManager.Initialize());
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+            TrackForDisposal(configManager);
+        });
 
         // Verify exception message contains provider information
         Assert.Contains("Required rule failed", exception.Message);
@@ -88,11 +88,8 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var config = configManager.GetConfig<TestConfig>();
 
 
@@ -127,11 +124,8 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false)) // Optional rule
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var config = configManager.GetConfig<TestConfig>();
 
 
@@ -172,11 +166,8 @@ public class ConfigManagerErrorHandlingTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var config = configManager.GetConfig<TestConfig>();
 
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
@@ -64,7 +64,7 @@ public class ConfigManagerIsolationTests : IDisposable
 
     [Fact]
     [Trait("Type", "Unit")]
-    public void ConfigManager_Initialize_ShouldSetInitializedFlag()
+    public void ConfigManager_Create_ShouldReturnInitializedManager()
     {
         var testConfig = new DatabaseConfig { ConnectionString = "test", Timeout = 30 };
         var rules = new List<ConfigRule>
@@ -72,13 +72,9 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
-        var result = configManager.Initialize();
-
-        Assert.Same(configManager, result); // Should return self for fluent interface
-        
         // Verify initialization by checking if configs are accessible
         var config = configManager.GetConfig<DatabaseConfig>();
         Assert.NotNull(config);
@@ -88,7 +84,7 @@ public class ConfigManagerIsolationTests : IDisposable
 
     [Fact]
     [Trait("Type", "Unit")]
-    public void ConfigManager_Initialize_ShouldBeIdempotent()
+    public void ConfigManager_Create_CanBeCalledMultipleTimes_IndependentInstances()
     {
         var testConfig = new DatabaseConfig { ConnectionString = "test", Timeout = 30 };
         var rules = new List<ConfigRule>
@@ -96,19 +92,21 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
-        TrackForDisposal(configManager);
+        var configManager1 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        TrackForDisposal(configManager1);
 
-        var result1 = configManager.Initialize();
-        var result2 = configManager.Initialize(); // Second call should be safe
+        var configManager2 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        TrackForDisposal(configManager2);
 
-        Assert.Same(configManager, result1);
-        Assert.Same(configManager, result2);
-        
-        // Verify configuration is still accessible
-        var config = configManager.GetConfig<DatabaseConfig>();
-        Assert.NotNull(config);
-        Assert.Equal("test", config.ConnectionString);
+        Assert.NotSame(configManager1, configManager2);
+
+        // Both should have accessible config
+        var config1 = configManager1.GetConfig<DatabaseConfig>();
+        var config2 = configManager2.GetConfig<DatabaseConfig>();
+        Assert.NotNull(config1);
+        Assert.NotNull(config2);
+        Assert.Equal("test", config1.ConnectionString);
+        Assert.Equal("test", config2.ConnectionString);
     }
 
     [Fact]
@@ -127,9 +125,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var result = configManager.GetConfig<DatabaseConfig>();
 
@@ -150,9 +147,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             configManager.GetConfig<ApiConfig>()); // Different type not configured
@@ -171,9 +167,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var success = configManager.TryGetConfig<DatabaseConfig>(out var result);
 
@@ -193,9 +188,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var success = configManager.TryGetConfig<ApiConfig>(out var result);
 
@@ -213,9 +207,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var result = configManager.GetRequiredConfig<DatabaseConfig>();
 
@@ -235,9 +228,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -272,9 +264,8 @@ public class ConfigManagerIsolationTests : IDisposable
             })
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var config = configManager.GetConfig<DatabaseConfig>();
 
@@ -296,9 +287,8 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(apiConfig)
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var dbResult = configManager.GetConfig<DatabaseConfig>();
         var apiResult = configManager.GetConfig<ApiConfig>();
@@ -336,10 +326,9 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
-        configManager.Initialize();
 
         // Verify initial state
         var initialResult = configManager.GetConfig<DatabaseConfig>();
@@ -388,10 +377,9 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Use longer debounce to test coalescing
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 100);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
-        configManager.Initialize();
 
 
         for (var i = 1; i < configs.Length; i++)
@@ -432,10 +420,9 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 200);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
-        configManager.Initialize();
 
 
         observable.OnNext(new() { ConnectionString = "change1", Timeout = 20 });
@@ -485,11 +472,10 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         TrackForDisposal(observable1);
         TrackForDisposal(observable2);
-        configManager.Initialize();
 
         // Initial state - rule2 should win (based on "last wins" rule order)
         var initialResult = configManager.GetConfig<DatabaseConfig>();
@@ -546,11 +532,9 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Short debounce to test rapid cancellation
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 30);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
-        
-        configManager.Initialize();
 
 
         const int totalChanges = 100; // 100 rapid changes to stress-test debounce/cancel
@@ -602,10 +586,9 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Longer debounce to test massive coalescing
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 200);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
-        configManager.Initialize();
 
 
         const int totalChanges = 200;
@@ -666,14 +649,12 @@ public class ConfigManagerIsolationTests : IDisposable
                 new()));
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         foreach (var obs in observables)
         {
             TrackForDisposal(obs);
         }
-
-        configManager.Initialize();
 
         // Initial state - last rule should win
         var initialResult = configManager.GetConfig<DatabaseConfig>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerIsolationTests.cs
@@ -72,7 +72,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         // Verify initialization by checking if configs are accessible
@@ -92,10 +92,10 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager1 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager1 = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager1);
 
-        var configManager2 = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager2 = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager2);
 
         Assert.NotSame(configManager1, configManager2);
@@ -125,7 +125,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var result = configManager.GetConfig<DatabaseConfig>();
@@ -147,7 +147,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -167,7 +167,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var success = configManager.TryGetConfig<DatabaseConfig>(out var result);
@@ -188,7 +188,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var success = configManager.TryGetConfig<ApiConfig>(out var result);
@@ -207,7 +207,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(expectedConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var result = configManager.GetRequiredConfig<DatabaseConfig>();
@@ -228,7 +228,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(testConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -264,7 +264,7 @@ public class ConfigManagerIsolationTests : IDisposable
             })
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var config = configManager.GetConfig<DatabaseConfig>();
@@ -287,7 +287,7 @@ public class ConfigManagerIsolationTests : IDisposable
             CreateStaticRule(apiConfig)
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
 
         var dbResult = configManager.GetConfig<DatabaseConfig>();
@@ -326,7 +326,7 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
 
@@ -377,7 +377,7 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Use longer debounce to test coalescing
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
 
@@ -420,7 +420,7 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
 
@@ -472,7 +472,7 @@ public class ConfigManagerIsolationTests : IDisposable
                 new())
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         TrackForDisposal(observable1);
         TrackForDisposal(observable2);
@@ -532,7 +532,7 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Short debounce to test rapid cancellation
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
 
@@ -586,7 +586,7 @@ public class ConfigManagerIsolationTests : IDisposable
         };
 
         // Longer debounce to test massive coalescing
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(200));
         TrackForDisposal(configManager);
         TrackForDisposal(observable);
 
@@ -649,7 +649,7 @@ public class ConfigManagerIsolationTests : IDisposable
                 new()));
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         foreach (var obs in observables)
         {

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerJsonCorruptionTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerJsonCorruptionTests.cs
@@ -114,7 +114,7 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+            var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
             TrackForDisposal(configManager);
         });
         
@@ -153,7 +153,7 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var config = configManager.GetConfig<TestConfig>();
 
@@ -196,7 +196,7 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var config = configManager.GetConfig<TestConfig>();
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerJsonCorruptionTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerJsonCorruptionTests.cs
@@ -112,11 +112,11 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
                 new(Required: true))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
-        TrackForDisposal(configManager);
-
-
-        var exception = Assert.Throws<InvalidOperationException>(() => configManager.Initialize());
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+            TrackForDisposal(configManager);
+        });
         
         // The inner exception should be a JSON-related exception from the malformed JSON
         Assert.NotNull(exception.InnerException);
@@ -153,11 +153,8 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var config = configManager.GetConfig<TestConfig>();
 
 
@@ -199,11 +196,8 @@ public class ConfigManagerJsonCorruptionTests : IDisposable
                 new(Required: false))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var config = configManager.GetConfig<TestConfig>();
 
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerRuntimeErrorTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerRuntimeErrorTests.cs
@@ -57,8 +57,7 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
-            configManager.Initialize();
+            ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         });
 
         Assert.Contains("Required rule failed for FailableProvider", exception.Message);
@@ -86,11 +85,8 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
                 new(Required: true))
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
-
-
-        configManager.Initialize();
         var initialConfig = configManager.GetConfig<TestConfig>();
 
 
@@ -115,8 +111,7 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            var failingConfigManager = new ConfigManager(failingRules, logger: NullLogger.Instance);
-            failingConfigManager.Initialize();
+            ConfigManager.Create(c => c.WithConfiguration(failingRules).UseLogger(NullLogger.Instance));
         });
 
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerRuntimeErrorTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Managers/ConfigManagerRuntimeErrorTests.cs
@@ -57,7 +57,7 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+            ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         });
 
         Assert.Contains("Required rule failed for FailableProvider", exception.Message);
@@ -85,7 +85,7 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
                 new(Required: true))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance));
         TrackForDisposal(configManager);
         var initialConfig = configManager.GetConfig<TestConfig>();
 
@@ -111,7 +111,7 @@ public class ConfigManagerRuntimeErrorTests : IDisposable
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
         {
-            ConfigManager.Create(c => c.WithConfiguration(failingRules).UseLogger(NullLogger.Instance));
+            ConfigManager.Create(c => c.UseConfiguration(failingRules).UseLogger(NullLogger.Instance));
         });
 
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Providers/ObservableProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Providers/ObservableProviderIsolationTests.cs
@@ -1065,7 +1065,7 @@ public class ObservableProviderIsolationTests
             TestRules.ObservableString<TestConfig>(System.Reactive.Linq.Observable.Return(jsonString))
         };
 
-        var configManager = new ConfigManager(rules).Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
 
 
         var config = configManager.GetConfig<TestConfig>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Providers/ObservableProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Providers/ObservableProviderIsolationTests.cs
@@ -1065,7 +1065,7 @@ public class ObservableProviderIsolationTests
             TestRules.ObservableString<TestConfig>(System.Reactive.Linq.Observable.Return(jsonString))
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules));
 
 
         var config = configManager.GetConfig<TestConfig>();

--- a/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
@@ -417,9 +417,9 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Test", "Value": 789, "Enabled": true}""";
         
         // Verify rule can be used in ConfigManager
-        using var manager = new ConfigManager(rules => [
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json)
-        ]).Initialize();
+        ]));
         var config = manager.GetConfig<TestConfig>();
         
         Assert.NotNull(config);
@@ -434,9 +434,9 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Works", "Value": 456, "Enabled": false}""";
 
         // Verify rule works correctly
-        using var manager = new ConfigManager(rules => [
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json)
-        ]).Initialize();
+        ]));
         var config = manager.GetConfig<TestConfig>();
         
         Assert.NotNull(config);
@@ -449,9 +449,9 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Required", "Value": 123, "Enabled": true}""";
 
         // Verify required flag is set by checking health service
-        using var manager = new ConfigManager(rules => [
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json).Required()
-        ]).Initialize();
+        ]));
         var health = manager.GetHealthService().Snapshot;
         
         Assert.True(health.Rules[0].Required);
@@ -465,9 +465,9 @@ public class StaticJsonProviderIsolationTests
         Func<IConfigurationAccessor, bool> useWhen = (_) => Environment.GetEnvironmentVariable("TEST_ENV") == "true";
 
         // Verify the rule can be created and used
-        using var manager = new ConfigManager(rules => [
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json).When(useWhen)
-        ]).Initialize();
+        ]));
 
         // Use TryGetConfig since the rule may be skipped depending on TEST_ENV
         // GetConfig would throw if the condition is false and rule is skipped

--- a/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Providers/StaticJsonProviderIsolationTests.cs
@@ -417,7 +417,7 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Test", "Value": 789, "Enabled": true}""";
         
         // Verify rule can be used in ConfigManager
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json)
         ]));
         var config = manager.GetConfig<TestConfig>();
@@ -434,7 +434,7 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Works", "Value": 456, "Enabled": false}""";
 
         // Verify rule works correctly
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json)
         ]));
         var config = manager.GetConfig<TestConfig>();
@@ -449,7 +449,7 @@ public class StaticJsonProviderIsolationTests
         const string json = """{"Name": "Required", "Value": 123, "Enabled": true}""";
 
         // Verify required flag is set by checking health service
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json).Required()
         ]));
         var health = manager.GetHealthService().Snapshot;
@@ -465,7 +465,7 @@ public class StaticJsonProviderIsolationTests
         Func<IConfigurationAccessor, bool> useWhen = (_) => Environment.GetEnvironmentVariable("TEST_ENV") == "true";
 
         // Verify the rule can be created and used
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rules => [
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(json).When(useWhen)
         ]));
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
@@ -13,34 +13,34 @@ public class CocoarTestConfigurationTests
     }
 
     [Fact]
-    public void ReplaceAllRules_SetsContextInReplaceMode()
+    public void ReplaceConfiguration_SetsContextInReplaceMode()
     {
         // Act
-        CocoarTestConfiguration.ReplaceAllRules(rule => [
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]);
 
         // Assert
         Assert.True(CocoarTestConfiguration.IsActive);
         Assert.NotNull(CocoarTestConfiguration.Current);
-        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.ConfigurationMode);
 
         // Cleanup
         CocoarTestConfiguration.Clear();
     }
 
     [Fact]
-    public void AppendTestRules_SetsContextInAppendMode()
+    public void AppendConfiguration_SetsContextInAppendMode()
     {
         // Act
-        CocoarTestConfiguration.AppendTestRules(rule => [
+        CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]);
 
         // Assert
         Assert.True(CocoarTestConfiguration.IsActive);
         Assert.NotNull(CocoarTestConfiguration.Current);
-        Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current!.Mode);
+        Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current!.ConfigurationMode);
 
         // Cleanup
         CocoarTestConfiguration.Clear();
@@ -50,7 +50,7 @@ public class CocoarTestConfigurationTests
     public void Clear_RemovesContext()
     {
         // Arrange
-        CocoarTestConfiguration.ReplaceAllRules(rule => [
+        CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]);
         Assert.True(CocoarTestConfiguration.IsActive);
@@ -64,15 +64,15 @@ public class CocoarTestConfigurationTests
     }
 
     [Fact]
-    public void ReplaceAllRules_ThrowsOnNullRules()
+    public void ReplaceConfiguration_ThrowsOnNullRules()
     {
-        Assert.Throws<ArgumentNullException>(() => CocoarTestConfiguration.ReplaceAllRules(null!));
+        Assert.Throws<ArgumentNullException>(() => CocoarTestConfiguration.ReplaceConfiguration(null!));
     }
 
     [Fact]
-    public void AppendTestRules_ThrowsOnNullRules()
+    public void AppendConfiguration_ThrowsOnNullRules()
     {
-        Assert.Throws<ArgumentNullException>(() => CocoarTestConfiguration.AppendTestRules(null!));
+        Assert.Throws<ArgumentNullException>(() => CocoarTestConfiguration.AppendConfiguration(null!));
     }
 
     private sealed class TestConfig
@@ -89,34 +89,34 @@ public class TestConfigurationScopeTests
     }
 
     [Fact]
-    public void ReplaceAllRules_ReturnsScope()
+    public void ReplaceConfiguration_ReturnsBuilder()
     {
         // Act
-        var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        var builder = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]);
 
-        // Assert
-        Assert.True(scope.IsActive);
+        // Assert — builder is active (auto-activated)
+        Assert.True(CocoarTestConfiguration.IsActive);
 
         // Cleanup
-        scope.Dispose();
+        builder.Dispose();
         Assert.False(CocoarTestConfiguration.IsActive);
     }
 
     [Fact]
-    public void AppendTestRules_ReturnsScope()
+    public void AppendConfiguration_ReturnsBuilder()
     {
         // Act
-        var scope = CocoarTestConfiguration.AppendTestRules(rule => [
+        var builder = CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]);
 
         // Assert
-        Assert.True(scope.IsActive);
+        Assert.True(CocoarTestConfiguration.IsActive);
 
         // Cleanup
-        scope.Dispose();
+        builder.Dispose();
         Assert.False(CocoarTestConfiguration.IsActive);
     }
 
@@ -127,11 +127,10 @@ public class TestConfigurationScopeTests
         Assert.False(CocoarTestConfiguration.IsActive);
 
         // Act & Assert
-        using (var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        using (var scope = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
         ]))
         {
-            Assert.True(scope.IsActive);
             Assert.True(CocoarTestConfiguration.IsActive);
         }
 
@@ -148,7 +147,7 @@ public class TestConfigurationScopeTests
         // Act
         try
         {
-            using var scope = CocoarTestConfiguration.ReplaceAllRules(rule => [
+            using var scope = CocoarTestConfiguration.ReplaceConfiguration(rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
             ]);
 
@@ -168,13 +167,13 @@ public class TestConfigurationScopeTests
     public void UsingPattern_WorksAsExpected()
     {
         // Arrange & Act
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "scoped-test" })
         ]);
 
         // Assert
         Assert.True(CocoarTestConfiguration.IsActive);
-        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current!.ConfigurationMode);
     }
 
     private sealed class TestConfig
@@ -186,29 +185,6 @@ public class TestConfigurationScopeTests
 public class TestConfigurationContextTests
 {
     [Fact]
-    public void Constructor_SetsPropertiesCorrectly()
-    {
-        // Arrange
-        Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
-            rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
-        ];
-
-        // Act
-        var context = new TestConfigurationContext(rules, TestConfigurationMode.Replace);
-
-        // Assert
-        Assert.Same(rules, context.Rules);
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
-    }
-
-    [Fact]
-    public void Constructor_ThrowsOnNullRules()
-    {
-        Assert.Throws<ArgumentNullException>(() =>
-            new TestConfigurationContext(null!, TestConfigurationMode.Replace));
-    }
-
-    [Fact]
     public void Replace_CreatesContextInReplaceMode()
     {
         // Act
@@ -217,7 +193,7 @@ public class TestConfigurationContextTests
         ]);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
     }
 
@@ -230,7 +206,7 @@ public class TestConfigurationContextTests
         ]);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Append, context.Mode);
+        Assert.Equal(TestConfigurationMode.Append, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
     }
 
@@ -244,6 +220,78 @@ public class TestConfigurationContextTests
     public void Append_ThrowsOnNullRules()
     {
         Assert.Throws<ArgumentNullException>(() => TestConfigurationContext.Append(null!));
+    }
+
+    private sealed class TestConfig
+    {
+        public string Value { get; set; } = "";
+    }
+}
+
+public class TestOverrideBuilderTests
+{
+    [Fact]
+    public void Builder_ReplaceConfiguration_SetsReplaceMode()
+    {
+        // Arrange & Act
+        var context = new TestOverrideBuilder()
+            .ReplaceConfiguration(rule => [
+                rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
+            ])
+            .Build();
+
+        // Assert
+        Assert.Equal(TestConfigurationMode.Replace, context.ConfigurationMode);
+        Assert.NotNull(context.Rules);
+    }
+
+    [Fact]
+    public void Builder_AppendConfiguration_SetsAppendMode()
+    {
+        // Arrange & Act
+        var context = new TestOverrideBuilder()
+            .AppendConfiguration(rule => [
+                rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
+            ])
+            .Build();
+
+        // Assert
+        Assert.Equal(TestConfigurationMode.Append, context.ConfigurationMode);
+        Assert.NotNull(context.Rules);
+    }
+
+    [Fact]
+    public void Builder_ReplaceConfiguration_ThrowsOnNullRules()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new TestOverrideBuilder().ReplaceConfiguration(null!));
+    }
+
+    [Fact]
+    public void Builder_AppendConfiguration_ThrowsOnNullRules()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new TestOverrideBuilder().AppendConfiguration(null!));
+    }
+
+    [Fact]
+    public void Builder_Build_DoesNotActivate()
+    {
+        // Arrange
+        CocoarTestConfiguration.Clear();
+
+        // Act — fixture pattern: build without activating
+        var context = new TestOverrideBuilder()
+            .ReplaceConfiguration(rule => [
+                rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
+            ])
+            .Build();
+
+        // Assert — not yet active
+        Assert.False(CocoarTestConfiguration.IsActive);
+        Assert.NotNull(context);
+
+        CocoarTestConfiguration.Clear();
     }
 
     private sealed class TestConfig
@@ -362,7 +410,7 @@ public class ConfigManagerIntegrationTests
     public void ConfigManager_AppliesTestOverrides_ReplaceMode()
     {
         // Arrange
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(rule => [
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "test-connection",
@@ -390,7 +438,7 @@ public class ConfigManagerIntegrationTests
     public void ConfigManager_AppliesTestOverrides_AppendMode()
     {
         // Arrange
-        using var _ = CocoarTestConfiguration.AppendTestRules(rule => [
+        using var _ = CocoarTestConfiguration.AppendConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 MaxConnections = 999
@@ -478,46 +526,7 @@ public class SetupOverrideTests
     }
 
     [Fact]
-    public void WithSetup_SetsContextWithSetup()
-    {
-        // Arrange
-        Func<SetupBuilder, SetupDefinition[]> setup = builder => [];
-
-        // Act
-        using var _ = CocoarTestConfiguration.WithSetup(setup);
-
-        // Assert
-        Assert.True(CocoarTestConfiguration.IsActive);
-        Assert.NotNull(CocoarTestConfiguration.Current);
-        Assert.NotNull(CocoarTestConfiguration.Current!.Setup);
-        Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current.Mode);
-
-        // Cleanup
-        CocoarTestConfiguration.Clear();
-    }
-
-    [Fact]
-    public void WithSetup_ThrowsOnNullSetup()
-    {
-        Assert.Throws<ArgumentNullException>(() => CocoarTestConfiguration.WithSetup(null!));
-    }
-
-    [Fact]
-    public void WithSetup_ReturnsScope()
-    {
-        // Act
-        var scope = CocoarTestConfiguration.WithSetup(setup => []);
-
-        // Assert
-        Assert.True(scope.IsActive);
-
-        // Cleanup
-        scope.Dispose();
-        Assert.False(CocoarTestConfiguration.IsActive);
-    }
-
-    [Fact]
-    public void ReplaceAllRules_WithSetup_SetsContextWithBothRulesAndSetup()
+    public void ReplaceConfiguration_WithSetup_SetsContextWithBothRulesAndSetup()
     {
         // Arrange
         Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
@@ -526,21 +535,21 @@ public class SetupOverrideTests
         Func<SetupBuilder, SetupDefinition[]> setup = builder => [];
 
         // Act
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(rules, setup);
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(rules, setup);
 
         // Assert
         Assert.True(CocoarTestConfiguration.IsActive);
         Assert.NotNull(CocoarTestConfiguration.Current);
         Assert.NotNull(CocoarTestConfiguration.Current!.Rules);
         Assert.NotNull(CocoarTestConfiguration.Current.Setup);
-        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, CocoarTestConfiguration.Current.ConfigurationMode);
 
         // Cleanup
         CocoarTestConfiguration.Clear();
     }
 
     [Fact]
-    public void AppendTestRules_WithSetup_SetsContextWithBothRulesAndSetup()
+    public void AppendConfiguration_WithSetup_SetsContextWithBothRulesAndSetup()
     {
         // Arrange
         Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
@@ -549,14 +558,14 @@ public class SetupOverrideTests
         Func<SetupBuilder, SetupDefinition[]> setup = builder => [];
 
         // Act
-        using var _ = CocoarTestConfiguration.AppendTestRules(rules, setup);
+        using var _ = CocoarTestConfiguration.AppendConfiguration(rules, setup);
 
         // Assert
         Assert.True(CocoarTestConfiguration.IsActive);
         Assert.NotNull(CocoarTestConfiguration.Current);
         Assert.NotNull(CocoarTestConfiguration.Current!.Rules);
         Assert.NotNull(CocoarTestConfiguration.Current.Setup);
-        Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current.Mode);
+        Assert.Equal(TestConfigurationMode.Append, CocoarTestConfiguration.Current.ConfigurationMode);
 
         // Cleanup
         CocoarTestConfiguration.Clear();
@@ -571,41 +580,6 @@ public class SetupOverrideTests
 public class TestConfigurationContextSetupTests
 {
     [Fact]
-    public void Constructor_WithSetup_SetsAllProperties()
-    {
-        // Arrange
-        Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
-            rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
-        ];
-        Func<SetupBuilder, SetupDefinition[]> setup = builder => [];
-
-        // Act
-        var context = new TestConfigurationContext(rules, TestConfigurationMode.Replace, setup);
-
-        // Assert
-        Assert.Same(rules, context.Rules);
-        Assert.Same(setup, context.Setup);
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
-    }
-
-    [Fact]
-    public void Constructor_WithoutSetup_SetsSetupToNull()
-    {
-        // Arrange
-        Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
-            rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
-        ];
-
-        // Act
-        var context = new TestConfigurationContext(rules, TestConfigurationMode.Replace);
-
-        // Assert
-        Assert.Same(rules, context.Rules);
-        Assert.Null(context.Setup);
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
-    }
-
-    [Fact]
     public void Replace_WithSetup_CreatesContextWithSetup()
     {
         // Arrange
@@ -619,7 +593,7 @@ public class TestConfigurationContextSetupTests
             setup);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Replace, context.Mode);
+        Assert.Equal(TestConfigurationMode.Replace, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
         Assert.Same(setup, context.Setup);
     }
@@ -638,9 +612,29 @@ public class TestConfigurationContextSetupTests
             setup);
 
         // Assert
-        Assert.Equal(TestConfigurationMode.Append, context.Mode);
+        Assert.Equal(TestConfigurationMode.Append, context.ConfigurationMode);
         Assert.NotNull(context.Rules);
         Assert.Same(setup, context.Setup);
+    }
+
+    [Fact]
+    public void Builder_WithRulesAndSetup_BuiltContextHasBoth()
+    {
+        // Arrange
+        Func<Fluent.RulesBuilder, Rules.ConfigRule[]> rules = rule => [
+            rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
+        ];
+        Func<SetupBuilder, SetupDefinition[]> setup = builder => [];
+
+        // Act
+        var context = new TestOverrideBuilder()
+            .ReplaceConfiguration(rules, setup)
+            .Build();
+
+        // Assert
+        Assert.Same(rules, context.Rules);
+        Assert.Same(setup, context.Setup);
+        Assert.Equal(TestConfigurationMode.Replace, context.ConfigurationMode);
     }
 
     private sealed class TestConfig
@@ -657,11 +651,11 @@ public class ConfigManagerSetupIntegrationTests
     }
 
     [Fact]
-    public void ConfigManager_AppliesTestSetupOverrides_WithReplaceAllRules()
+    public void ConfigManager_AppliesTestSetupOverrides_WithReplaceConfiguration()
     {
         // Arrange
         var testSetupCalled = false;
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
             ],
@@ -683,11 +677,11 @@ public class ConfigManagerSetupIntegrationTests
     }
 
     [Fact]
-    public void ConfigManager_AppliesTestSetupOverrides_WithAppendTestRules()
+    public void ConfigManager_AppliesTestSetupOverrides_WithAppendConfiguration()
     {
         // Arrange
         var testSetupCalled = false;
-        using var _ = CocoarTestConfiguration.AppendTestRules(
+        using var _ = CocoarTestConfiguration.AppendConfiguration(
             rule => [],
             setup =>
             {
@@ -707,64 +701,11 @@ public class ConfigManagerSetupIntegrationTests
     }
 
     [Fact]
-    public void ConfigManager_AppliesTestSetupOverrides_WithSetupOnly()
-    {
-        // Arrange
-        var testSetupCalled = false;
-        using var _ = CocoarTestConfiguration.WithSetup(setup =>
-        {
-            testSetupCalled = true;
-            return [];
-        });
-
-        // Act
-        var configManager = ConfigManager.Create(c => c.UseConfiguration(
-            rule => [
-                rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
-            ],
-            setup => []));
-
-        // Assert - Original rules should still work
-        var config = configManager.GetRequiredConfig<TestConfig>();
-        Assert.Equal("original", config.Value);
-        Assert.True(testSetupCalled);
-    }
-
-    [Fact]
-    public void ConfigManager_MergesConfiguredAndTestSetup()
-    {
-        // Arrange
-        var configuredSetupCalled = false;
-        var testSetupCalled = false;
-
-        using var _ = CocoarTestConfiguration.WithSetup(setup =>
-        {
-            testSetupCalled = true;
-            return [];
-        });
-
-        // Act
-        var configManager = ConfigManager.Create(c => c.UseConfiguration(
-            rule => [
-                rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
-            ],
-            setup =>
-            {
-                configuredSetupCalled = true;
-                return [];
-            }));
-
-        // Assert - Both setups should be called (merged)
-        Assert.True(configuredSetupCalled);
-        Assert.True(testSetupCalled);
-    }
-
-    [Fact]
     public void ConfigManager_WorksWithoutSetup_WhenTestSetupIsNull()
     {
         // Arrange
         var configuredSetupCalled = false;
-        using var _ = CocoarTestConfiguration.ReplaceAllRules(
+        using var _ = CocoarTestConfiguration.ReplaceConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "test" })
             ]); // No setup parameter

--- a/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
@@ -371,7 +371,7 @@ public class ConfigManagerIntegrationTests
         ]);
 
         // Act - ConfigManager with original rules
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
@@ -398,7 +398,7 @@ public class ConfigManagerIntegrationTests
         ]);
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
@@ -418,7 +418,7 @@ public class ConfigManagerIntegrationTests
         // Arrange - No test configuration set
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "normal-connection",
@@ -448,7 +448,7 @@ public class ConfigManagerIntegrationTests
         using var _ = CocoarTestConfiguration.Apply(context);
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
@@ -672,7 +672,7 @@ public class ConfigManagerSetupIntegrationTests
             });
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -696,7 +696,7 @@ public class ConfigManagerSetupIntegrationTests
             });
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -718,7 +718,7 @@ public class ConfigManagerSetupIntegrationTests
         });
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -744,7 +744,7 @@ public class ConfigManagerSetupIntegrationTests
         });
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -770,7 +770,7 @@ public class ConfigManagerSetupIntegrationTests
             ]); // No setup parameter
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -802,7 +802,7 @@ public class ConfigManagerSetupIntegrationTests
         using var _ = CocoarTestConfiguration.Apply(context);
 
         // Act
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],

--- a/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/Testing/CocoarTestConfigurationTests.cs
@@ -371,14 +371,13 @@ public class ConfigManagerIntegrationTests
         ]);
 
         // Act - ConfigManager with original rules
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
                 MaxConnections = 10
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var config = configManager.GetRequiredConfig<TestConfig>();
 
@@ -399,14 +398,13 @@ public class ConfigManagerIntegrationTests
         ]);
 
         // Act
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
                 MaxConnections = 10
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var config = configManager.GetRequiredConfig<TestConfig>();
 
@@ -420,14 +418,13 @@ public class ConfigManagerIntegrationTests
         // Arrange - No test configuration set
 
         // Act
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "normal-connection",
                 MaxConnections = 50
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var config = configManager.GetRequiredConfig<TestConfig>();
 
@@ -451,14 +448,13 @@ public class ConfigManagerIntegrationTests
         using var _ = CocoarTestConfiguration.Apply(context);
 
         // Act
-        var configManager = new ConfigManager(rule => [
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<TestConfig>().FromStatic(_ => new TestConfig
             {
                 Connection = "original-connection",
                 MaxConnections = 10
             })
-        ]);
-        configManager.Initialize();
+        ]));
 
         var config = configManager.GetRequiredConfig<TestConfig>();
 
@@ -676,12 +672,11 @@ public class ConfigManagerSetupIntegrationTests
             });
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
-            setup => []);
-        configManager.Initialize();
+            setup => []));
 
         // Assert
         Assert.True(testSetupCalled);
@@ -701,12 +696,11 @@ public class ConfigManagerSetupIntegrationTests
             });
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
-            setup => []);
-        configManager.Initialize();
+            setup => []));
 
         // Assert
         Assert.True(testSetupCalled);
@@ -724,12 +718,11 @@ public class ConfigManagerSetupIntegrationTests
         });
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
-            setup => []);
-        configManager.Initialize();
+            setup => []));
 
         // Assert - Original rules should still work
         var config = configManager.GetRequiredConfig<TestConfig>();
@@ -751,7 +744,7 @@ public class ConfigManagerSetupIntegrationTests
         });
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -759,8 +752,7 @@ public class ConfigManagerSetupIntegrationTests
             {
                 configuredSetupCalled = true;
                 return [];
-            });
-        configManager.Initialize();
+            }));
 
         // Assert - Both setups should be called (merged)
         Assert.True(configuredSetupCalled);
@@ -778,7 +770,7 @@ public class ConfigManagerSetupIntegrationTests
             ]); // No setup parameter
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
@@ -786,8 +778,7 @@ public class ConfigManagerSetupIntegrationTests
             {
                 configuredSetupCalled = true;
                 return [];
-            });
-        configManager.Initialize();
+            }));
 
         // Assert - Configured setup should still run
         Assert.True(configuredSetupCalled);
@@ -811,12 +802,11 @@ public class ConfigManagerSetupIntegrationTests
         using var _ = CocoarTestConfiguration.Apply(context);
 
         // Act
-        var configManager = new ConfigManager(
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(
             rule => [
                 rule.For<TestConfig>().FromStatic(_ => new TestConfig { Value = "original" })
             ],
-            setup => []);
-        configManager.Initialize();
+            setup => []));
 
         // Assert
         Assert.True(testSetupCalled);

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/AdvancedCancellationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/AdvancedCancellationTests.cs
@@ -60,7 +60,7 @@ public class AdvancedCancellationTests : IDisposable
                 new())
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
         TrackForDisposal(configManager);
 
         // Wait for initial configuration
@@ -108,7 +108,7 @@ public class AdvancedCancellationTests : IDisposable
                 typeof(CancellationConfig),
                 new())).ToList();
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
 
         // Wait for initial state
@@ -161,7 +161,7 @@ public class AdvancedCancellationTests : IDisposable
                 new())
         };
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
 
         // Track emissions

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/AdvancedCancellationTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/AdvancedCancellationTests.cs
@@ -60,9 +60,8 @@ public class AdvancedCancellationTests : IDisposable
                 new())
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 30);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Wait for initial configuration
         await ActiveWaitHelpers.WaitUntilAsync(
@@ -109,9 +108,8 @@ public class AdvancedCancellationTests : IDisposable
                 typeof(CancellationConfig),
                 new())).ToList();
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 100);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Wait for initial state
         await ActiveWaitHelpers.WaitUntilAsync(
@@ -163,9 +161,8 @@ public class AdvancedCancellationTests : IDisposable
                 new())
         };
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         // Track emissions
         var emissionCount = 0;

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
@@ -85,9 +85,8 @@ public class DifferentialCorrectnessFuzzTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var random = new Random(42); // Deterministic seed for reproducible tests
 
@@ -185,9 +184,8 @@ public class DifferentialCorrectnessFuzzTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 100);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
 
         for (var burst = 0; burst < 3; burst++)

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/DifferentialCorrectnessFuzzTests.cs
@@ -85,7 +85,7 @@ public class DifferentialCorrectnessFuzzTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
 
         var random = new Random(42); // Deterministic seed for reproducible tests
@@ -184,7 +184,7 @@ public class DifferentialCorrectnessFuzzTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
 
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/InterfaceReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/InterfaceReactiveConfigTests.cs
@@ -55,7 +55,7 @@ public class InterfaceReactiveConfigTests
         ConfigRule[] rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
     {
-        return new ConfigManager(rules, setup, logger: NullLogger.Instance, debounceMilliseconds: 10).Initialize();
+        return ConfigManager.Create(c => c.WithConfiguration(rules, setup).UseLogger(NullLogger.Instance).UseDebounce(10));
     }
 
     [Fact]

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/InterfaceReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/InterfaceReactiveConfigTests.cs
@@ -55,7 +55,7 @@ public class InterfaceReactiveConfigTests
         ConfigRule[] rules,
         Func<SetupBuilder, SetupDefinition[]>? setup = null)
     {
-        return ConfigManager.Create(c => c.WithConfiguration(rules, setup).UseLogger(NullLogger.Instance).UseDebounce(10));
+        return ConfigManager.Create(c => c.UseConfiguration(rules, setup).UseLogger(NullLogger.Instance).UseDebounce(10));
     }
 
     [Fact]

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/RecomputeStressTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/RecomputeStressTests.cs
@@ -81,9 +81,8 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 20);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(20));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var initialMemory = GC.GetTotalMemory(true);
 
@@ -165,9 +164,8 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 100);
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
-        configManager.Initialize();
 
         var publicationCount = 0;
         var reactive = configManager.GetReactiveConfig<StressConfig>();
@@ -248,12 +246,10 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 50);
-        TrackForDisposal(configManager);
-
         var initialMemory = GC.GetTotalMemory(true);
-        
-        configManager.Initialize();
+
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        TrackForDisposal(configManager);
         
         // Wait for initial configuration
         await ActiveWaitHelpers.WaitUntilAsync(
@@ -338,8 +334,7 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 30);
-        configManager.Initialize();
+        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
 
 
         var changeTask = Task.Run(async () =>

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/RecomputeStressTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/RecomputeStressTests.cs
@@ -81,7 +81,7 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(20));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(20));
         TrackForDisposal(configManager);
 
         var initialMemory = GC.GetTotalMemory(true);
@@ -164,7 +164,7 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(100));
         TrackForDisposal(configManager);
 
         var publicationCount = 0;
@@ -248,7 +248,7 @@ public class RecomputeStressTests : IDisposable
 
         var initialMemory = GC.GetTotalMemory(true);
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(50));
         TrackForDisposal(configManager);
         
         // Wait for initial configuration
@@ -334,7 +334,7 @@ public class RecomputeStressTests : IDisposable
             rules.Add(rule);
         }
 
-        var configManager = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
+        var configManager = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(30));
 
 
         var changeTask = Task.Run(async () =>

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
@@ -19,7 +19,7 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Unconfigured_Primitive_Fails()
     {
-        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
+        var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{
             CreateStaticRule(new App(1))
         }).UseLogger(NullLogger.Instance));
         // int is not a configured type; guard should throw
@@ -29,7 +29,7 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Exposed_Interface_Succeeds()
     {
-        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
+        var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{
             CreateStaticRule(new App(2))
         }, setup => [setup.ConcreteType<App>().ExposeAs<IApp>()]).UseLogger(NullLogger.Instance));
         var cfg = mgr.GetReactiveConfig<(IApp,App)>();
@@ -41,7 +41,7 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Unexposed_Interface_Fails()
     {
-        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
+        var mgr = ConfigManager.Create(c => c.UseConfiguration(new[]{
             CreateStaticRule(new App(3))
         }).UseLogger(NullLogger.Instance));
         Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(IApp,App)>());

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigGuardTests.cs
@@ -19,9 +19,9 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Unconfigured_Primitive_Fails()
     {
-        var mgr = new ConfigManager(new[]{ 
+        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
             CreateStaticRule(new App(1))
-        }, logger: NullLogger.Instance).Initialize();
+        }).UseLogger(NullLogger.Instance));
         // int is not a configured type; guard should throw
         Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(App,int)>());
     }
@@ -29,9 +29,9 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Exposed_Interface_Succeeds()
     {
-        var mgr = new ConfigManager(new[]{ 
+        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
             CreateStaticRule(new App(2))
-        }, c => [c.ConcreteType<App>().ExposeAs<IApp>()], NullLogger.Instance).Initialize();
+        }, setup => [setup.ConcreteType<App>().ExposeAs<IApp>()]).UseLogger(NullLogger.Instance));
         var cfg = mgr.GetReactiveConfig<(IApp,App)>();
         var snapshot = cfg.CurrentValue;
         Assert.Equal(2, snapshot.Item1.V);
@@ -41,9 +41,9 @@ public class TupleReactiveConfigGuardTests
     [Fact]
     public void Tuple_With_Unexposed_Interface_Fails()
     {
-        var mgr = new ConfigManager(new[]{ 
+        var mgr = ConfigManager.Create(c => c.WithConfiguration(new[]{
             CreateStaticRule(new App(3))
-        }, logger: NullLogger.Instance).Initialize();
+        }).UseLogger(NullLogger.Instance));
         Assert.Throws<InvalidOperationException>(() => mgr.GetReactiveConfig<(IApp,App)>());
     }
 }

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
@@ -19,7 +19,7 @@ public class TupleReactiveConfigTests
 
     private static ConfigManager Create(params ConfigRule[] rules)
     {
-        var mgr = new ConfigManager(rules, logger: NullLogger.Instance, debounceMilliseconds: 10).Initialize();
+        var mgr = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(10));
         return mgr;
     }
 

--- a/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
+++ b/src/tests/Cocoar.Configuration.Core.Tests/WhiteBox/TupleReactiveConfigTests.cs
@@ -19,7 +19,7 @@ public class TupleReactiveConfigTests
 
     private static ConfigManager Create(params ConfigRule[] rules)
     {
-        var mgr = ConfigManager.Create(c => c.WithConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(10));
+        var mgr = ConfigManager.Create(c => c.UseConfiguration(rules).UseLogger(NullLogger.Instance).UseDebounce(10));
         return mgr;
     }
 

--- a/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
@@ -26,9 +26,9 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Register WITHOUT setup.ConcreteType<>() call
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
-        ]);
+        ]));
         
         // Assert - Type should still be injectable
         var sp = services.BuildServiceProvider();
@@ -46,11 +46,11 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Multiple rules, no explicit setup
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required(),
             rules.For<DatabaseConfig>().FromStaticJson("{\"Host\":\"localhost\",\"Port\":5432}").Required(),
             rules.For<FeatureFlags>().FromStaticJson("{\"EnableNewUI\":true,\"EnableBetaFeatures\":false}").Required()
-        ]);
+        ]));
         
         // Assert - All types should be injectable
         var sp = services.BuildServiceProvider();
@@ -73,10 +73,10 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
-        ]);
-        
+        ]));
+
         // Assert - Check that AppConfig is registered as Scoped
         var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(AppConfig));
         Assert.NotNull(descriptor);
@@ -89,9 +89,9 @@ public class AutomaticRegistrationTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // All scopes receive the same cached instance.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
 
@@ -120,12 +120,12 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
-        ]);
-        
+        ]));
+
         var sp = services.BuildServiceProvider();
-        
+
         // Act - Get instances from same scope
         using var scope = sp.CreateScope();
         var instance1 = scope.ServiceProvider.GetRequiredService<AppConfig>();
@@ -142,11 +142,11 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Explicit setup.ConcreteType() should take precedence
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ], setup => [
             setup.ConcreteType<AppConfig>().AsSingleton()
-        ]);
+        ]));
         
         var sp = services.BuildServiceProvider();
         
@@ -163,10 +163,10 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
-        ]);
-        
+        ]));
+
         // Assert - IReactiveConfig<T> should also be available
         var sp = services.BuildServiceProvider();
         var reactiveConfig = sp.GetService<IReactiveConfig<AppConfig>>();
@@ -185,11 +185,11 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Explicitly disable auto-registration
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ], setup => [
             setup.ConcreteType<AppConfig>().DisableAutoRegistration()
-        ]);
+        ]));
         
         // Assert - Type should NOT be registered
         var sp = services.BuildServiceProvider();
@@ -211,10 +211,10 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Same type from multiple rules (layering)
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"BaseApp\",\"Version\":1}").Required(),
             rules.For<AppConfig>().FromStaticJson("{\"Version\":2}").Required() // Overrides Version
-        ]);
+        ]));
         
         // Assert - Should get merged config
         var sp = services.BuildServiceProvider();

--- a/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/AutomaticRegistrationTests.cs
@@ -26,7 +26,7 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Register WITHOUT setup.ConcreteType<>() call
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]));
         
@@ -46,7 +46,7 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Multiple rules, no explicit setup
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required(),
             rules.For<DatabaseConfig>().FromStaticJson("{\"Host\":\"localhost\",\"Port\":5432}").Required(),
             rules.For<FeatureFlags>().FromStaticJson("{\"EnableNewUI\":true,\"EnableBetaFeatures\":false}").Required()
@@ -73,7 +73,7 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]));
 
@@ -89,7 +89,7 @@ public class AutomaticRegistrationTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // All scopes receive the same cached instance.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]));
 
@@ -120,7 +120,7 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]));
 
@@ -142,7 +142,7 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Explicit setup.ConcreteType() should take precedence
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ], setup => [
             setup.ConcreteType<AppConfig>().AsSingleton()
@@ -163,7 +163,7 @@ public class AutomaticRegistrationTests
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ]));
 
@@ -185,7 +185,7 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Explicitly disable auto-registration
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"TestApp\",\"Version\":1}").Required()
         ], setup => [
             setup.ConcreteType<AppConfig>().DisableAutoRegistration()
@@ -211,7 +211,7 @@ public class AutomaticRegistrationTests
         var services = new ServiceCollection();
         
         // Act - Same type from multiple rules (layering)
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppConfig>().FromStaticJson("{\"Name\":\"BaseApp\",\"Version\":1}").Required(),
             rules.For<AppConfig>().FromStaticJson("{\"Version\":2}").Required() // Overrides Version
         ]));

--- a/src/tests/Cocoar.Configuration.DI.Tests/BuilderPatternApiTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/BuilderPatternApiTests.cs
@@ -16,13 +16,13 @@ public class BuilderPatternApiTests
     public void Builder_Pattern_Works_With_Multiple_Types()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required(),
             rules.For<AppImpl>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new AppImpl(42))).Required()
         ], setup => [
             setup.ConcreteType<TestConfig>().ExposeAs<ITestConfig>(),
             setup.ConcreteType<AppImpl>()
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         

--- a/src/tests/Cocoar.Configuration.DI.Tests/BuilderPatternApiTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/BuilderPatternApiTests.cs
@@ -16,7 +16,7 @@ public class BuilderPatternApiTests
     public void Builder_Pattern_Works_With_Multiple_Types()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required(),
             rules.For<AppImpl>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new AppImpl(42))).Required()
         ], setup => [

--- a/src/tests/Cocoar.Configuration.DI.Tests/ConfigureLifetimeAndKeyTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ConfigureLifetimeAndKeyTests.cs
@@ -17,7 +17,7 @@ public class ConfigureLifetimeAndKeyTests
     public void Reactive_Config_Registered_When_Opted_In()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<AppImpl>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new AppImpl(5))).Required()
         ], setup => [
             setup.ConcreteType<AppImpl>() // reactive always available

--- a/src/tests/Cocoar.Configuration.DI.Tests/ConfigureLifetimeAndKeyTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ConfigureLifetimeAndKeyTests.cs
@@ -17,11 +17,11 @@ public class ConfigureLifetimeAndKeyTests
     public void Reactive_Config_Registered_When_Opted_In()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<AppImpl>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new AppImpl(5))).Required()
         ], setup => [
             setup.ConcreteType<AppImpl>() // reactive always available
-        ]);
+        ]));
         var sp = services.BuildServiceProvider();
         var mgr = sp.GetRequiredService<ConfigManager>();
         var reactive = sp.GetRequiredService<IReactiveConfig<AppImpl>>();

--- a/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
@@ -23,14 +23,14 @@ public class ExposedTypeRegistrationTests
     {
         // With Master Backplane architecture, all scopes receive the same cached instance
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
         ], setup => [
             // Provide the concrete mapping so ConfigManager can resolve the interface
             setup.ConcreteType<TestConfig>().ExposeAs<ITestConfig>(),
             // No lifetime capability specified for the exposed type => defaults to Scoped
             setup.ExposedType<ITestConfig>()
-        ]);
+        ]));
 
         using var sp = services.BuildServiceProvider();
         using var scope1 = sp.CreateScope();
@@ -54,13 +54,13 @@ public class ExposedTypeRegistrationTests
         // With Master Backplane architecture, all instances are the same cached object
         // regardless of DI lifetime settings
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
         ], setup => [
             setup.ConcreteType<TestConfig>().ExposeAs<ITestConfig>(),
             // Override default (non-keyed) to Singleton, disable default (redundant when overriding), and add a keyed transient
             setup.ExposedType<ITestConfig>().AsSingleton().DisableAutoRegistration().AsTransient("my-key")
-        ]);
+        ]));
 
         using var sp = services.BuildServiceProvider();
 

--- a/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ExposedTypeRegistrationTests.cs
@@ -23,7 +23,7 @@ public class ExposedTypeRegistrationTests
     {
         // With Master Backplane architecture, all scopes receive the same cached instance
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
         ], setup => [
             // Provide the concrete mapping so ConfigManager can resolve the interface
@@ -54,7 +54,7 @@ public class ExposedTypeRegistrationTests
         // With Master Backplane architecture, all instances are the same cached object
         // regardless of DI lifetime settings
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestConfig>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestConfig("Hello"))).Required()
         ], setup => [
             setup.ConcreteType<TestConfig>().ExposeAs<ITestConfig>(),

--- a/src/tests/Cocoar.Configuration.DI.Tests/ReactiveConfigAbsenceTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ReactiveConfigAbsenceTests.cs
@@ -15,7 +15,7 @@ public class ReactiveConfigAbsenceTests
     public void Reactive_Not_Registered_Unless_Opted_In()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<Foo>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new Foo(9))).Required()
         ], setup => [
             setup.ConcreteType<Foo>()

--- a/src/tests/Cocoar.Configuration.DI.Tests/ReactiveConfigAbsenceTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ReactiveConfigAbsenceTests.cs
@@ -15,11 +15,11 @@ public class ReactiveConfigAbsenceTests
     public void Reactive_Not_Registered_Unless_Opted_In()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<Foo>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new Foo(9))).Required()
         ], setup => [
             setup.ConcreteType<Foo>()
-        ]);
+        ]));
         var sp = services.BuildServiceProvider();
         // Now always registered
         var reactive = sp.GetRequiredService<IReactiveConfig<Foo>>();

--- a/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
@@ -29,11 +29,11 @@ public class ServiceLifetimeCapabilityTests
     public void AsSingleton_Should_Create_Same_Instance()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(42))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton()
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
@@ -47,11 +47,11 @@ public class ServiceLifetimeCapabilityTests
     public void RegisterAs_Singleton_Should_Create_Same_Instance()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(42))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Singleton)
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
@@ -67,11 +67,11 @@ public class ServiceLifetimeCapabilityTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // AsTransient affects DI container behavior but doesn't create new config instances.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsTransient()
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
@@ -87,11 +87,11 @@ public class ServiceLifetimeCapabilityTests
     {
         // With Master Backplane architecture, configuration instances are cached globally.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Transient)
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredService<TestService>();
@@ -106,11 +106,11 @@ public class ServiceLifetimeCapabilityTests
     public void WithKey_Should_Register_Keyed_Service()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(999))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Scoped, "my-key")
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance = sp.GetRequiredKeyedService<TestService>("my-key");
@@ -125,11 +125,11 @@ public class ServiceLifetimeCapabilityTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // All scopes receive the same cached instance.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(555))).Required()
         ], setup => [
             setup.ConcreteType<TestService>() // No explicit lifetime specified
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         using var scope1 = sp.CreateScope();
@@ -148,11 +148,11 @@ public class ServiceLifetimeCapabilityTests
     public void AsSingletonWithKey_Should_Register_Singleton_Keyed_Service()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(777))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton("singleton-key")
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
         var instance1 = sp.GetRequiredKeyedService<TestService>("singleton-key");
@@ -166,11 +166,11 @@ public class ServiceLifetimeCapabilityTests
     public void Skip_Should_Prevent_Service_Registration()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(888))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().DisableAutoRegistration()
-        ]);
+        ]));
 
         var sp = services.BuildServiceProvider();
 

--- a/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
+++ b/src/tests/Cocoar.Configuration.DI.Tests/ServiceLifetimeCapabilityTests.cs
@@ -29,7 +29,7 @@ public class ServiceLifetimeCapabilityTests
     public void AsSingleton_Should_Create_Same_Instance()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(42))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton()
@@ -47,7 +47,7 @@ public class ServiceLifetimeCapabilityTests
     public void RegisterAs_Singleton_Should_Create_Same_Instance()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(42))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Singleton)
@@ -67,7 +67,7 @@ public class ServiceLifetimeCapabilityTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // AsTransient affects DI container behavior but doesn't create new config instances.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsTransient()
@@ -87,7 +87,7 @@ public class ServiceLifetimeCapabilityTests
     {
         // With Master Backplane architecture, configuration instances are cached globally.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(123))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Transient)
@@ -106,7 +106,7 @@ public class ServiceLifetimeCapabilityTests
     public void WithKey_Should_Register_Keyed_Service()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(999))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().RegisterAs(ServiceLifetime.Scoped, "my-key")
@@ -125,7 +125,7 @@ public class ServiceLifetimeCapabilityTests
         // With Master Backplane architecture, configuration instances are cached globally.
         // All scopes receive the same cached instance.
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(555))).Required()
         ], setup => [
             setup.ConcreteType<TestService>() // No explicit lifetime specified
@@ -148,7 +148,7 @@ public class ServiceLifetimeCapabilityTests
     public void AsSingletonWithKey_Should_Register_Singleton_Keyed_Service()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(777))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().AsSingleton("singleton-key")
@@ -166,7 +166,7 @@ public class ServiceLifetimeCapabilityTests
     public void Skip_Should_Prevent_Service_Registration()
     {
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             rules.For<TestService>().FromStaticJson(System.Text.Json.JsonSerializer.Serialize(new TestService(888))).Required()
         ], setup => [
             setup.ConcreteType<TestService>().DisableAutoRegistration()

--- a/src/tests/Cocoar.Configuration.Providers.Tests/CommandLine/CommandLineArgumentProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/CommandLine/CommandLineArgumentProviderUnitTests.cs
@@ -22,8 +22,7 @@ public class CommandLineArgumentProviderUnitTests
     {
         var args = Array.Empty<string>();
         
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -37,8 +36,7 @@ public class CommandLineArgumentProviderUnitTests
     public void EqualsFormat_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -52,8 +50,7 @@ public class CommandLineArgumentProviderUnitTests
     public void SpaceFormat_ParsesCorrectly()
     {
         var args = new[] { "--host", "localhost", "--port", "8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -67,8 +64,7 @@ public class CommandLineArgumentProviderUnitTests
     public void MixedFormats_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "--port", "8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -82,8 +78,7 @@ public class CommandLineArgumentProviderUnitTests
     public void BooleanFlags_ParseAsTrue()
     {
         var args = new[] { "--debug", "--verbose" };
-        using var manager = new ConfigManager(rule => [rule.For<FlagsConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<FlagsConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<FlagsConfig>();
         Assert.NotNull(cfg);
@@ -97,8 +92,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NestedConfiguration_WithColon_ParsesCorrectly()
     {
         var args = new[] { "--database:host=localhost", "--database:port=5432", "--database:name=mydb" };
-        using var manager = new ConfigManager(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -114,8 +108,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NestedConfiguration_WithDoubleUnderscore_ParsesCorrectly()
     {
         var args = new[] { "--database__host=localhost", "--database__port=5432" };
-        using var manager = new ConfigManager(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -130,12 +123,11 @@ public class CommandLineArgumentProviderUnitTests
     public void SingleDashPrefix_ParsesCorrectly()
     {
         var args = new[] { "-host=localhost", "-port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["-"]
-        })]);
-        manager.Initialize();
+        })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -149,8 +141,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NonSwitchArguments_AreIgnored()
     {
         var args = new[] { "somecommand", "--host=localhost", "anotherarg", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -164,8 +155,7 @@ public class CommandLineArgumentProviderUnitTests
     public void CaseInsensitive_ParsesCorrectly()
     {
         var args = new[] { "--HOST=localhost", "--Port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -179,8 +169,7 @@ public class CommandLineArgumentProviderUnitTests
     public void FluentAPI_WithArgs_Works()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -194,8 +183,7 @@ public class CommandLineArgumentProviderUnitTests
     public void EmptyValueAfterEquals_ParsesAsEmptyString()
     {
         var args = new[] { "--host=", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -209,8 +197,7 @@ public class CommandLineArgumentProviderUnitTests
     public void ValueWithSpaces_InEqualsFormat_ParsesCorrectly()
     {
         var args = new[] { "--host=my server name", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -224,8 +211,7 @@ public class CommandLineArgumentProviderUnitTests
     public void LastValueWins_WhenDuplicateKeys()
     {
         var args = new[] { "--host=server1", "--host=server2", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -240,8 +226,7 @@ public class CommandLineArgumentProviderUnitTests
     {
         // Simulating: docker run myapp --host=localhost --port=8080 --debug
         var args = new[] { "--host=localhost", "--port=8080", "--debug" };
-        using var manager = new ConfigManager(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<MixedConfig>();
         Assert.NotNull(cfg);
@@ -256,8 +241,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_FiltersAndStripsPrefix()
     {
         var args = new[] { "--app_host=localhost", "--app_port=8080", "--db_host=dbserver" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -271,11 +255,10 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_WithMultipleTypes_MapsCorrectly()
     {
         var args = new[] { "--app_host=localhost", "--app_port=8080", "--db_host=dbserver", "--db_port=5432" };
-        using var manager = new ConfigManager(rule => [
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
             rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" }),
             rule.For<DatabaseConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "db_" })
-        ]);
-        manager.Initialize();
+        ]));
 
         var appCfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(appCfg);
@@ -294,8 +277,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_WithNestedKeys_WorksCorrectly()
     {
         var args = new[] { "--app_database:host=localhost", "--app_database:port=5432" };
-        using var manager = new ConfigManager(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -310,8 +292,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_CaseInsensitive()
     {
         var args = new[] { "--APP_host=localhost", "--app_port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -325,8 +306,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NoPrefix_ReturnsAllArguments()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -340,8 +320,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_NoMatchingArgs_ReturnsEmptyConfig()
     {
         var args = new[] { "--other_host=localhost", "--other_port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]);
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -355,12 +334,11 @@ public class CommandLineArgumentProviderUnitTests
     public void MultipleSwitchPrefixes_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "-port=8080", "/debug=true" };
-        using var manager = new ConfigManager(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["--", "-", "/"]
-        })]);
-        manager.Initialize();
+        })]));
 
         var cfg = manager.GetConfig<MixedConfig>();
         Assert.NotNull(cfg);
@@ -375,12 +353,11 @@ public class CommandLineArgumentProviderUnitTests
     public void MultipleSwitchPrefixes_WithSpaceFormat_ParsesCorrectly()
     {
         var args = new[] { "--host", "localhost", "-port", "8080", "/debug" };
-        using var manager = new ConfigManager(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["--", "-", "/"]
-        })]);
-        manager.Initialize();
+        })]));
 
         var cfg = manager.GetConfig<MixedConfig>();
         Assert.NotNull(cfg);
@@ -396,12 +373,11 @@ public class CommandLineArgumentProviderUnitTests
     {
         // Ensure "--" matches before "-" even if array order is reversed
         var args = new[] { "--host=localhost", "-port=8080" };
-        using var manager = new ConfigManager(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["-", "--"]  // Note: shorter prefix first in array
-        })]);
-        manager.Initialize();
+        })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);

--- a/src/tests/Cocoar.Configuration.Providers.Tests/CommandLine/CommandLineArgumentProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/CommandLine/CommandLineArgumentProviderUnitTests.cs
@@ -22,7 +22,7 @@ public class CommandLineArgumentProviderUnitTests
     {
         var args = Array.Empty<string>();
         
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -36,7 +36,7 @@ public class CommandLineArgumentProviderUnitTests
     public void EqualsFormat_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -50,7 +50,7 @@ public class CommandLineArgumentProviderUnitTests
     public void SpaceFormat_ParsesCorrectly()
     {
         var args = new[] { "--host", "localhost", "--port", "8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -64,7 +64,7 @@ public class CommandLineArgumentProviderUnitTests
     public void MixedFormats_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "--port", "8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -78,7 +78,7 @@ public class CommandLineArgumentProviderUnitTests
     public void BooleanFlags_ParseAsTrue()
     {
         var args = new[] { "--debug", "--verbose" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<FlagsConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<FlagsConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<FlagsConfig>();
         Assert.NotNull(cfg);
@@ -92,7 +92,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NestedConfiguration_WithColon_ParsesCorrectly()
     {
         var args = new[] { "--database:host=localhost", "--database:port=5432", "--database:name=mydb" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -108,7 +108,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NestedConfiguration_WithDoubleUnderscore_ParsesCorrectly()
     {
         var args = new[] { "--database__host=localhost", "--database__port=5432" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -123,7 +123,7 @@ public class CommandLineArgumentProviderUnitTests
     public void SingleDashPrefix_ParsesCorrectly()
     {
         var args = new[] { "-host=localhost", "-port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["-"]
@@ -141,7 +141,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NonSwitchArguments_AreIgnored()
     {
         var args = new[] { "somecommand", "--host=localhost", "anotherarg", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -155,7 +155,7 @@ public class CommandLineArgumentProviderUnitTests
     public void CaseInsensitive_ParsesCorrectly()
     {
         var args = new[] { "--HOST=localhost", "--Port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -169,7 +169,7 @@ public class CommandLineArgumentProviderUnitTests
     public void FluentAPI_WithArgs_Works()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -183,7 +183,7 @@ public class CommandLineArgumentProviderUnitTests
     public void EmptyValueAfterEquals_ParsesAsEmptyString()
     {
         var args = new[] { "--host=", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -197,7 +197,7 @@ public class CommandLineArgumentProviderUnitTests
     public void ValueWithSpaces_InEqualsFormat_ParsesCorrectly()
     {
         var args = new[] { "--host=my server name", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -211,7 +211,7 @@ public class CommandLineArgumentProviderUnitTests
     public void LastValueWins_WhenDuplicateKeys()
     {
         var args = new[] { "--host=server1", "--host=server2", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -226,7 +226,7 @@ public class CommandLineArgumentProviderUnitTests
     {
         // Simulating: docker run myapp --host=localhost --port=8080 --debug
         var args = new[] { "--host=localhost", "--port=8080", "--debug" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<MixedConfig>();
         Assert.NotNull(cfg);
@@ -241,7 +241,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_FiltersAndStripsPrefix()
     {
         var args = new[] { "--app_host=localhost", "--app_port=8080", "--db_host=dbserver" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -255,7 +255,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_WithMultipleTypes_MapsCorrectly()
     {
         var args = new[] { "--app_host=localhost", "--app_port=8080", "--db_host=dbserver", "--db_port=5432" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [
             rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" }),
             rule.For<DatabaseConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "db_" })
         ]));
@@ -277,7 +277,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_WithNestedKeys_WorksCorrectly()
     {
         var args = new[] { "--app_database:host=localhost", "--app_database:port=5432" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<NestedConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<NestedConfig>();
         Assert.NotNull(cfg);
@@ -292,7 +292,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_CaseInsensitive()
     {
         var args = new[] { "--APP_host=localhost", "--app_port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -306,7 +306,7 @@ public class CommandLineArgumentProviderUnitTests
     public void NoPrefix_ReturnsAllArguments()
     {
         var args = new[] { "--host=localhost", "--port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -320,7 +320,7 @@ public class CommandLineArgumentProviderUnitTests
     public void Prefix_NoMatchingArgs_ReturnsEmptyConfig()
     {
         var args = new[] { "--other_host=localhost", "--other_port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions { Args = args, Prefix = "app_" })]));
 
         var cfg = manager.GetConfig<SimpleConfig>();
         Assert.NotNull(cfg);
@@ -334,7 +334,7 @@ public class CommandLineArgumentProviderUnitTests
     public void MultipleSwitchPrefixes_ParsesCorrectly()
     {
         var args = new[] { "--host=localhost", "-port=8080", "/debug=true" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["--", "-", "/"]
@@ -353,7 +353,7 @@ public class CommandLineArgumentProviderUnitTests
     public void MultipleSwitchPrefixes_WithSpaceFormat_ParsesCorrectly()
     {
         var args = new[] { "--host", "localhost", "-port", "8080", "/debug" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<MixedConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["--", "-", "/"]
@@ -373,7 +373,7 @@ public class CommandLineArgumentProviderUnitTests
     {
         // Ensure "--" matches before "-" even if array order is reversed
         var args = new[] { "--host=localhost", "-port=8080" };
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(rule => [rule.For<SimpleConfig>().FromCommandLine(cm => new CommandLineRuleOptions
         {
             Args = args,
             SwitchPrefixes = ["-", "--"]  // Note: shorter prefix first in array

--- a/src/tests/Cocoar.Configuration.Providers.Tests/Environment/EnvironmentProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/Environment/EnvironmentProviderUnitTests.cs
@@ -18,8 +18,7 @@ public class EnvironmentProviderUnitTests
     {
         var prefix = "COCOAR_TEST_APP_" + Guid.NewGuid().ToString("N") + "_"; // unique prefix with no variables
         var rule = EnvironmentVariableProvider.CreateRule<object>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        try { manager.Initialize(); } catch { }
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         var snap = manager.GetHealthService().Snapshot;
         Assert.Equal(Health.HealthStatus.Healthy, snap.OverallStatus); // Fetch succeeded with empty object
         Assert.Single(snap.Rules);
@@ -36,8 +35,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(variableName, "200");
 
         var rule = EnvironmentVariableProvider.CreateRule<SimpleValueConfig>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<SimpleValueConfig>();
         Assert.NotNull(cfg);
@@ -56,8 +54,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "__Logging__Level", "Debug");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -73,8 +70,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "_Feature_Flag", "enabled");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -90,8 +86,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "Logging:Level", "Info");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -107,8 +102,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "Logging___Level", "Warn");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -124,8 +118,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(testVar, "global-value");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(null, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -142,8 +135,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(key, "CS");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -161,8 +153,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(key, "x");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -184,8 +175,7 @@ public class EnvironmentProviderUnitTests
         using var s3 = EnvScope.Set("MYAPP:Data:ConnectionString", "cs");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);

--- a/src/tests/Cocoar.Configuration.Providers.Tests/Environment/EnvironmentProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/Environment/EnvironmentProviderUnitTests.cs
@@ -18,7 +18,7 @@ public class EnvironmentProviderUnitTests
     {
         var prefix = "COCOAR_TEST_APP_" + Guid.NewGuid().ToString("N") + "_"; // unique prefix with no variables
         var rule = EnvironmentVariableProvider.CreateRule<object>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         var snap = manager.GetHealthService().Snapshot;
         Assert.Equal(Health.HealthStatus.Healthy, snap.OverallStatus); // Fetch succeeded with empty object
         Assert.Single(snap.Rules);
@@ -35,7 +35,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(variableName, "200");
 
         var rule = EnvironmentVariableProvider.CreateRule<SimpleValueConfig>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<SimpleValueConfig>();
         Assert.NotNull(cfg);
@@ -54,7 +54,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "__Logging__Level", "Debug");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -70,7 +70,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "_Feature_Flag", "enabled");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -86,7 +86,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "Logging:Level", "Info");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -102,7 +102,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(prefix + "Logging___Level", "Warn");
 
         var rule = EnvironmentVariableProvider.CreateRule<AppSettings>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<AppSettings>();
         Assert.NotNull(cfg);
@@ -118,7 +118,7 @@ public class EnvironmentProviderUnitTests
         using var s1 = EnvScope.Set(testVar, "global-value");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(null, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -135,7 +135,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(key, "CS");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -153,7 +153,7 @@ public class EnvironmentProviderUnitTests
         using var scope = EnvScope.Set(key, "x");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);
@@ -175,7 +175,7 @@ public class EnvironmentProviderUnitTests
         using var s3 = EnvScope.Set("MYAPP:Data:ConnectionString", "cs");
 
         var rule = EnvironmentVariableProvider.CreateRule<Dictionary<string, object>>(prefix, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
 
         var cfg = manager.GetConfig<Dictionary<string, object>>();
         Assert.NotNull(cfg);

--- a/src/tests/Cocoar.Configuration.Providers.Tests/File/FileProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/File/FileProviderUnitTests.cs
@@ -29,10 +29,7 @@ public class FileProviderUnitTests
     {
         var path = Path.Combine(Path.GetTempPath(), "cocoar_missing_" + Guid.NewGuid().ToString("N") + ".json");
         var rule = CreateFileRule<object>(path, required: false); // explicitly optional
-        using var manager = new ConfigManager(new[]{rule});
-        
-        // Optional rule should initialize successfully even with missing file
-        manager.Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         var snap = manager.GetHealthService().Snapshot;
         
         // Optional rule fails but doesn't make the system unhealthy - shows as Down but overall Degraded
@@ -49,10 +46,8 @@ public class FileProviderUnitTests
     {
         var path = Path.Combine(Path.GetTempPath(), "cocoar_missing_req_" + Guid.NewGuid().ToString("N") + ".json");
         var rule = CreateFileRule<object>(path, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        
         // Should throw during initialization for required missing file (wrapped in InvalidOperationException)
-        var ex = Assert.Throws<InvalidOperationException>(() => manager.Initialize());
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.WithConfiguration(new[]{rule})));
         Assert.Contains("Required rule failed", ex.Message);
         Assert.IsType<FileNotFoundException>(ex.InnerException);
     }
@@ -66,7 +61,7 @@ public class FileProviderUnitTests
         file.WriteJson(new { Name = "TestApp", Value = 42 });
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
-        using var manager = new ConfigManager(new[]{rule}).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);
@@ -87,10 +82,8 @@ public class FileProviderUnitTests
         file.WriteContent("{ invalid json syntax }");
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
-        using var manager = new ConfigManager(new[]{rule});
-        
         // Should throw during initialization due to JSON parse error (wrapped in InvalidOperationException)
-        var ex = Assert.Throws<InvalidOperationException>(() => manager.Initialize());
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.WithConfiguration(new[]{rule})));
         Assert.Contains("Required rule failed", ex.Message);
         // Inner exception should be JSON parsing related
         Assert.True(ex.InnerException is JsonException || ex.InnerException?.GetType().Name.Contains("Json") == true);
@@ -105,7 +98,7 @@ public class FileProviderUnitTests
         file.WriteContent("{}");
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
-        using var manager = new ConfigManager(new[]{rule}).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);
@@ -126,7 +119,7 @@ public class FileProviderUnitTests
         file.WriteJson(new { App = new { Name = "Nested", Value = 100 } });
 
         var rule = CreateFileRule<NestedConfig>(file.FilePath, required: true);
-        using var manager = new ConfigManager(new[]{rule}).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<NestedConfig>();
         Assert.NotNull(config);
@@ -146,7 +139,7 @@ public class FileProviderUnitTests
         });
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, selectPath: "App", required: true);
-        using var manager = new ConfigManager(new[]{rule}).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);

--- a/src/tests/Cocoar.Configuration.Providers.Tests/File/FileProviderUnitTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/File/FileProviderUnitTests.cs
@@ -29,7 +29,7 @@ public class FileProviderUnitTests
     {
         var path = Path.Combine(Path.GetTempPath(), "cocoar_missing_" + Guid.NewGuid().ToString("N") + ".json");
         var rule = CreateFileRule<object>(path, required: false); // explicitly optional
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         var snap = manager.GetHealthService().Snapshot;
         
         // Optional rule fails but doesn't make the system unhealthy - shows as Down but overall Degraded
@@ -47,7 +47,7 @@ public class FileProviderUnitTests
         var path = Path.Combine(Path.GetTempPath(), "cocoar_missing_req_" + Guid.NewGuid().ToString("N") + ".json");
         var rule = CreateFileRule<object>(path, required: true);
         // Should throw during initialization for required missing file (wrapped in InvalidOperationException)
-        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.WithConfiguration(new[]{rule})));
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.UseConfiguration(new[]{rule})));
         Assert.Contains("Required rule failed", ex.Message);
         Assert.IsType<FileNotFoundException>(ex.InnerException);
     }
@@ -61,7 +61,7 @@ public class FileProviderUnitTests
         file.WriteJson(new { Name = "TestApp", Value = 42 });
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);
@@ -83,7 +83,7 @@ public class FileProviderUnitTests
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
         // Should throw during initialization due to JSON parse error (wrapped in InvalidOperationException)
-        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.WithConfiguration(new[]{rule})));
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigManager.Create(c => c.UseConfiguration(new[]{rule})));
         Assert.Contains("Required rule failed", ex.Message);
         // Inner exception should be JSON parsing related
         Assert.True(ex.InnerException is JsonException || ex.InnerException?.GetType().Name.Contains("Json") == true);
@@ -98,7 +98,7 @@ public class FileProviderUnitTests
         file.WriteContent("{}");
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);
@@ -119,7 +119,7 @@ public class FileProviderUnitTests
         file.WriteJson(new { App = new { Name = "Nested", Value = 100 } });
 
         var rule = CreateFileRule<NestedConfig>(file.FilePath, required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<NestedConfig>();
         Assert.NotNull(config);
@@ -139,7 +139,7 @@ public class FileProviderUnitTests
         });
 
         var rule = CreateFileRule<AppConfig>(file.FilePath, selectPath: "App", required: true);
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         
         var config = manager.GetConfig<AppConfig>();
         Assert.NotNull(config);

--- a/src/tests/Cocoar.Configuration.Providers.Tests/Http/HttpProviderSmokeTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/Http/HttpProviderSmokeTests.cs
@@ -49,7 +49,7 @@ public class HttpProviderSmokeTests
         var handler = new QueueHandler(queue);
 
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
             // Provide base settings with Url via in-memory Microsoft IConfigurationSource (adapter)
             rules.For<MyHttpPollingSettings>().FromMicrosoftSource(cm => new(
                     new ConfigurationBuilder()
@@ -65,7 +65,7 @@ public class HttpProviderSmokeTests
                     handler: handler
                 ))
                 .When(_ => true)
-        ]);
+        ]));
         var sp = services.BuildServiceProvider();
         var manager = sp.GetRequiredService<ConfigManager>();
         var first = manager.GetConfig<MyCfg>();

--- a/src/tests/Cocoar.Configuration.Providers.Tests/Http/HttpProviderSmokeTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/Http/HttpProviderSmokeTests.cs
@@ -49,7 +49,7 @@ public class HttpProviderSmokeTests
         var handler = new QueueHandler(queue);
 
         var services = new ServiceCollection();
-        services.AddCocoarConfiguration(c => c.WithConfiguration(rules => [
+        services.AddCocoarConfiguration(c => c.UseConfiguration(rules => [
             // Provide base settings with Url via in-memory Microsoft IConfigurationSource (adapter)
             rules.For<MyHttpPollingSettings>().FromMicrosoftSource(cm => new(
                     new ConfigurationBuilder()

--- a/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterBattleTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterBattleTests.cs
@@ -189,7 +189,7 @@ public class MicrosoftAdapterBattleTests : IDisposable
                 configSource,
                 configurationPrefix: "App"));
 
-        using var manager = new ConfigManager(new[] { rule }).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
 
 
         var config = manager.GetConfig<AppConfig>();

--- a/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterBattleTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterBattleTests.cs
@@ -189,7 +189,7 @@ public class MicrosoftAdapterBattleTests : IDisposable
                 configSource,
                 configurationPrefix: "App"));
 
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[] { rule }));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[] { rule }));
 
 
         var config = manager.GetConfig<AppConfig>();

--- a/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterSmokeTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterSmokeTests.cs
@@ -21,7 +21,7 @@ public class MicrosoftAdapterSmokeTests
         var configSource = new Microsoft.Extensions.Configuration.Memory.MemoryConfigurationSource { InitialData = dict };
 
         var rule = MicrosoftConfigurationSourceProvider.CreateRule<AppConfig>(_ => new(configSource, configurationPrefix: "App"));
-        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
+        using var manager = ConfigManager.Create(c => c.UseConfiguration(new[]{rule}));
         var config = manager.GetConfig<AppConfig>();
         Assert.Equal("42", config!.Value);
         var snap = manager.GetHealthService().Snapshot;

--- a/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterSmokeTests.cs
+++ b/src/tests/Cocoar.Configuration.Providers.Tests/MicrosoftAdapter/MicrosoftAdapterSmokeTests.cs
@@ -21,7 +21,7 @@ public class MicrosoftAdapterSmokeTests
         var configSource = new Microsoft.Extensions.Configuration.Memory.MemoryConfigurationSource { InitialData = dict };
 
         var rule = MicrosoftConfigurationSourceProvider.CreateRule<AppConfig>(_ => new(configSource, configurationPrefix: "App"));
-        using var manager = new ConfigManager(new[]{rule}).Initialize();
+        using var manager = ConfigManager.Create(c => c.WithConfiguration(new[]{rule}));
         var config = manager.GetConfig<AppConfig>();
         Assert.Equal("42", config!.Value);
         var snap = manager.GetHealthService().Snapshot;

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
@@ -61,7 +61,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -87,7 +87,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","Password":"secret123","ApiKey":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -119,7 +119,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -145,7 +145,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"Test","ApiKey":12345}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -172,7 +172,7 @@ public class AllowPlaintextTests
 
         // This test verifies fluent API chaining compiles and works
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -197,7 +197,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -240,7 +240,7 @@ public class AllowPlaintextTests
         // 1. The envelope is recognized as an envelope (not plaintext)
         // 2. AllowPlaintext doesn't break envelope handling
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
@@ -285,7 +285,7 @@ public class AllowPlaintextTests
 
         // Deserialization fails at startup with Master Backplane architecture
         var ex = Assert.Throws<ConfigurationDeserializationException>(() => ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
@@ -306,7 +306,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
@@ -331,7 +331,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","RequiredStringSecret":"password","RequiredIntSecret":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
@@ -364,7 +364,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","RequiredStringSecret":"test","RequiredIntSecret":null}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -390,7 +390,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -416,7 +416,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableStringSecret":"secret-value"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -445,7 +445,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableStringSecret":null}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -471,7 +471,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableIntSecret":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -497,7 +497,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableIntSecret":null}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -523,7 +523,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableBoolSecret":true}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -549,7 +549,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","NullableStringSecret":"password","NullableIntSecret":123,"NullableBoolSecret":false}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
@@ -585,7 +585,7 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
@@ -65,7 +65,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets) // No AllowPlaintext - default security
+            .UseSecretsSetup(secrets => secrets) // No AllowPlaintext - default security
         );
 
         // Act
@@ -91,7 +91,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -123,7 +123,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext(false))
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext(false))
         );
 
         // Act
@@ -149,7 +149,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -176,7 +176,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext(true))
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext(true))
         );
 
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -201,7 +201,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets
+            .UseSecretsSetup(secrets => secrets
                 .AllowPlaintext(false)  // First: disable
                 .AllowPlaintext(true))  // Second: enable (wins)
         );
@@ -244,7 +244,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -289,7 +289,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         ));
         Assert.Contains("Secret<Int32>", ex.Failures[0].Message);
     }
@@ -310,7 +310,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         var config = manager.GetConfig<ConfigWithNonNullableSecrets>();
@@ -335,7 +335,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -368,7 +368,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -394,7 +394,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -420,7 +420,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -449,7 +449,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -475,7 +475,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -501,7 +501,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -527,7 +527,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -553,7 +553,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -589,7 +589,7 @@ public class AllowPlaintextTests
                 rules => [
                     rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/AllowPlaintextTests.cs
@@ -60,14 +60,13 @@ public class AllowPlaintextTests
         // Arrange - ConfigManager without AllowPlaintext (default behavior)
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets() // No AllowPlaintext - default security
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets) // No AllowPlaintext - default security
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -87,14 +86,13 @@ public class AllowPlaintextTests
         // Arrange - ConfigManager with AllowPlaintext(true)
         var json = """{"Name":"TestApp","Password":"secret123","ApiKey":42}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()  // defaults to true
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -120,14 +118,13 @@ public class AllowPlaintextTests
         // Arrange - Explicitly set AllowPlaintext(false) for self-documenting code
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext(false)  // explicit disable
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext(false))
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -147,14 +144,13 @@ public class AllowPlaintextTests
         // Arrange
         var json = """{"Name":"Test","ApiKey":12345}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithSecret>();
@@ -175,15 +171,13 @@ public class AllowPlaintextTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         // This test verifies fluent API chaining compiles and works
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets()
-                    .AllowPlaintext(true)  // Can be chained
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext(true))
+        );
 
         var config = manager.GetConfig<ConfigWithSecret>();
 
@@ -202,16 +196,15 @@ public class AllowPlaintextTests
         // Arrange - If called multiple times, last value wins
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets()
-                    .AllowPlaintext(false)  // First: disable
-                    .AllowPlaintext(true)   // Second: enable (wins)
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets
+                .AllowPlaintext(false)  // First: disable
+                .AllowPlaintext(true))  // Second: enable (wins)
+        );
 
         var config = manager.GetConfig<ConfigWithSecret>();
 
@@ -246,14 +239,13 @@ public class AllowPlaintextTests
         // Without a certificate, we can't actually decrypt, but we can verify:
         // 1. The envelope is recognized as an envelope (not plaintext)
         // 2. AllowPlaintext doesn't break envelope handling
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()  // Should not affect envelopes
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecret>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         var config = manager.GetConfig<ConfigWithSecret>();
 
@@ -291,17 +283,14 @@ public class AllowPlaintextTests
         // With Master Backplane architecture, deserialization failures at startup throw.
         var json = """{"Name":"TestApp","RequiredStringSecret":"test","RequiredIntSecret":null}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        );
-
         // Deserialization fails at startup with Master Backplane architecture
-        var ex = Assert.Throws<ConfigurationDeserializationException>(() => manager.Initialize());
+        var ex = Assert.Throws<ConfigurationDeserializationException>(() => ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        ));
         Assert.Contains("Secret<Int32>", ex.Failures[0].Message);
     }
 
@@ -316,14 +305,13 @@ public class AllowPlaintextTests
         // Therefore, the converter creates a Secret containing null.
         var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         var config = manager.GetConfig<ConfigWithNonNullableSecrets>();
         Assert.NotNull(config);
@@ -342,14 +330,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<int> and Secret<string> with valid values
         var json = """{"Name":"TestApp","RequiredStringSecret":"password","RequiredIntSecret":42}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNonNullableSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNonNullableSecrets>();
@@ -376,14 +363,13 @@ public class AllowPlaintextTests
         // a Secret that contains null inside, NOT a null Secret.
         var json = """{"Name":"TestApp","RequiredStringSecret":"test","RequiredIntSecret":null}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithRequiredNullableInnerSecrets>();
@@ -403,14 +389,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<string?> with null value
         var json = """{"Name":"TestApp","RequiredStringSecret":null,"RequiredIntSecret":42}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithRequiredNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithRequiredNullableInnerSecrets>();
@@ -430,14 +415,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<string?> with an actual value
         var json = """{"Name":"TestApp","NullableStringSecret":"secret-value"}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -460,14 +444,13 @@ public class AllowPlaintextTests
         // regardless of whether the property is declared as Secret<T?>? or Secret<T?>.
         var json = """{"Name":"TestApp","NullableStringSecret":null}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -487,14 +470,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<int?> with an actual value
         var json = """{"Name":"TestApp","NullableIntSecret":42}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -514,14 +496,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<int?>? with explicit null JSON value
         var json = """{"Name":"TestApp","NullableIntSecret":null}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -541,14 +522,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<bool?> with an actual value
         var json = """{"Name":"TestApp","NullableBoolSecret":true}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -568,14 +548,13 @@ public class AllowPlaintextTests
         // Arrange - All nullable inner secrets with values
         var json = """{"Name":"TestApp","NullableStringSecret":"password","NullableIntSecret":123,"NullableBoolSecret":false}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();
@@ -605,14 +584,13 @@ public class AllowPlaintextTests
         // Arrange - Secret<T?> properties not present in JSON
         var json = """{"Name":"TestApp"}""";
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets().AllowPlaintext()
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithNullableInnerSecrets>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithNullableInnerSecrets>();

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
@@ -38,14 +38,13 @@ public class ErrorMessageTests
         }
         """;
 
-        var manager = new ConfigManager(
-            rules => [
-                rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
-            ],
-            setup => [
-                setup.Secrets()  // Secrets enabled, but no certificates configured
-            ]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [
+                    rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
+                ])
+            .WithSecretsSetup(secrets => secrets) // Secrets enabled, but no certificates configured
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithSecretString>();
@@ -81,10 +80,11 @@ public class ErrorMessageTests
         }
         """;
 
-        var manager = new ConfigManager(
-            rules => [rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()],
-            setup => [setup.Secrets()]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()])
+            .WithSecretsSetup(secrets => secrets)
+        );
 
         var config = manager.GetConfig<ConfigWithSecretString>();
 
@@ -94,7 +94,7 @@ public class ErrorMessageTests
         // Assert - error should have code examples showing certificate setup
         Assert.Contains(".UseCertificateFromFile(", ex.Message);
         Assert.Contains(".WithKeyId(", ex.Message);
-        Assert.Contains("setup.Secrets()", ex.Message);
+        Assert.Contains(".WithSecretsSetup(", ex.Message);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class ErrorMessageTests
         var ex = Assert.Throws<InvalidOperationException>(() => secret.Open());
 
         Assert.Contains("secrets infrastructure not configured", ex.Message);
-        Assert.Contains("setup.Secrets()", ex.Message);
+        Assert.Contains("WithSecretsSetup", ex.Message);
         Assert.Contains("ConfigManager", ex.Message);
         Assert.Contains("AddCocoarConfiguration", ex.Message);
     }
@@ -179,15 +179,13 @@ public class ErrorMessageTests
         }
         """;
 
-        var manager = new ConfigManager(
+        // Act & Assert - With Master Backplane, deserialization fails at startup
+        var ex = Assert.Throws<ConfigurationDeserializationException>(() => ConfigManager.Create(c => c.WithConfiguration(
             rules => [
                 rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
             ]
             // NOTE: No setup.Secrets() - deserialization will fail
-        );
-
-        // Act & Assert - With Master Backplane, deserialization fails at startup
-        var ex = Assert.Throws<ConfigurationDeserializationException>(() => manager.Initialize());
+        )));
 
         // The error is about JSON deserialization, not about secrets infrastructure
         Assert.Contains("Deserialization", ex.Message);

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
@@ -39,7 +39,7 @@ public class ErrorMessageTests
         """;
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [
                     rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
                 ])
@@ -81,7 +81,7 @@ public class ErrorMessageTests
         """;
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()])
             .WithSecretsSetup(secrets => secrets)
         );
@@ -180,7 +180,7 @@ public class ErrorMessageTests
         """;
 
         // Act & Assert - With Master Backplane, deserialization fails at startup
-        var ex = Assert.Throws<ConfigurationDeserializationException>(() => ConfigManager.Create(c => c.WithConfiguration(
+        var ex = Assert.Throws<ConfigurationDeserializationException>(() => ConfigManager.Create(c => c.UseConfiguration(
             rules => [
                 rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
             ]

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ErrorMessageTests.cs
@@ -43,7 +43,7 @@ public class ErrorMessageTests
                 rules => [
                     rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()
                 ])
-            .WithSecretsSetup(secrets => secrets) // Secrets enabled, but no certificates configured
+            .UseSecretsSetup(secrets => secrets) // Secrets enabled, but no certificates configured
         );
 
         // Act
@@ -83,7 +83,7 @@ public class ErrorMessageTests
         var manager = ConfigManager.Create(c => c
             .UseConfiguration(
                 rules => [rules.For<ConfigWithSecretString>().FromStaticJson(json).Required()])
-            .WithSecretsSetup(secrets => secrets)
+            .UseSecretsSetup(secrets => secrets)
         );
 
         var config = manager.GetConfig<ConfigWithSecretString>();
@@ -94,7 +94,7 @@ public class ErrorMessageTests
         // Assert - error should have code examples showing certificate setup
         Assert.Contains(".UseCertificateFromFile(", ex.Message);
         Assert.Contains(".WithKeyId(", ex.Message);
-        Assert.Contains(".WithSecretsSetup(", ex.Message);
+        Assert.Contains(".UseSecretsSetup(", ex.Message);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class ErrorMessageTests
         var ex = Assert.Throws<InvalidOperationException>(() => secret.Open());
 
         Assert.Contains("secrets infrastructure not configured", ex.Message);
-        Assert.Contains("WithSecretsSetup", ex.Message);
+        Assert.Contains("UseSecretsSetup", ex.Message);
         Assert.Contains("ConfigManager", ex.Message);
         Assert.Contains("AddCocoarConfiguration", ex.Message);
     }

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
@@ -153,7 +153,7 @@ public class ISecretInterfaceTests
         var manager = ConfigManager.Create(c => c
             .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -179,7 +179,7 @@ public class ISecretInterfaceTests
         var manager = ConfigManager.Create(c => c
             .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         // Act
@@ -204,7 +204,7 @@ public class ISecretInterfaceTests
         var manager = ConfigManager.Create(c => c
             .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
-            .WithSecretsSetup(secrets => secrets)
+            .UseSecretsSetup(secrets => secrets)
         );
 
         // Act
@@ -229,7 +229,7 @@ public class ISecretInterfaceTests
         var manager = ConfigManager.Create(c => c
             .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
-            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())
         );
 
         var config = manager.GetConfig<ConfigWithISecret>();

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
@@ -150,10 +150,11 @@ public class ISecretInterfaceTests
         // Arrange - Config class with ISecret<T> property (interface, not concrete)
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
-        var manager = new ConfigManager(
-            rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()],
-            setup => [setup.Secrets().AllowPlaintext()]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithISecret>();
@@ -175,10 +176,11 @@ public class ISecretInterfaceTests
         // Arrange
         var json = """{"Name":"Test","ApiKey":42}""";
 
-        var manager = new ConfigManager(
-            rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()],
-            setup => [setup.Secrets().AllowPlaintext()]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithISecret>();
@@ -199,10 +201,11 @@ public class ISecretInterfaceTests
         // Arrange - Default security behavior (no AllowPlaintext)
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
-        var manager = new ConfigManager(
-            rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()],
-            setup => [setup.Secrets()]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
+            .WithSecretsSetup(secrets => secrets)
+        );
 
         // Act
         var config = manager.GetConfig<ConfigWithISecret>();
@@ -223,10 +226,11 @@ public class ISecretInterfaceTests
         // Verify the deserialized value is actually a Secret<T> instance
         var json = """{"Name":"Test","Password":"value"}""";
 
-        var manager = new ConfigManager(
-            rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()],
-            setup => [setup.Secrets().AllowPlaintext()]
-        ).Initialize();
+        var manager = ConfigManager.Create(c => c
+            .WithConfiguration(
+                rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
+            .WithSecretsSetup(secrets => secrets.AllowPlaintext())
+        );
 
         var config = manager.GetConfig<ConfigWithISecret>();
 

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ISecretInterfaceTests.cs
@@ -151,7 +151,7 @@ public class ISecretInterfaceTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
             .WithSecretsSetup(secrets => secrets.AllowPlaintext())
         );
@@ -177,7 +177,7 @@ public class ISecretInterfaceTests
         var json = """{"Name":"Test","ApiKey":42}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
             .WithSecretsSetup(secrets => secrets.AllowPlaintext())
         );
@@ -202,7 +202,7 @@ public class ISecretInterfaceTests
         var json = """{"Name":"TestApp","Password":"secret123"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
             .WithSecretsSetup(secrets => secrets)
         );
@@ -227,7 +227,7 @@ public class ISecretInterfaceTests
         var json = """{"Name":"Test","Password":"value"}""";
 
         var manager = ConfigManager.Create(c => c
-            .WithConfiguration(
+            .UseConfiguration(
                 rules => [rules.For<ConfigWithISecret>().FromStaticJson(json).Required()])
             .WithSecretsSetup(secrets => secrets.AllowPlaintext())
         );

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/ReplaceSecretsSetupTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/ReplaceSecretsSetupTests.cs
@@ -1,0 +1,202 @@
+using Cocoar.Configuration.Configure;
+using Cocoar.Configuration.Core;
+using Cocoar.Configuration.Fluent;
+using Cocoar.Configuration.Providers;
+using Cocoar.Configuration.Secrets;
+using Cocoar.Configuration.Secrets.SecretTypes;
+using Cocoar.Configuration.Testing;
+
+namespace Cocoar.Configuration.Secrets.Tests;
+
+/// <summary>
+/// Tests for ReplaceSecretsSetup — the per-concern secrets override that is independent of
+/// ReplaceConfiguration / AppendConfiguration.
+/// </summary>
+public class ReplaceSecretsSetupTests
+{
+    public ReplaceSecretsSetupTests()
+    {
+        CocoarTestConfiguration.Clear();
+    }
+
+    // Helper: activate a secrets-only override via Apply (ReplaceSecretsSetup is a Secrets extension
+    // on TestOverrideBuilder; CocoarTestConfiguration.ReplaceSecretsSetup takes Delegate and can't
+    // infer lambda types, so we use the builder pattern for standalone secrets overrides).
+    private static TestConfigurationScope ApplySecretsOverride(Func<SecretsBuilder, SetupDefinition> configure)
+        => CocoarTestConfiguration.Apply(
+            new TestOverrideBuilder().ReplaceSecretsSetup(configure).Build());
+
+    private record AppConfig
+    {
+        public Secret<string>? ApiKey { get; init; }
+        public string Name { get; init; } = "";
+    }
+
+    // ------------------------------------------------------------------
+    // Standalone secrets override (no rule replacement)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ReplaceSecretsSetup_AllowsPlaintext_WhenAppCallsUseSecretsSetup()
+    {
+        using var _ = ApplySecretsOverride(secrets => secrets.AllowPlaintext());
+
+        var manager = ConfigManager.Create(c => c
+            .UseConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"test","ApiKey":"plain-value"}""")
+            ])
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext())); // intercepted by test override
+
+        var config = manager.GetConfig<AppConfig>();
+        Assert.NotNull(config);
+        using var lease = config.ApiKey!.Open();
+        Assert.Equal("plain-value", lease.Value);
+    }
+
+    [Fact]
+    public void ReplaceSecretsSetup_Alone_DoesNotAffectRules()
+    {
+        // Only secrets setup is overridden; original rules still run
+        using var _ = ApplySecretsOverride(secrets => secrets.AllowPlaintext());
+
+        var manager = ConfigManager.Create(c => c
+            .UseConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"from-original","ApiKey":"original-key"}""")
+            ])
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext()));
+
+        var config = manager.GetConfig<AppConfig>();
+        Assert.NotNull(config);
+        // Original rule still runs — name comes from the original static JSON
+        Assert.Equal("from-original", config.Name);
+        using var lease = config.ApiKey!.Open();
+        Assert.Equal("original-key", lease.Value);
+    }
+
+    [Fact]
+    public void ReplaceSecretsSetup_DoesNotActivateRulesOverride()
+    {
+        using var _ = ApplySecretsOverride(secrets => secrets.AllowPlaintext());
+
+        // Context is active but ConfigurationMode is null — rules override is NOT set
+        Assert.True(CocoarTestConfiguration.IsActive);
+        Assert.Null(CocoarTestConfiguration.Current?.ConfigurationMode);
+    }
+
+    // ------------------------------------------------------------------
+    // Chaining: ReplaceConfiguration + ReplaceSecretsSetup
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ReplaceConfiguration_ChainedWithReplaceSecretsSetup_BothApply()
+    {
+        using var _ = CocoarTestConfiguration
+            .ReplaceConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"overridden","ApiKey":"chained-key"}""")
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+
+        var manager = ConfigManager.Create(c => c
+            .UseConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"original","ApiKey":"original-key"}""")
+            ])
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext()));
+
+        var config = manager.GetConfig<AppConfig>();
+        Assert.NotNull(config);
+        Assert.Equal("overridden", config.Name);
+        using var lease = config.ApiKey!.Open();
+        Assert.Equal("chained-key", lease.Value);
+    }
+
+    [Fact]
+    public void AppendConfiguration_ChainedWithReplaceSecretsSetup_BothApply()
+    {
+        using var _ = CocoarTestConfiguration
+            .AppendConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"appended"}""")
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext());
+
+        var manager = ConfigManager.Create(c => c
+            .UseConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"original","ApiKey":"base-key"}""")
+            ])
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext()));
+
+        var config = manager.GetConfig<AppConfig>();
+        Assert.NotNull(config);
+        // Last rule wins for Name
+        Assert.Equal("appended", config.Name);
+        // ApiKey from base rule
+        using var lease = config.ApiKey!.Open();
+        Assert.Equal("base-key", lease.Value);
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture pattern: TestOverrideBuilder (no auto-activate)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void TestOverrideBuilder_WithReplaceSecretsSetup_BuildsThenApply()
+    {
+        var context = new TestOverrideBuilder()
+            .ReplaceConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"fixture","ApiKey":"fixture-key"}""")
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext())
+            .Build();
+
+        // Not yet active
+        Assert.False(CocoarTestConfiguration.IsActive);
+
+        using var scope = CocoarTestConfiguration.Apply(context);
+        Assert.True(CocoarTestConfiguration.IsActive);
+
+        var manager = ConfigManager.Create(c => c
+            .UseConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"original","ApiKey":"original-key"}""")
+            ])
+            .UseSecretsSetup(secrets => secrets.AllowPlaintext()));
+
+        var config = manager.GetConfig<AppConfig>();
+        Assert.NotNull(config);
+        Assert.Equal("fixture", config.Name);
+        using var lease = config.ApiKey!.Open();
+        Assert.Equal("fixture-key", lease.Value);
+    }
+
+    // ------------------------------------------------------------------
+    // Scope / dispose behavior
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ReplaceSecretsSetup_ClearsOnDispose()
+    {
+        Assert.False(CocoarTestConfiguration.IsActive);
+
+        using (var scope = ApplySecretsOverride(secrets => secrets.AllowPlaintext()))
+        {
+            Assert.True(CocoarTestConfiguration.IsActive);
+        }
+
+        Assert.False(CocoarTestConfiguration.IsActive);
+    }
+
+    [Fact]
+    public void ChainedReplaceSecretsSetup_ClearsOnDispose()
+    {
+        Assert.False(CocoarTestConfiguration.IsActive);
+
+        using (CocoarTestConfiguration
+            .ReplaceConfiguration(rule => [
+                rule.For<AppConfig>().FromStaticJson("""{"Name":"test"}""")
+            ])
+            .ReplaceSecretsSetup(secrets => secrets.AllowPlaintext()))
+        {
+            Assert.True(CocoarTestConfiguration.IsActive);
+        }
+
+        Assert.False(CocoarTestConfiguration.IsActive);
+    }
+}


### PR DESCRIPTION
- Introduced ConfigManagerBuilder for streamlined configuration setup.
- Updated AddCocoarConfiguration to utilize the new builder API.
- Replaced internal initialization logic with a fluent interface for creating ConfigManager instances.
- Modified tests to align with the new builder pattern, ensuring all configurations are properly initialized.
- Added migration guide for transitioning from v4.x to v5.0, detailing breaking changes and new usage patterns.
- Enhanced secrets configuration with dedicated extension methods for better clarity and separation of concerns.