### PR TITLE
feat: lenient JSON options for secret payloads (enum names + case-insensitive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Secret payloads (the decrypted value of `Secret<T>`) now (de)serialize with lenient options: **enums as names** (round-trip-safe if the enum is later reordered) and **case-insensitive** property matching. Reading still accepts numeric enums and any casing, so **existing encrypted secrets remain fully readable** — no migration. Only the in-memory form of newly serialized typed secret values changes (enum name instead of ordinal); encrypted envelopes at rest are unaffected.
+
 ## [5.0.0] - 2026-03-24
 
 ### Added

--- a/src/Cocoar.Configuration.Secrets.Cli/Commands/EncryptCommand.cs
+++ b/src/Cocoar.Configuration.Secrets.Cli/Commands/EncryptCommand.cs
@@ -26,7 +26,8 @@ internal static class EncryptCommand
 
         var valueOption = new Option<string?>("--value")
         {
-            Description = "The plaintext value to encrypt. If omitted, encrypts the existing value at the specified path.",
+            Description = "The plaintext value to encrypt. If omitted, encrypts the existing value at the specified path. " +
+                          "For enum values, pass the name (e.g. 'Active') rather than the number — names survive enum reordering.",
             Required = false
         };
         valueOption.Aliases.Add("-v");

--- a/src/Cocoar.Configuration/Secrets/SecretTypes/Secret.cs
+++ b/src/Cocoar.Configuration/Secrets/SecretTypes/Secret.cs
@@ -20,7 +20,8 @@ public sealed class Secret<T> : ISecret<T>
     internal Secret(T plain, SecretsDecryptorResolver? resolver = null, bool allowPlaintext = false)
     {
         // Serialize directly to UTF-8 bytes — never create an intermediate string.
-        _plainBytes = JsonSerializer.SerializeToUtf8Bytes(plain);
+        // Lenient options (enums as names) keep the payload round-trip-safe and consistent with the read side.
+        _plainBytes = JsonSerializer.SerializeToUtf8Bytes(plain, SecretValueSerialization.Options);
         _resolver = resolver;
         _blockPlaintextAccess = !allowPlaintext; // Block access if plaintext is NOT explicitly allowed
     }
@@ -132,7 +133,7 @@ public sealed class Secret<T> : ISecret<T>
         // Security at rest: before Open(), secrets exist only as encrypted envelopes.
         // At Open() time, the consumer needs the value (to pass to HttpClient, DB, etc.)
         // so converting to T is unavoidable. The decrypted bytes are zeroed on lease dispose.
-        var value = JsonSerializer.Deserialize<T>(new ReadOnlySpan<byte>(bytes));
+        var value = JsonSerializer.Deserialize<T>(new ReadOnlySpan<byte>(bytes), SecretValueSerialization.Options);
 
         if (value is null)
         {

--- a/src/Cocoar.Configuration/Secrets/SecretTypes/SecretValueSerialization.cs
+++ b/src/Cocoar.Configuration/Secrets/SecretTypes/SecretValueSerialization.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cocoar.Configuration.Secrets.SecretTypes;
+
+/// <summary>
+/// JSON options for (de)serializing a secret's decrypted plaintext <em>value</em> (the payload of
+/// <c>Secret&lt;T&gt;</c>), kept in one place so the serialize and deserialize sides stay symmetric.
+/// <para>
+/// These are intentionally lenient — matching the configuration pipeline's conventions rather than the
+/// stricter <see cref="JsonSerializerOptions.Default"/>:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="JsonSerializerOptions.PropertyNameCaseInsensitive"/> = true, so payloads
+/// produced by external encryptors (CLI, a browser, hand-edited files) bind regardless of casing.</description></item>
+/// <item><description><see cref="JsonStringEnumConverter"/>, so enums serialize as their <em>names</em>
+/// (round-trip-safe if the enum is later reordered) while still <em>reading</em> both names and numbers —
+/// which keeps older envelopes (enum-as-number) decryptable.</description></item>
+/// </list>
+/// <para>
+/// Only the type-aware paths inside the library serialize a typed value (<c>Secret&lt;T&gt;</c>); anything
+/// coming from outside is plain JSON, which is exactly why a name-based, case-insensitive contract is the
+/// safer default here.
+/// </para>
+/// </summary>
+internal static class SecretValueSerialization
+{
+    internal static readonly JsonSerializerOptions Options = Create();
+
+    private static JsonSerializerOptions Create()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+}

--- a/src/tests/Cocoar.Configuration.Secrets.Tests/SecretEnumSerializationTests.cs
+++ b/src/tests/Cocoar.Configuration.Secrets.Tests/SecretEnumSerializationTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Cocoar.Configuration.Secrets.SecretTypes;
+using Xunit;
+
+namespace Cocoar.Configuration.Secrets.Tests;
+
+public class SecretEnumSerializationTests
+{
+    public enum Tier { Free = 0, Pro = 1, Enterprise = 2 }
+
+    public record Plan(string Name, Tier Tier);
+
+    // ---- options-level: the decrypted-envelope deserialize path uses these exact options ----
+
+    [Fact]
+    public void Options_Enum_ReadsName()
+        => Assert.Equal(Tier.Pro, JsonSerializer.Deserialize<Tier>("\"Pro\"", SecretValueSerialization.Options));
+
+    [Fact]
+    public void Options_Enum_ReadsNumber_StaysBackwardCompatible()
+        => Assert.Equal(Tier.Pro, JsonSerializer.Deserialize<Tier>("1", SecretValueSerialization.Options));
+
+    [Fact]
+    public void Options_Enum_WritesName_NotOrdinal()
+        => Assert.Equal("\"Pro\"", JsonSerializer.Serialize(Tier.Pro, SecretValueSerialization.Options));
+
+    [Fact]
+    public void Options_Object_IsCaseInsensitive_AndReadsEnumName()
+    {
+        var plan = JsonSerializer.Deserialize<Plan>(
+            "{\"name\":\"acme\",\"tier\":\"Enterprise\"}", SecretValueSerialization.Options);
+
+        Assert.NotNull(plan);
+        Assert.Equal("acme", plan!.Name);
+        Assert.Equal(Tier.Enterprise, plan.Tier);
+    }
+
+    // ---- end-to-end via FromPlain (exercises both the ctor serialize and the Open deserialize) ----
+
+    [Fact]
+    public void FromPlain_Enum_RoundTrips()
+    {
+        var secret = Secret<Tier>.FromPlain(Tier.Enterprise);
+        using var lease = secret.Open();
+        Assert.Equal(Tier.Enterprise, lease.Value);
+    }
+
+    [Fact]
+    public void FromPlain_RecordWithEnum_RoundTrips()
+    {
+        var plan = new Plan("Acme", Tier.Pro);
+        var secret = Secret<Plan>.FromPlain(plan);
+        using var lease = secret.Open();
+        Assert.Equal(plan, lease.Value);
+    }
+
+    [Fact]
+    public void FromPlain_NullableEnum_RoundTrips()
+    {
+        var secret = Secret<Tier?>.FromPlain(Tier.Free);
+        using var lease = secret.Open();
+        Assert.Equal(Tier.Free, lease.Value);
+    }
+}

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+**Secrets — robust enum & casing handling**
+- Secret payloads now (de)serialize with lenient options: **enums as names** (safe against enum reordering) and **case-insensitive** property matching.
+- Reading still accepts numeric enums and any casing → **existing encrypted secrets remain fully readable**, no migration.
+- Recommendation: when encrypting an enum secret with the CLI, pass the **name** (e.g. `Active`) rather than the ordinal.
+
 ## [5.0.0] — 2026-03-24
 
 ### Added


### PR DESCRIPTION
## Summary

`Secret<T>` previously (de)serialized its payload with `JsonSerializerOptions.Default` — case-sensitive, **enums as ordinals**. Enum-as-ordinal is fragile: if someone later reorders the enum, the stored number silently maps to a different member. This switches secret payloads to a shared, lenient `SecretValueSerialization.Options`:

- **enums serialize as names** (round-trip-safe against reordering)
- reading still accepts **numeric enums** *and* **any property casing**

### Why it's safe for existing secrets
The change is strictly **more permissive on read**, so existing encrypted envelopes at rest (enum-as-number, PascalCase) stay fully readable — **no migration**. Only the *in-memory* form of newly serialized typed secret values changes (enum name instead of ordinal); the encrypted bytes at rest are produced by a separate encryptor path and are untouched.

### Why a name/case-insensitive contract is the right default
Only the **type-aware** path inside the library (`Secret<T>` ctor) ever serializes a typed value (enum/object). Everything from outside — the CLI, hand-edited files, or a future browser encryptor — supplies plain JSON and would naturally send an enum's **name**. A name-based, case-insensitive contract handles all of those robustly. (The plaintext-config read path already used the lenient pipeline options; this aligns the decrypted-envelope path with it.)

## Changes
- `SecretValueSerialization.Options` (case-insensitive + `JsonStringEnumConverter`), applied to `Secret<T>` ctor serialize + `Open()` deserialize.
- CLI `encrypt --value` help: pass enum **names**, not ordinals.
- 7 tests: enum name/number read, name-write (not ordinal), case-insensitive object, `FromPlain` round-trips (enum, record-with-enum, nullable enum).

## Verification
- Full solution Release build: **0 errors**
- Full test suite (excl. Performance): **616 passing, 0 failing** (Secrets 135, incl. 7 new) — no regressions.

## Notes
Independent of #47 (LocalStorage). This is a small, focused enabler that also makes the future browser-encrypted-secrets idea (and complex/enum secret authoring in general) far more forgiving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)